### PR TITLE
add endpoint to return languages

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -38,6 +38,15 @@ impl Fairing for CORS {
     }
 }
 
+#[rocket::get("/languages", format = "application/json")]
+fn languages() -> Value {
+    let languages: Vec<String> = kernel::model::common::ALL_LANGUAGES
+        .iter()
+        .map(|x| format!("{}", x))
+        .collect();
+    json!(languages)
+}
+
 #[rocket::post("/analyze", format = "application/json", data = "<request>")]
 fn analyze(request: Json<AnalysisRequest>) -> Value {
     json!(process_analysis_request(request.into_inner()))
@@ -130,4 +139,5 @@ fn rocket_main() -> _ {
         .mount("/", rocket::routes![ping])
         .mount("/", rocket::routes![get_options])
         .mount("/", rocket::routes![serve_static])
+        .mount("/", rocket::routes![languages])
 }

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -40,9 +40,9 @@ impl Fairing for CORS {
 
 #[rocket::get("/languages", format = "application/json")]
 fn languages() -> Value {
-    let languages: Vec<String> = kernel::model::common::ALL_LANGUAGES
+    let languages: Vec<Value> = kernel::model::common::ALL_LANGUAGES
         .iter()
-        .map(|x| format!("{}", x))
+        .map(|x| json!(x))
         .collect();
     json!(languages)
 }

--- a/kernel/src/model/common.rs
+++ b/kernel/src/model/common.rs
@@ -43,8 +43,13 @@ pub enum Language {
 }
 
 #[allow(dead_code)]
-static ALL_LANGUAGES: &[Language] = &[
+pub static ALL_LANGUAGES: &[Language] = &[
+    Language::Csharp,
+    Language::Dockerfile,
+    Language::Go,
+    Language::Java,
     Language::JavaScript,
+    Language::Json,
     Language::Python,
     Language::Rust,
     Language::TypeScript,


### PR DESCRIPTION
## What problem are you trying to solve?

We want to expose the languages supported by the analyzer. The server must return the list of supported languages.

## What is your solution?

Adding the endpoint that returns all the languages available using the list from the `kernel.`

## Testing

```
curl http://localhost:8000/languages
["CSHARP","DOCKERFILE","GO","JAVA","JAVASCRIPT","JSON","PYTHON","RUST","TYPESCRIPT"]%
```