### PR TITLE
add support for static files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ trigger_internal_image:
   variables:
     IMAGE_VERSION: current
     IMAGE_NAME: datadog-static-analyzer
-    RELEASE_TAG: 2023071001
+    RELEASE_TAG: 2023071201
     BUILD_TAG: 2023071001
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -58,24 +58,16 @@ async fn serve_static(
     server_configuration: &State<ServerConfiguration>,
     name: &str,
 ) -> Option<NamedFile> {
-    server_configuration.static_directory.as_ref()?;
-
-    if name.contains("..") {
+    if server_configuration.static_directory.is_none()
+        || name.contains("..")
+        || name.starts_with('.')
+    {
         return None;
     }
 
-    if name.starts_with('.') {
-        return None;
-    }
+    let s = server_configuration.static_directory.as_ref().unwrap();
 
-    let full_path = Path::new(
-        server_configuration
-            .static_directory
-            .clone()
-            .unwrap()
-            .as_str(),
-    )
-    .join(Path::new(name));
+    let full_path = Path::new(s).join(name);
     NamedFile::open(full_path).await.ok()
 }
 


### PR DESCRIPTION
## What problem are you trying to solve?

We want to support serving static files for the server. We did it before but we need to specify the path for each file. As we will serve all the WASM files, we want to just specify one directory that will contain all the static files.

## What is your solution?

Add a new flag `-s` or `--static` that provides a single directory that contains all static files to serve. If a static file is requested and is in the directory, we return it.

For extra safety, we ensure that the file does not contain `..` or start with `.` to prevent any malicious users to walk through the file hierarchy.