### PR TITLE
add more information about the analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ lto = true
 [workspace.dependencies]
 anyhow = "1"
 base64 = "0.21.2"
+itertools = "0.11.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 derive_builder = "0.12"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,6 +3,7 @@ anyhow,https://crates.io/crates/anyhow,MIT,Copyright (c) 2019 David Tolnay
 base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 2015 Alice Maz
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
 glob-match,https://crates.io/crates/glob-match,MIT, Copyright (c) 2023 Devon Govett
+itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean McArthur
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -27,6 +27,7 @@ kernel = {path = "../kernel" }
 server = {path = "../server"}
 # workspace
 anyhow = { workspace = true }
+itertools = { workspace = true }
 serde_json = { workspace = true }
 # other
 getopts = "0.2.21"

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -141,7 +141,15 @@ pub fn execute_rule(
                     execution_time_ms,
                 }
             } else if let Some(res) = rx_result.try_recv().unwrap_or(None) {
-                res
+                RuleResult {
+                    rule_name: res.rule_name,
+                    filename: res.filename,
+                    violations: res.violations,
+                    errors: res.errors,
+                    execution_error: res.execution_error,
+                    execution_time_ms,
+                    output: res.output,
+                }
             } else {
                 RuleResult {
                     rule_name: rule_name_copy,


### PR DESCRIPTION
## What problem are you trying to solve?

We want to solve two problems:
1. Showing more information to the user about how many violations have been found in how many files in how long
2. Troubleshooting the rules and see what rules take most time

## What is your solution?

For (1), we surface a message like the following once we execute the tool.

```
Found 314 violations in 311 files within 7 secs
```

For (2), we add an option (`-x`) that shows the cumulative time spent in a rule. It tells us exactly what rule are taking a lot of time and help us prioritize what rule to optimize.

```
Rule execution time
-------------------
rule "python-code-style/max-function-lines" execution time 1064 ms
rule "python-design/function-too-long" execution time 1052 ms
Rule timed out
--------------
No rule timed out
```


## What the reviewer should know

We fixed a bug in `javascript.rs` to report the execution time of a rule.
