### PR TITLE
Add file to track versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   upload-versions:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,16 @@ permissions:
   contents: write
 
 jobs:
+  upload-versions:
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Upload versions
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: versions.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   upload-assets:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Upload versions
-        uses: JasonEtco/upload-to-release@master
+        uses: softprops/action-gh-release@v1
         with:
-          args: versions.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: versions.json
   upload-assets:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [workspace]
-
 members = [
     "bins",
     "cli",
     "kernel",
     "server"
 ]
+
+[workspace.package]
+version = "0.0.5"
 
 [profile.release]
 lto = true

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-static-analyzer"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -1,5 +1,5 @@
 use getopts::Options;
-use kernel::constants::VERSION;
+use kernel::constants::{CARGO_VERSION, VERSION};
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::fs::NamedFile;
 use rocket::http::Header;
@@ -59,7 +59,7 @@ fn get_tree(request: Json<TreeSitterRequest>) -> Value {
 
 #[rocket::get("/version", format = "text/html")]
 fn get_version() -> String {
-    VERSION.to_string()
+    format!("{}/{}", CARGO_VERSION, VERSION)
 }
 
 #[rocket::get("/static/<name>", format = "text/html")]

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -5,7 +5,7 @@ use cli::model::config_file::ConfigFile;
 use cli::rule_utils::{get_languages_for_rules, get_rulesets_from_file};
 use itertools::Itertools;
 use kernel::analysis::analyze::analyze;
-use kernel::constants::VERSION;
+use kernel::constants::{CARGO_VERSION, VERSION};
 use kernel::model::analysis::{AnalysisOptions, ERROR_RULE_TIMEOUT};
 use kernel::model::common::OutputFormat;
 use kernel::model::rule::{Rule, RuleInternal, RuleResult};
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
     };
 
     if matches.opt_present("v") {
-        println!("{}", VERSION);
+        println!("Version: {}, revision: {}", CARGO_VERSION, VERSION);
         exit(1);
     }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cli"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
 
 [dependencies]
 # local

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kernel"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
 
 [dependencies]
 # workspace

--- a/kernel/src/constants.rs
+++ b/kernel/src/constants.rs
@@ -1,1 +1,2 @@
 pub const VERSION: &str = "development";
+pub const CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
-version = "0.1.0"
 edition = "2021"
+version.workspace = true
 
 [dependencies]
 # local

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,32 @@
+{
+  "0": [
+    {
+      "0.0.5": {
+        "windows": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+        },
+        "linux": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+        },
+        "macos": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-apple-darwin.zip",
+          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-aarch64-apple-darwin.zip"
+        }
+      },
+      "0.0.4": {
+        "windows": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+        },
+        "linux": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+        },
+        "macos": {
+          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-apple-darwin.zip",
+          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-aarch64-apple-darwin.zip"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to track the number of versions that are offered along with the major and minor versions.

## What is your solution?

1. First, we need to make sure we have a consistent versioning mechanism across the software. We declare one version in the `Cargo.toml` at the root directory and use this version across the workspace. Each module refers to the workspace version using `version.workspace = true`. See [this documentation](https://doc.rust-lang.org/cargo/reference/workspaces.html) for more information
2. We introduce a file `versions.json` that we keep to track all our versions. This file will be available at `https://github.com/DataDog/datadog-static-analyzer/releases/latest/download/versions.json`
3. We upload this file when we release a new version using a new GitHub Action

## What the reviewer should know?

We updated our release process as we need to add two new steps:
1. Add the new links in `versions.json`
2. Change the version in `Cargo.toml`