### PR TITLE
use_snake_case_for_server_api

### DIFF
--- a/kernel/src/model/analysis.rs
+++ b/kernel/src/model/analysis.rs
@@ -40,7 +40,6 @@ pub struct TreeSitterNode {
     #[serde(rename = "fieldName")]
     pub field_name: Option<String>,
     pub children: Vec<TreeSitterNode>,
-    // pub parent: Option<TreeSitterNode>,
 }
 
 // The node that is then passed to the visit function.

--- a/server/src/model.rs
+++ b/server/src/model.rs
@@ -1,4 +1,5 @@
 pub mod analysis_request;
 pub mod analysis_response;
+pub mod tree_sitter_tree_node;
 pub mod tree_sitter_tree_request;
 pub mod tree_sitter_tree_response;

--- a/server/src/model/tree_sitter_tree_node.rs
+++ b/server/src/model/tree_sitter_tree_node.rs
@@ -1,0 +1,31 @@
+use kernel::model::analysis::TreeSitterNode;
+use kernel::model::common::Position;
+use serde_derive::{Deserialize, Serialize};
+
+// This representation is for the server only for an node representation. In the kernel,
+// we serialize/deserialize in camelCase since the value is retrieved in JavaScript code.
+// The API only emits camel_case_code, which is why we have this class.
+#[derive(Clone, Deserialize, Debug, Serialize)]
+pub struct ServerTreeSitterNode {
+    pub ast_type: String,
+    pub start: Position,
+    pub end: Position,
+    pub field_name: Option<String>,
+    pub children: Vec<ServerTreeSitterNode>,
+}
+
+pub fn convert_tree_sitter_node_for_server(node: TreeSitterNode) -> ServerTreeSitterNode {
+    let children: Vec<ServerTreeSitterNode> = node
+        .children
+        .into_iter()
+        .map(convert_tree_sitter_node_for_server)
+        .collect();
+
+    ServerTreeSitterNode {
+        ast_type: node.ast_type,
+        start: node.start.clone(),
+        end: node.end.clone(),
+        field_name: node.field_name,
+        children,
+    }
+}

--- a/server/src/model/tree_sitter_tree_response.rs
+++ b/server/src/model/tree_sitter_tree_response.rs
@@ -1,8 +1,8 @@
-use kernel::model::analysis::TreeSitterNode;
+use crate::model::tree_sitter_tree_node::ServerTreeSitterNode;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct TreeSitterResponse {
-    pub result: Option<TreeSitterNode>,
+    pub result: Option<ServerTreeSitterNode>,
     pub errors: Vec<String>,
 }

--- a/server/src/tree_sitter_tree.rs
+++ b/server/src/tree_sitter_tree.rs
@@ -1,4 +1,5 @@
 use crate::constants::{ERROR_CODE_NOT_BASE64, ERROR_CODE_NO_ROOT_NODE};
+use crate::model::tree_sitter_tree_node::convert_tree_sitter_node_for_server;
 use crate::model::tree_sitter_tree_request::TreeSitterRequest;
 use crate::model::tree_sitter_tree_response::TreeSitterResponse;
 use kernel::analysis::tree_sitter::{get_tree, map_node};
@@ -32,7 +33,7 @@ pub fn process_tree_sitter_tree_request(request: TreeSitterRequest) -> TreeSitte
     }
 
     TreeSitterResponse {
-        result: root_node,
+        result: root_node.map(convert_tree_sitter_node_for_server),
         errors: vec![],
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

The server API uses `camelCase` for all attributes when it should returns `snake_case`. The serde serialization for the node is using `camelCase`, which is what we expect in rules for JavaScript code. We need to have the conversion in the server to use `snake_case`.

