### PR TITLE
Export category from sarif report

### DIFF
--- a/kernel/src/model/rule.rs
+++ b/kernel/src/model/rule.rs
@@ -34,6 +34,19 @@ pub enum RuleCategory {
     Unknown, // kept only for backward compatibility
 }
 
+impl fmt::Display for RuleCategory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::BestPractices => write!(f, "best_practices"),
+            Self::CodeStyle => write!(f, "code_style"),
+            Self::ErrorProne => write!(f, "error_prone"),
+            Self::Performance => write!(f, "performance"),
+            Self::Security => write!(f, "security"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub enum RuleSeverity {
     #[serde(rename = "ERROR")]
@@ -52,7 +65,7 @@ impl fmt::Display for RuleSeverity {
             Self::Error => write!(f, "error"),
             Self::Warning => write!(f, "warning"),
             Self::Notice => write!(f, "notice"),
-            Self::None => write!(f, "unone"),
+            Self::None => write!(f, "none"),
         }
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

We want to export the rule category in the SARIF report.

## What is your solution?

Export the category. Put the category in the report as a property using a `propertyBag`. The property is under the tag `DATADOG_CATEGORY`. See the example below.


```
                {
                    "fixes": [
                        {
                            "artifactChanges": [
                                {
                                    "artifactLocation": {
                                        "uri": "yaml_load.py"
                                    },
                                    "replacements": [
                                        {
                                            "deletedRegion": {
                                                "endColumn": 10,
                                                "endLine": 3,
                                                "startColumn": 6,
                                                "startLine": 3
                                            },
                                            "insertedContent": {
                                                "text": "safe_load"
                                            }
                                        }
                                    ]
                                }
                            ],
                            "description": {
                                "text": "use safe_load"
                            }
                        }
                    ],
                    "level": "warning",
                    "locations": [
                        {
                            "physicalLocation": {
                                "artifactLocation": {
                                    "uri": "yaml_load.py"
                                },
                                "region": {
                                    "endColumn": 10,
                                    "endLine": 3,
                                    "startColumn": 6,
                                    "startLine": 3
                                }
                            }
                        }
                    ],
                    "message": {
                        "text": "prefer using safe_load to avoid arbitrary code execution"
                    },
                    "properties": {
                        "tags": [
                            "DATADOG_CATEGORY:SECURITY"
                        ]
                    },
                    "ruleId": "python-security/yaml-load",
                    "ruleIndex": 6
                },
```
