### PR TITLE
enable debug via environment variables

### DIFF
--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
     let use_debug = *matches
         .opt_str("d")
         .map(|value| value == "yes")
-        .get_or_insert(false);
+        .get_or_insert(env::var_os("DD_DEBUG").is_some());
     let output_file = matches
         .opt_str("o")
         .context("output file must be specified")?;

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
     let use_debug = *matches
         .opt_str("d")
         .map(|value| value == "yes")
-        .get_or_insert(env::var_os("DD_DEBUG").is_some());
+        .get_or_insert(env::var_os("DD_SA_DEBUG").is_some());
     let output_file = matches
         .opt_str("o")
         .context("output file must be specified")?;


### PR DESCRIPTION
## What problem are you trying to solve?

We want to enable debug via environment variables. This way, in a CI/CD pipeline, customers can simply enable a environment variable instead of modifying how they invoke a command.

## What is your solution?

Check the environment variable is set when we enable debug mode.