### PR TITLE
Add server AST endpoint

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -3,9 +3,9 @@ use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::Header;
 use rocket::serde::json::{json, Json, Value};
 use rocket::{Request as RocketRequest, Response};
-use server::analysis::process_request;
 use server::model::analysis_request::AnalysisRequest;
 use server::model::tree_sitter_tree_request::TreeSitterRequest;
+use server::request::process_analysis_request;
 use server::tree_sitter_tree::process_tree_sitter_tree_request;
 
 pub struct CORS;
@@ -35,7 +35,7 @@ impl Fairing for CORS {
 
 #[rocket::post("/analyze", format = "application/json", data = "<request>")]
 fn analyze(request: Json<AnalysisRequest>) -> Value {
-    json!(process_request(request.into_inner()))
+    json!(process_analysis_request(request.into_inner()))
 }
 
 #[rocket::post("/get-treesitter-ast", format = "application/json", data = "<request>")]

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -3,8 +3,10 @@ use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::Header;
 use rocket::serde::json::{json, Json, Value};
 use rocket::{Request as RocketRequest, Response};
-use server::model::request::Request;
-use server::server::process_request;
+use server::analysis::process_request;
+use server::model::analysis_request::AnalysisRequest;
+use server::model::tree_sitter_tree_request::TreeSitterRequest;
+use server::tree_sitter_tree::process_tree_sitter_tree_request;
 
 pub struct CORS;
 
@@ -32,8 +34,13 @@ impl Fairing for CORS {
 }
 
 #[rocket::post("/analyze", format = "application/json", data = "<request>")]
-fn analyze(request: Json<Request>) -> Value {
+fn analyze(request: Json<AnalysisRequest>) -> Value {
     json!(process_request(request.into_inner()))
+}
+
+#[rocket::post("/get-treesitter-ast", format = "application/json", data = "<request>")]
+fn get_tree(request: Json<TreeSitterRequest>) -> Value {
+    json!(process_tree_sitter_tree_request(request.into_inner()))
 }
 
 #[rocket::get("/version", format = "text/html")]
@@ -58,6 +65,7 @@ fn rocket_main() -> _ {
     rocket::build()
         .attach(CORS)
         .mount("/", rocket::routes![analyze])
+        .mount("/", rocket::routes![get_tree])
         .mount("/", rocket::routes![get_version])
         .mount("/", rocket::routes![ping])
         .mount("/", rocket::routes![get_options])

--- a/server/src/analysis.rs
+++ b/server/src/analysis.rs
@@ -1,15 +1,15 @@
 use crate::constants::{
     ERROR_CODE_LANGUAGE_MISMATCH, ERROR_CODE_NOT_BASE64, ERROR_DECODING_BASE64,
 };
-use crate::model::request::{Request, ServerRule};
-use crate::model::response::{Response, RuleResponse};
+use crate::model::analysis_request::{AnalysisRequest, ServerRule};
+use crate::model::analysis_response::{AnalysisResponse, RuleResponse};
 use kernel::analysis::analyze::analyze;
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
 use kernel::utils::decode_base64_string;
 use std::collections::HashMap;
 
-pub fn process_request(request: Request) -> Response {
+pub fn process_request(request: AnalysisRequest) -> AnalysisResponse {
     let rules_with_invalid_language: Vec<ServerRule> = request
         .rules
         .iter()
@@ -17,7 +17,7 @@ pub fn process_request(request: Request) -> Response {
         .filter(|v| v.language != request.language)
         .collect();
     if !rules_with_invalid_language.is_empty() {
-        return Response {
+        return AnalysisResponse {
             rule_responses: vec![],
             errors: vec![ERROR_CODE_LANGUAGE_MISMATCH.to_string()],
         };
@@ -49,7 +49,7 @@ pub fn process_request(request: Request) -> Response {
     // let's try to decode the code
     let code_decoded_attempt = decode_base64_string(request.code_base64);
     if code_decoded_attempt.is_err() {
-        return Response {
+        return AnalysisResponse {
             rule_responses: vec![],
             errors: vec![ERROR_CODE_NOT_BASE64.to_string()],
         };
@@ -84,12 +84,12 @@ pub fn process_request(request: Request) -> Response {
                 })
                 .collect();
 
-            Response {
+            AnalysisResponse {
                 rule_responses,
                 errors: vec![],
             }
         }
-        Err(_) => Response {
+        Err(_) => AnalysisResponse {
             rule_responses: vec![],
             errors: vec![ERROR_DECODING_BASE64.to_string()],
         },
@@ -98,7 +98,7 @@ pub fn process_request(request: Request) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use crate::model::request::ServerRule;
+    use crate::model::analysis_request::ServerRule;
     use kernel::model::{
         common::Language,
         rule::{RuleCategory, RuleSeverity, RuleType},
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_request_correct_response() {
-        let request = Request{
+        let request = AnalysisRequest {
             filename: "myfile.py".to_string(),
             language: Language::Python,
             file_encoding: "utf-8".to_string(),
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_request_invalid_base64() {
-        let request = Request{
+        let request = AnalysisRequest {
             filename: "myfile.py".to_string(),
             language: Language::Python,
             file_encoding: "utf-8".to_string(),
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_request_invalid_rule_base64_encoding() {
-        let request = Request{
+        let request = AnalysisRequest {
             filename: "myfile.py".to_string(),
             language: Language::Python,
             file_encoding: "utf-8".to_string(),
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_request_invalid_language() {
-        let request = Request{
+        let request = AnalysisRequest {
             filename: "myfile.py".to_string(),
             language: Language::Python,
             file_encoding: "utf-8".to_string(),

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -4,3 +4,5 @@ pub const ERROR_DECODING_BASE64: &str = "error-decoding-base64";
 pub const ERROR_CODE_NOT_BASE64: &str = "code-not-base64";
 // rules and core language are different
 pub const ERROR_CODE_LANGUAGE_MISMATCH: &str = "language-mismatch";
+// no root node when trying to get the AST
+pub const ERROR_CODE_NO_ROOT_NODE: &str = "no-root-node";

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod analysis;
 pub mod constants;
 pub mod model;
+pub mod request;
 pub mod tree_sitter_tree;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 pub mod constants;
 pub mod model;
-pub mod server;
+pub mod tree_sitter_tree;

--- a/server/src/model.rs
+++ b/server/src/model.rs
@@ -1,2 +1,4 @@
-pub mod request;
-pub mod response;
+pub mod analysis_request;
+pub mod analysis_response;
+pub mod tree_sitter_tree_request;
+pub mod tree_sitter_tree_response;

--- a/server/src/model/analysis_request.rs
+++ b/server/src/model/analysis_request.rs
@@ -31,9 +31,7 @@ pub struct ServerRule {
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct AnalysisRequestOptions {
-    #[serde(rename = "useTreeSitter")]
     pub use_tree_sitter: Option<bool>,
-    #[serde(rename = "logOutput")]
     pub log_output: Option<bool>,
 }
 

--- a/server/src/model/analysis_request.rs
+++ b/server/src/model/analysis_request.rs
@@ -30,7 +30,7 @@ pub struct ServerRule {
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
-pub struct RequestOptions {
+pub struct AnalysisRequestOptions {
     #[serde(rename = "useTreeSitter")]
     pub use_tree_sitter: Option<bool>,
     #[serde(rename = "logOutput")]
@@ -38,7 +38,7 @@ pub struct RequestOptions {
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
-pub struct Request {
+pub struct AnalysisRequest {
     pub filename: String,
     pub language: Language,
     #[serde(rename = "file_encoding")]
@@ -46,5 +46,5 @@ pub struct Request {
     #[serde(rename = "code")]
     pub code_base64: String,
     pub rules: Vec<ServerRule>,
-    pub options: Option<RequestOptions>,
+    pub options: Option<AnalysisRequestOptions>,
 }

--- a/server/src/model/analysis_response.rs
+++ b/server/src/model/analysis_response.rs
@@ -14,7 +14,7 @@ pub struct RuleResponse {
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
-pub struct Response {
+pub struct AnalysisResponse {
     pub rule_responses: Vec<RuleResponse>,
     pub errors: Vec<String>,
 }

--- a/server/src/model/tree_sitter_tree_request.rs
+++ b/server/src/model/tree_sitter_tree_request.rs
@@ -1,0 +1,10 @@
+use kernel::model::common::Language;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Debug, Serialize)]
+pub struct TreeSitterRequest {
+    pub language: Language,
+    pub file_encoding: String,
+    #[serde(rename = "code")]
+    pub code_base64: String,
+}

--- a/server/src/model/tree_sitter_tree_response.rs
+++ b/server/src/model/tree_sitter_tree_response.rs
@@ -1,0 +1,8 @@
+use kernel::model::analysis::TreeSitterNode;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Debug, Serialize)]
+pub struct TreeSitterResponse {
+    pub result: Option<TreeSitterNode>,
+    pub errors: Vec<String>,
+}

--- a/server/src/request.rs
+++ b/server/src/request.rs
@@ -9,7 +9,7 @@ use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
 use kernel::utils::decode_base64_string;
 use std::collections::HashMap;
 
-pub fn process_request(request: AnalysisRequest) -> AnalysisResponse {
+pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
     let rules_with_invalid_language: Vec<ServerRule> = request
         .rules
         .iter()
@@ -132,7 +132,7 @@ mod tests {
                 }
             ]
         };
-        let response = process_request(request);
+        let response = process_analysis_request(request);
         assert!(response.errors.is_empty());
         assert_eq!(1, response.rule_responses.len());
         assert_eq!(1, response.rule_responses.get(0).unwrap().violations.len());
@@ -164,7 +164,7 @@ mod tests {
                 }
             ]
         };
-        let response = process_request(request);
+        let response = process_analysis_request(request);
         assert_eq!(0, response.rule_responses.len());
         assert_eq!(
             &ERROR_CODE_NOT_BASE64.to_string(),
@@ -198,7 +198,7 @@ mod tests {
                 }
             ]
         };
-        let response = process_request(request);
+        let response = process_analysis_request(request);
         assert_eq!(0, response.rule_responses.len());
         assert_eq!(
             &ERROR_DECODING_BASE64.to_string(),
@@ -232,7 +232,7 @@ mod tests {
                 }
             ]
         };
-        let response = process_request(request);
+        let response = process_analysis_request(request);
         assert_eq!(0, response.rule_responses.len());
         assert_eq!(
             &ERROR_CODE_LANGUAGE_MISMATCH.to_string(),

--- a/server/src/tree_sitter_tree.rs
+++ b/server/src/tree_sitter_tree.rs
@@ -1,0 +1,73 @@
+use crate::constants::{ERROR_CODE_NOT_BASE64, ERROR_CODE_NO_ROOT_NODE};
+use crate::model::tree_sitter_tree_request::TreeSitterRequest;
+use crate::model::tree_sitter_tree_response::TreeSitterResponse;
+use kernel::analysis::tree_sitter::{get_tree, map_node};
+use kernel::utils::decode_base64_string;
+
+// Return the tree for the language and code sent as parameter.
+pub fn process_tree_sitter_tree_request(request: TreeSitterRequest) -> TreeSitterResponse {
+    let decoded = decode_base64_string(request.code_base64);
+
+    let no_root_node = TreeSitterResponse {
+        result: None,
+        errors: vec![ERROR_CODE_NO_ROOT_NODE.to_string()],
+    };
+
+    if decoded.is_err() {
+        return TreeSitterResponse {
+            result: None,
+            errors: vec![ERROR_CODE_NOT_BASE64.to_string()],
+        };
+    }
+
+    let tree = get_tree(&decoded.unwrap(), &request.language);
+
+    if tree.is_none() {
+        return no_root_node;
+    }
+    let root_node = map_node(tree.unwrap().root_node());
+
+    if root_node.is_none() {
+        return no_root_node;
+    }
+
+    TreeSitterResponse {
+        result: root_node,
+        errors: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kernel::model::common::Language;
+
+    use super::*;
+
+    #[test]
+    fn test_process_tree_sitter_tree_request_happy_path() {
+        let request = TreeSitterRequest {
+            code_base64: "ZnVuY3Rpb24gdmlzaXQobm9kZSwgZmlsZW5hbWUsIGNvZGUpIHsKICAgIGNvbnN0IGZ1bmN0aW9uTmFtZSA9IG5vZGUuY2FwdHVyZXNbIm5hbWUiXTsKICAgIGlmKGZ1bmN0aW9uTmFtZSkgewogICAgICAgIGNvbnN0IGVycm9yID0gYnVpbGRFcnJvcihmdW5jdGlvbk5hbWUuc3RhcnQubGluZSwgZnVuY3Rpb25OYW1lLnN0YXJ0LmNvbCwgZnVuY3Rpb25OYW1lLmVuZC5saW5lLCBmdW5jdGlvbk5hbWUuZW5kLmNvbCwKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgImludmFsaWQgbmFtZSIsICJDUklUSUNBTCIsICJzZWN1cml0eSIpOwoKICAgICAgICBjb25zdCBlZGl0ID0gYnVpbGRFZGl0KGZ1bmN0aW9uTmFtZS5zdGFydC5saW5lLCBmdW5jdGlvbk5hbWUuc3RhcnQuY29sLCBmdW5jdGlvbk5hbWUuZW5kLmxpbmUsIGZ1bmN0aW9uTmFtZS5lbmQuY29sLCAidXBkYXRlIiwgImJhciIpOwogICAgICAgIGNvbnN0IGZpeCA9IGJ1aWxkRml4KCJ1c2UgYmFyIiwgW2VkaXRdKTsKICAgICAgICBhZGRFcnJvcihlcnJvci5hZGRGaXgoZml4KSk7CiAgICB9Cn0=".to_string(),
+            file_encoding: "utf-8".to_string(),
+            language: Language::Python,
+        };
+        let response = process_tree_sitter_tree_request(request);
+        assert!(response.errors.is_empty());
+        assert!(response.result.is_some());
+        assert_eq!("module", response.result.unwrap().ast_type);
+    }
+
+    #[test]
+    fn test_process_tree_sitter_invalid_base64() {
+        let request = TreeSitterRequest {
+            code_base64: "we2323423423090909)()(&(*&!@!@=".to_string(),
+            file_encoding: "utf-8".to_string(),
+            language: Language::Python,
+        };
+        let response = process_tree_sitter_tree_request(request);
+        assert_eq!(
+            &ERROR_CODE_NOT_BASE64.to_string(),
+            response.errors.get(0).unwrap()
+        );
+        assert!(response.result.is_none());
+    }
+}


### PR DESCRIPTION
## What problem are you trying to solve?

We need to expose an API endpoint to print the AST in JSON

## What is your solution?

Add the `/get-treesitter-ast` API that returns the root node of the code passed as parameter.

## What the reviewer should know

We also addressed the log output but that was caused by naming conventions issues (using `camelCase` instead of `snake_case`).