### PR TITLE
Fix rule timeout

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,9 +21,7 @@ jobs:
         run: cargo fmt --check
       - name: Run tests
         run: cargo test
-      - name: Check python-best-practices ruleset
-        run: cargo run --bin datadog-static-analyzer-test-ruleset  -- -r python-best-practices
-      - name: Check python-security ruleset
-        run: cargo run --bin datadog-static-analyzer-test-ruleset  -- -r python-security
-      - name: Check python-code-style ruleset
-        run: cargo run --bin datadog-static-analyzer-test-ruleset  -- -r python-code-style
+      - name: Check python rulesets - part1
+        run: cargo run --bin datadog-static-analyzer-test-ruleset -- -r python-best-practices -r python-security -r python-code-style -r python-inclusive
+      - name: Check python rulesets - part2
+        run: cargo run --bin datadog-static-analyzer-test-ruleset -- -r python-django -r python-flask -r python-design

--- a/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -58,7 +58,7 @@ fn main() {
     let program = args[0].clone();
     let mut opts = Options::new();
 
-    opts.optopt("r", "ruleset", "rules to test", "python-security");
+    opts.optmulti("r", "ruleset", "rules to test", "python-security");
     opts.optflag("h", "help", "print this help");
 
     let matches = match opts.parse(&args[1..]) {

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -211,7 +211,8 @@ fn main() -> Result<()> {
 
     // we always keep one thread free and some room for the management threads that monitor
     // the rule execution.
-    let num_threads = ((num_cpus::get() as f32 - 1.0) * 0.75) as usize;
+    let ideal_threads = ((num_cpus::get() as f32 - 1.0) * 0.80) as usize;
+    let num_threads = if ideal_threads == 0 { 1 } else { ideal_threads };
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
         .build_global()?;

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
 
     // we always keep one thread free and some room for the management threads that monitor
     // the rule execution.
-    let num_threads = ((num_cpus::get() as f32 - 1.0) * 0.80) as usize;
+    let num_threads = ((num_cpus::get() as f32 - 1.0) * 0.75) as usize;
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
         .build_global()?;

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -4,15 +4,16 @@ use crate::model::analysis::{
 use crate::model::rule::{RuleInternal, RuleResult};
 use crate::model::violation::Violation;
 use deno_core::{v8, FastString, JsRuntime, JsRuntimeForSnapshot, RuntimeOptions, Snapshot};
-use std::sync::{mpsc, Arc, Condvar, Mutex};
+use std::sync::{mpsc, Arc, Barrier, Condvar, Mutex};
 use std::thread;
+use std::thread::yield_now;
 use std::time::{Duration, SystemTime};
 
 use lazy_static::lazy_static;
 use serde_derive::{Deserialize, Serialize};
 
 // how long a rule can execute before it's a timeout.
-const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 5000;
+const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 1000;
 
 lazy_static! {
     static ref STARTUP_DATA: Vec<u8> = {
@@ -155,6 +156,8 @@ pub fn execute_rule(
 ) -> RuleResult {
     let rule_name_copy = rule.name.clone();
     let filename_copy = filename.clone();
+    let rule_name_copy_thr = rule.name.clone();
+    let filename_copy_thr = filename.clone();
     let use_debug = analysis_options.use_debug;
     let start = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -162,12 +165,11 @@ pub fn execute_rule(
         .as_millis();
     // These mutexes and condition variables are used to wait on the execution
     // and have a proper timeout.
-    let condvar_main = Arc::new((Mutex::new(()), Condvar::new()));
+    let condvar_main = Arc::new((Mutex::new(()), Condvar::new(), Barrier::new(2)));
     let condvar_thread = Arc::clone(&condvar_main);
 
     // to send the handle of the JS runtime to terminate the runtime
     let (tx_runtime, rx_runtime) = mpsc::channel();
-
     // To send the result once the execution is complete.
     let (tx_result, rx_result) = mpsc::channel();
     let thr = thread::spawn(move || {
@@ -182,7 +184,10 @@ pub fn execute_rule(
             panic!("we should be able to send the handle to the main thread");
         }
 
-        let (_, cvar) = &*condvar_thread;
+        let (mutex, cvar, barrier) = &*condvar_thread;
+
+        // let's make sure the other thread is ready for us to run and will wait.
+        barrier.wait();
 
         // execute the rule and return
         let res = execute_rule_internal(
@@ -194,16 +199,27 @@ pub fn execute_rule(
         );
 
         // send the result back
-        tx_result
-            .send(Some(res))
-            .expect("sending results to the main thread");
+        let send_result_result = tx_result.send(Some(res));
+        if use_debug && send_result_result.is_err() {
+            eprintln!(
+                "rule {}:{} - error when sending results",
+                rule_name_copy_thr.clone(),
+                filename_copy_thr.clone()
+            );
+        }
 
+        let _ = mutex.lock();
         // notify the main thread we are done with the execution
         cvar.notify_one();
     });
 
+    yield_now();
     let handle = rx_runtime.recv();
-    let (lock, cvar) = &*condvar_main;
+    let (lock, cvar, barrier) = &*condvar_main;
+
+    // synchronize with the other thread and make sure we are ready to execute
+    barrier.wait();
+
     let started = lock.lock().expect("should lock mutex");
 
     // Wait for the rule to execute. If the rule times out, we return a specific RuleResult
@@ -230,7 +246,8 @@ pub fn execute_rule(
             if v.1.timed_out() {
                 if use_debug {
                     eprintln!(
-                        "rule {} TIMED OUT out on file {}, execution time: {} ms",
+                        "[{}] rule:file {}:{} TIMED OUT, execution time: {} ms",
+                        end,
                         rule_name_copy.as_str(),
                         filename_copy.as_str(),
                         execution_time_ms

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -13,7 +13,7 @@ use lazy_static::lazy_static;
 use serde_derive::{Deserialize, Serialize};
 
 // how long a rule can execute before it's a timeout.
-const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 1000;
+const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 5000;
 
 lazy_static! {
     static ref STARTUP_DATA: Vec<u8> = {

--- a/kernel/src/analysis/tree_sitter.rs
+++ b/kernel/src/analysis/tree_sitter.rs
@@ -109,7 +109,7 @@ pub fn map_node(node: tree_sitter::Node) -> Option<TreeSitterNode> {
             loop {
                 let maybe_child = map_node_internal(cursor);
                 if let Some(child) = maybe_child {
-                    children.push(child.clone());
+                    children.push(child);
                 }
                 if !cursor.goto_next_sibling() {
                     break;

--- a/kernel/src/analysis/tree_sitter.rs
+++ b/kernel/src/analysis/tree_sitter.rs
@@ -109,7 +109,7 @@ pub fn map_node(node: tree_sitter::Node) -> Option<TreeSitterNode> {
             loop {
                 let maybe_child = map_node_internal(cursor);
                 if let Some(child) = maybe_child {
-                    children.push(child);
+                    children.push(child.clone());
                 }
                 if !cursor.goto_next_sibling() {
                     break;


### PR DESCRIPTION
## What problem are you trying to solve?

We had rules that randomly timed'out and did not give any results. It makes the execution of the tool unpredictable and our pipelines failed (see example [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/5490472654/jobs/10005956655) or [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/5490529721/jobs/10006087565)).

The problem we have is that the function was executing too fast. So the main thread did not had the opportunity to wait for the thread termination. Instead, it was waiting for a termination that already happened.

The main issue is that before we do `cvar.wait_timeout` in the main thread, the child thread must have the opportunity to execute `cvar.notify_one();`. If the thread execute `cvar.notify_one();` before the main thread `cvar.wait_timeout`, then the main thread will time out.


## What is your solution?

The solution is to synchronize all threads using a [barrier](https://en.wikipedia.org/wiki/Barrier_(computer_science)). A barrier ensure that all thread are synchronized at one point in time. To do so, we use the [`Barrier`](https://doc.rust-lang.org/std/sync/struct.Barrier.html) from the standard Rust library.

## Notes

We are adding compatibility check of all existing rulesets with the version being comitted.
