### PR TITLE
separate /version and /revision

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -57,9 +57,14 @@ fn get_tree(request: Json<TreeSitterRequest>) -> Value {
     json!(process_tree_sitter_tree_request(request.into_inner()))
 }
 
-#[rocket::get("/version", format = "text/html")]
+#[rocket::get("/version", format = "text/plain")]
 fn get_version() -> String {
-    format!("{}/{}", CARGO_VERSION, VERSION)
+    CARGO_VERSION.to_string()
+}
+
+#[rocket::get("/revision", format = "text/plain")]
+fn get_revision() -> String {
+    VERSION.to_string()
 }
 
 #[rocket::get("/static/<name>", format = "text/html")]
@@ -136,6 +141,7 @@ fn rocket_main() -> _ {
         .mount("/", rocket::routes![analyze])
         .mount("/", rocket::routes![get_tree])
         .mount("/", rocket::routes![get_version])
+        .mount("/", rocket::routes![get_revision])
         .mount("/", rocket::routes![ping])
         .mount("/", rocket::routes![get_options])
         .mount("/", rocket::routes![serve_static])


### PR DESCRIPTION
## What problem are you trying to solve?

We want to have a separate `/version` and `/revision` endpoint. For the `/revision`, it shows us the exact Git version running. The `/version` will be useful for the IDE integration to distinguish exactly the version running and if there is a need to upgrade

## What is your solution?

Have two endpoints:
 - `/version` used to show the cargo version (e.g. `0.0.5`)
 - `/revision` that shows the Git SHA of the code running

## Testing

```
curl http://127.0.0.1:8000/version                                                                                                                                                                                                                                                                                                                                                                                                                  
0.0.5%
[julien.delange@kaneda]/Users/julien.delange/git/tree-sitter#curl http://127.0.0.1:8000/revision                                                                                                                                                                                                                                                                                                                                                                                                                 
development%
```