### PR TITLE
fix(windows): use shell in actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           target: ${{ matrix.target }}
         if: startsWith(matrix.os, 'ubuntu')
       - name: Set the version
+        shell: bash
         run: sed  "s/development/$GITHUB_SHA/g" kernel/src/constants.rs > bla && rm kernel/src/constants.rs && mv bla kernel/src/constants.rs
       - uses: taiki-e/upload-rust-binary-action@v1
         with:


### PR DESCRIPTION
## What problem are you trying to solve?

As I was testing the server binary to see how we could work with it in our extension, I realized that the Windows binary was not sending the version.

## What is your solution?

Not sure if this is going to solve it as it seems that the substitution is taking place, given that when I do a request to the `version` endpoint I don't get `development` but an empty string.

In any case, it's a good practice to use the `bash` shell so typical Unix commands can get executed in Windows. See [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell) for more information. 

I'm submitting this under the assumption that `sed` will work as expected when executed in a bash shell.

## What the reviewer should know

Screenshot of the server not returning anything:

![image](https://github.com/DataDog/datadog-static-analyzer/assets/696981/3ec4af64-e246-49bd-9b39-5bb9769197e9)

