### PR TITLE
add --cpus option to control parallelism

### DIFF
--- a/cli/src/model/cli_configuration.rs
+++ b/cli/src/model/cli_configuration.rs
@@ -1,7 +1,16 @@
-// represents the CLI configuration
-// pub struct CliConfiguration {
-//     use_debug: bool,
-//     ignore_paths: Vec<String>,
-//     rules_file: String,
-//     output_format: model::OutputFormat,
-// }
+use kernel::model::common::OutputFormat;
+use kernel::model::rule::Rule;
+
+/// represents the CLI configuratoin
+#[derive(Clone)]
+pub struct CliConfiguration {
+    pub use_debug: bool,
+    pub use_configuration_file: bool,
+    pub source_directory: String,
+    pub ignore_paths: Vec<String>,
+    pub rules_file: Option<String>,
+    pub output_format: OutputFormat, // SARIF or JSON
+    pub output_file: String,
+    pub num_cpus: usize, // of cpus to use for parallelism
+    pub rules: Vec<Rule>,
+}

--- a/kernel/src/model/common.rs
+++ b/kernel/src/model/common.rs
@@ -2,7 +2,7 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Deserialize, Debug, Serialize, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub enum OutputFormat {
     Json,
     Sarif,


### PR DESCRIPTION
## What problem are you trying to solve?

When executing our analyzer in container, it gets the number of cpus incorrectly. We need to bring a way to control the parallelism of the analyzer.

## What is your solution?

Add a `-cpus` option that lets the user define the number of CPU on the host. If the program is executed on a host where the number of not correctly detected, it will let them override the default value.

## What the reviewer should know

We refactored the code to avoid having too many configuration variable. We put all the cli configuration in a common data structure `CliConfiguration`.
