### PR TITLE
feat(version): add version information to some binaries

### DIFF
--- a/bins/src/bin/datadog-export-rulesets.rs
+++ b/bins/src/bin/datadog-export-rulesets.rs
@@ -1,4 +1,5 @@
 use cli::datadog_utils::get_ruleset;
+use kernel::constants::VERSION;
 use kernel::model::ruleset::RuleSet;
 
 use getopts::Options;
@@ -19,6 +20,7 @@ fn main() {
     opts.optopt("o", "output", "output file", "rulesets.json");
     opts.optmulti("r", "ruleset", "ruleset to fetch", "python-security");
     opts.optflag("h", "help", "print this help");
+    opts.optflag("v", "version", "shows the version");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -26,6 +28,11 @@ fn main() {
             panic!("error when parsing arguments: {}", f)
         }
     };
+
+    if matches.opt_present("v") {
+        println!("{}", VERSION);
+        exit(1);
+    }
 
     if matches.opt_present("h") {
         print_usage(&program, opts);

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -5,6 +5,7 @@ use cli::model::config_file::ConfigFile;
 use cli::rule_utils::{get_languages_for_rules, get_rulesets_from_file};
 use cli::sarif_utils::generate_sarif_report;
 use kernel::analysis::analyze::analyze;
+use kernel::constants::VERSION;
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::common::Language;
 use kernel::model::rule::{Rule, RuleInternal};
@@ -86,6 +87,7 @@ fn main() -> Result<()> {
     opts.optopt("o", "output", "output file", "output.json");
     opts.optmulti("p", "ignore-path", "path to ignore", "**/test*.py");
     opts.optflag("h", "help", "print this help");
+    opts.optflag("v", "version", "shows the version");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -93,6 +95,11 @@ fn main() -> Result<()> {
             panic!("error when parsing arguments: {}", f)
         }
     };
+
+    if matches.opt_present("v") {
+        println!("{}", VERSION);
+        exit(1);
+    }
 
     if matches.opt_present("h") {
         print_usage(&program, opts);

--- a/kernel/src/constants.rs
+++ b/kernel/src/constants.rs
@@ -1,1 +1,2 @@
-pub const VERSION: &str = "development";
+// pub const VERSION: &str = "development";
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/kernel/src/constants.rs
+++ b/kernel/src/constants.rs
@@ -1,2 +1,1 @@
-// pub const VERSION: &str = "development";
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = "development";

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1,8 +1,6 @@
 use base64::engine::general_purpose;
 use base64::Engine;
 
-pub const VERSION: &str = "development";
-
 pub fn decode_base64_string(base64_string: String) -> anyhow::Result<String> {
     anyhow::Ok(String::from_utf8(
         general_purpose::STANDARD.decode(base64_string)?,


### PR DESCRIPTION
## What problem are you trying to solve?

1. There are two different places in the the `kernel` crate that were exposing a VERSION const:
   1. [utils.rs](https://github.com/robertohuertasm/datadog-static-analyzer/blob/ffce75f6a1c387b7a0e6f27089eb4463b3febb37/kernel/src/utils.rs#L4)
   2. [constants.rs](https://github.com/robertohuertasm/datadog-static-analyzer/blob/ffce75f6a1c387b7a0e6f27089eb4463b3febb37/kernel/src/constants.rs#L1)
 1. Some crates don't expose the version, so it may be difficult to determine if we have the latest build.

## What is your solution?

1. Remove the code in [utils](https://github.com/robertohuertasm/datadog-static-analyzer/blob/ffce75f6a1c387b7a0e6f27089eb4463b3febb37/kernel/src/utils.rs#L4) as it seems that it's not being used at all.
2. Add a `--version` flag for some CLIs so that consumers can understand which version are they using.

## Alternatives considered

I thought of using the `kernel` Cargo.toml version to expose the version as a constant but then @juli1 pointed out the current release system which uses the commit_sha as the version, so I rollback that change.
