### PR TITLE
chore(typo): fix typo in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest nightly
+      - name: Install Stable + Rustfmt + Clippy
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -58,4 +58,4 @@ jobs:
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.GITHUB_TOKEN }}
-          archive: "datadog-static-analyzer-$target"
+          archive: 'datadog-static-analyzer-$target'


### PR DESCRIPTION
There was a copy paste typo from the original action. Modified the text to describe current status of the action step.