### PR TITLE
feat(workspace): use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ members = [
 
 [profile.release]
 lto = true
+
+[workspace.dependencies]
+anyhow = "1"
+base64 = "0.21.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+derive_builder = "0.12"
+serde-sarif = "0.4"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -10,7 +10,6 @@ rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio 
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld
 sarif-rs,https://github.com/psastras/sarif-rs,MIT,Copyright (c) 2021 Paul Sastrasinh
 serde,https://github.com/serde-rs/serde,Apache-2.0,2015 David Tolnay and Serde contributors
-serde_derive,https://github.com/serde-rs/serde,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_json,https://github.com/serde-rs/json,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0,2016 David Tolnay
 walkdir,https://github.com/BurntSushi/walkdir,MIT,Copyright (c) 2015 Andrew Gallant

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -20,17 +20,19 @@ version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
 
-
 [dependencies]
-anyhow = "1"
+# local
 cli = {path = "../cli"}
 kernel = {path = "../kernel" }
 server = {path = "../server"}
+# workspace
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+# other
 getopts = "0.2.21"
 num_cpus = "1.15.0"
 rayon = "1.7.0"
 rocket = {version = "=0.5.0-rc.3", features = ["json"]}
-serde_json = "1.0.96"
 
 
 # For linux and macos, we need the vendored ssl (especially

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,16 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
-base64 = "0.21.2"
+# local
 kernel = {path = "../kernel" }
-derive_builder = "0.12.0"
+# workspace
+anyhow = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+derive_builder = { workspace = true }
+serde-sarif = { workspace = true }
+# other
 glob-match = "0.2.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-serde = "1.0"
-serde_json = "1.0.96"
-serde_derive = "1.0"
-serde-sarif = "0.4.0"
 serde_yaml = "0.9.21"
 walkdir = "2.3.3"
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
-base64 = "0.21.2"
+# workspace
+anyhow = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+derive_builder = { workspace = true }
+serde-sarif = { workspace = true }
+# other
 deno_core = "0.194.0"
-derive_builder = "0.12.0"
 lazy_static = "1.4.0"
 serde_v8 = "0.105.0"
-serde_json = "1.0.96"
 tree-sitter = "0.20.10"
-serde = "1.0"
-serde_derive = "1.0"
-serde-sarif = "0.4.0"
 
 [build-dependencies]
 cc="*"

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -10,7 +10,7 @@ use std::thread::yield_now;
 use std::time::{Duration, SystemTime};
 
 use lazy_static::lazy_static;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 // how long a rule can execute before it's a timeout.
 const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 5000;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
-base64 = "0.21.2"
+# local
 kernel = {path = "../kernel" }
-derive_builder = "0.12.0"
-serde = "1.0"
-serde_json = "1.0.96"
-serde_derive = "1.0"
+# workspace
+anyhow = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+derive_builder = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/server/src/model/analysis_request.rs
+++ b/server/src/model/analysis_request.rs
@@ -1,6 +1,6 @@
 use kernel::model::common::Language;
 use kernel::model::rule::{EntityChecked, RuleCategory, RuleSeverity, RuleType};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // This is a copy of the rule. We are just renaming the attribute to be

--- a/server/src/model/analysis_response.rs
+++ b/server/src/model/analysis_response.rs
@@ -1,5 +1,5 @@
 use kernel::model::violation::Violation;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct RuleResponse {

--- a/server/src/model/tree_sitter_tree_node.rs
+++ b/server/src/model/tree_sitter_tree_node.rs
@@ -1,6 +1,6 @@
 use kernel::model::analysis::TreeSitterNode;
 use kernel::model::common::Position;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 // This representation is for the server only for an node representation. In the kernel,
 // we serialize/deserialize in camelCase since the value is retrieved in JavaScript code.

--- a/server/src/model/tree_sitter_tree_request.rs
+++ b/server/src/model/tree_sitter_tree_request.rs
@@ -1,5 +1,5 @@
 use kernel::model::common::Language;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct TreeSitterRequest {

--- a/server/src/model/tree_sitter_tree_response.rs
+++ b/server/src/model/tree_sitter_tree_response.rs
@@ -1,5 +1,5 @@
 use crate::model::tree_sitter_tree_node::ServerTreeSitterNode;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct TreeSitterResponse {


### PR DESCRIPTION
## What problem are you trying to solve?

1. The repo has different crates that share some dependencies. Now, those dependencies are declared in each Cargo.toml, along with their versions. This can make difficult to upgrade the version of the dependencies in order to keep all of them in sync.
1. We have a dependency on `serde_derive`.

## What is your solution?

1. The solution is to use [Cargo Workspace Depencencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table).
1. Use serde's `derive` feature.

## What the reviewer should know

Nor 1 or 2 are inherently a problem. This are suggestions to basically reduce the maintainability cost (1) and reduce the number of third party dependencies (2)

Other projects using similar approach:

- [Cargo](https://github.com/rust-lang/cargo/blob/master/Cargo.toml#L13)
- [Rust Analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/Cargo.toml#L47)
- [Deno](https://github.com/gliheng/deno/blob/main/Cargo.toml#L43)
- [Vercel](https://github.com/vercel/next.js/blob/canary/Cargo.toml#L27)
- [Solana](https://github.com/solana-labs/solana/blob/master/Cargo.toml#L126)
