### PR TITLE
Ensure the server is using snake case in response

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,8 +27,8 @@ trigger_internal_image:
   variables:
     IMAGE_VERSION: current
     IMAGE_NAME: datadog-static-analyzer
-    RELEASE_TAG: 2023070601
-    BUILD_TAG: 2023070601
+    RELEASE_TAG: 2023071001
+    BUILD_TAG: 2023071001
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"

--- a/server/src/model.rs
+++ b/server/src/model.rs
@@ -3,3 +3,4 @@ pub mod analysis_response;
 pub mod tree_sitter_tree_node;
 pub mod tree_sitter_tree_request;
 pub mod tree_sitter_tree_response;
+pub mod violation;

--- a/server/src/model/analysis_response.rs
+++ b/server/src/model/analysis_response.rs
@@ -6,10 +6,8 @@ pub struct RuleResponse {
     pub identifier: String,
     pub violations: Vec<Violation>,
     pub errors: Vec<String>,
-    #[serde(rename = "executionError")]
     pub execution_error: Option<String>,
     pub output: Option<String>,
-    #[serde(rename = "executionTimeMs")]
     pub execution_time_ms: u128,
 }
 

--- a/server/src/model/analysis_response.rs
+++ b/server/src/model/analysis_response.rs
@@ -1,10 +1,10 @@
-use kernel::model::violation::Violation;
+use crate::model::violation::ServerViolation;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct RuleResponse {
     pub identifier: String,
-    pub violations: Vec<Violation>,
+    pub violations: Vec<ServerViolation>,
     pub errors: Vec<String>,
     pub execution_error: Option<String>,
     pub output: Option<String>,

--- a/server/src/model/violation.rs
+++ b/server/src/model/violation.rs
@@ -1,0 +1,67 @@
+use kernel::model::common::Position;
+use kernel::model::rule::{RuleCategory, RuleSeverity};
+
+use derive_builder::Builder;
+use kernel::model::violation::{Edit, EditType, Fix, Violation};
+use serde::{Deserialize, Serialize};
+
+/// because of our naming conventions that mix camelCase in the JS code
+/// and other parts of rosie adn the snake_case that got adopted for our
+/// API, we need to have a model for the server that exposes only
+/// snake_case data.
+///
+/// Therefore, for each data type from the model in the kernel, we duplicate
+/// the classes and make sure the casing follows what is expected.
+#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
+pub struct ServerEdit {
+    pub start: Position,
+    pub end: Option<Position>,
+    pub edit_type: EditType,
+    pub content: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
+pub struct ServerFix {
+    pub description: String,
+    pub edits: Vec<ServerEdit>,
+}
+
+#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
+pub struct ServerViolation {
+    pub start: Position,
+    pub end: Position,
+    pub message: String,
+    pub severity: RuleSeverity,
+    pub category: RuleCategory,
+    pub fixes: Vec<ServerFix>,
+}
+
+/// Transform an edit from the kernel into an edit that is surfaced by the server.
+pub fn edit_to_server(edit: &Edit) -> ServerEdit {
+    ServerEdit {
+        start: edit.start.clone(),
+        end: edit.end.clone(),
+        edit_type: edit.edit_type,
+        content: edit.content.clone(),
+    }
+}
+
+/// Transform a fix from the kernel data model into a fix that is surfaced by the server.
+pub fn fix_to_server(fix: &Fix) -> ServerFix {
+    ServerFix {
+        description: fix.description.clone(),
+        edits: fix.edits.iter().map(edit_to_server).collect(),
+    }
+}
+
+/// Transform a violation from the kernel data model into what is surfaced by the server.
+pub fn violation_to_server(violation: &Violation) -> ServerViolation {
+    ServerViolation {
+        start: violation.start.clone(),
+        end: violation.end.clone(),
+        message: violation.message.clone(),
+        severity: violation.severity,
+        category: violation.category,
+        fixes: violation.fixes.iter().map(fix_to_server).collect(),
+    }
+}

--- a/server/src/request.rs
+++ b/server/src/request.rs
@@ -3,6 +3,7 @@ use crate::constants::{
 };
 use crate::model::analysis_request::{AnalysisRequest, ServerRule};
 use crate::model::analysis_response::{AnalysisResponse, RuleResponse};
+use crate::model::violation::violation_to_server;
 use kernel::analysis::analyze::analyze;
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
@@ -76,7 +77,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
                 .iter()
                 .map(|rr| RuleResponse {
                     identifier: rr.rule_name.clone(),
-                    violations: rr.violations.clone(),
+                    violations: rr.violations.iter().map(violation_to_server).collect(),
                     errors: rr.errors.clone(),
                     execution_error: rr.execution_error.clone(),
                     output: rr.output.clone(),


### PR DESCRIPTION
## What problem are you trying to solve?

The server was still using some `camelCase` in the server response. Because of recent renaming, this needs to be changed.

## What is your solution?

Copy the data model that will ensure we do not use `camelCase` and ensure we use `snake_case`.

## What the reviewer should know

We also bump the version to be released internally.