### PR TITLE
Check rule checksum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 derive_builder = "0.12"
 serde-sarif = "0.4"
+sha2 = "0.10.7"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,5 +13,6 @@ sarif-rs,https://github.com/psastras/sarif-rs,MIT,Copyright (c) 2021 Paul Sastra
 serde,https://github.com/serde-rs/serde,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_json,https://github.com/serde-rs/json,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0,2016 David Tolnay
+sha2,https://crates.io/crates/sha2,Apache-2.0,Copyright (c) 2006-2009 Graydon Hoare 2009-2013 Mozilla Foundation 2016 Artyom Pavlov
 valico,https://github.com/s-panferov/valico,MIT,Copyright (c) 2014 Stanislav Panferov
 walkdir,https://github.com/BurntSushi/walkdir,MIT,Copyright (c) 2015 Andrew Gallant

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -11,6 +11,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 derive_builder = { workspace = true }
 serde-sarif = { workspace = true }
+sha2 = { workspace = true }
+
 # other
 deno_core = "0.196.0"
 lazy_static = "1.4.0"

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -6,3 +6,7 @@ pub fn decode_base64_string(base64_string: String) -> anyhow::Result<String> {
         general_purpose::STANDARD.decode(base64_string)?,
     )?)
 }
+
+pub fn encode_base64_string(str: String) -> String {
+    general_purpose::STANDARD.encode(str)
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,9 +9,9 @@ kernel = {path = "../kernel" }
 # workspace
 anyhow = { workspace = true }
 base64 = { workspace = true }
+derive_builder = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-derive_builder = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -6,3 +6,4 @@ pub const ERROR_CODE_NOT_BASE64: &str = "code-not-base64";
 pub const ERROR_CODE_LANGUAGE_MISMATCH: &str = "language-mismatch";
 // no root node when trying to get the AST
 pub const ERROR_CODE_NO_ROOT_NODE: &str = "no-root-node";
+pub const ERROR_CHECKSUM_MISMATCH: &str = "checksum-mismatch";


### PR DESCRIPTION
## What problem are you trying to solve?

We want to check the checksum of the rules to make sure there is no issue with the rules, either from a consistency or security issues. 

## What is your solution?

1. For each server request, we check the checksum passed. If the checksum is not correct, we return an error
2. For the CLI, we check the checksum of each rule. If one checksum is incorrect, we panic and exit the program

## What the reviewer should know

We added a `-b` option (disabled by default) to bypass the checksum check if needed.

## Testing

```
[julien.delange@kaneda]/Users/julien.delange/git/datadog-static-analyzer#cargo run --bin datadog-static-analyzer -- --directory /Users/julien.delange/git/rosie-tests -o plop.json --debug yes
   Compiling datadog-static-analyzer v0.0.5 (/Users/julien.delange/git/datadog-static-analyzer/bins)
    Finished dev [unoptimized + debuginfo] target(s) in 1.53s
     Running `target/debug/datadog-static-analyzer --directory /Users/julien.delange/git/rosie-tests -o plop.json --debug yes`
Configuration
=============
config method    : config file (static-analysis.datadog.[yml|yaml])
cores available  : 10
cores used       : 10
#rules loaded    : 84
source directory : /Users/julien.delange/git/rosie-tests
output file      : plop.json
output format    : json
ignore paths     :
use config file  : true
use debug        : true
rules languages  : python
Checking rule checksum ... done!
Analyzing python, 4 files detected
Found 4 violations in 4 files using 84 rules within 0 secs
```

and

```
[julien.delange@kaneda]/Users/julien.delange/git/datadog-static-analyzer#cargo run --bin datadog-static-analyzer -- --directory /Users/julien.delange/git/rosie-tests -o plop.json --debug yes -b  
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/datadog-static-analyzer --directory /Users/julien.delange/git/rosie-tests -o plop.json --debug yes -b`
Configuration
=============
config method    : config file (static-analysis.datadog.[yml|yaml])
cores available  : 10
cores used       : 10
#rules loaded    : 84
source directory : /Users/julien.delange/git/rosie-tests
output file      : plop.json
output format    : json
ignore paths     :
use config file  : true
use debug        : true
rules languages  : python
Skipping checksum verification
Analyzing python, 4 files detected
Found 4 violations in 4 files using 84 rules within 0 secs
```