### PR TITLE
chore(from): use the From trait for ServerTreeSitterNode

### DIFF
--- a/server/src/model/tree_sitter_tree_node.rs
+++ b/server/src/model/tree_sitter_tree_node.rs
@@ -14,18 +14,18 @@ pub struct ServerTreeSitterNode {
     pub children: Vec<ServerTreeSitterNode>,
 }
 
-pub fn convert_tree_sitter_node_for_server(node: TreeSitterNode) -> ServerTreeSitterNode {
-    let children: Vec<ServerTreeSitterNode> = node
-        .children
-        .into_iter()
-        .map(convert_tree_sitter_node_for_server)
-        .collect();
-
-    ServerTreeSitterNode {
-        ast_type: node.ast_type,
-        start: node.start.clone(),
-        end: node.end.clone(),
-        field_name: node.field_name,
-        children,
+impl From<TreeSitterNode> for ServerTreeSitterNode {
+    fn from(value: TreeSitterNode) -> Self {
+        ServerTreeSitterNode {
+            ast_type: value.ast_type,
+            start: value.start,
+            end: value.end,
+            field_name: value.field_name,
+            children: value
+                .children
+                .into_iter()
+                .map(ServerTreeSitterNode::from)
+                .collect(),
+        }
     }
 }

--- a/server/src/tree_sitter_tree.rs
+++ b/server/src/tree_sitter_tree.rs
@@ -1,5 +1,4 @@
 use crate::constants::{ERROR_CODE_NOT_BASE64, ERROR_CODE_NO_ROOT_NODE};
-use crate::model::tree_sitter_tree_node::convert_tree_sitter_node_for_server;
 use crate::model::tree_sitter_tree_request::TreeSitterRequest;
 use crate::model::tree_sitter_tree_response::TreeSitterResponse;
 use kernel::analysis::tree_sitter::{get_tree, map_node};
@@ -33,7 +32,7 @@ pub fn process_tree_sitter_tree_request(request: TreeSitterRequest) -> TreeSitte
     }
 
     TreeSitterResponse {
-        result: root_node.map(convert_tree_sitter_node_for_server),
+        result: root_node.map(|node| node.into()),
         errors: vec![],
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

It's not really a problem, but I thought I would introduce this change to provide a more idiomatic way of dealing with type transformations.

## What is your solution?

The solution is avoid using a custom function for type transformation and implement the `From` trait.

## What the reviewer should know

See [From and Into](https://doc.rust-lang.org/rust-by-example/conversion/from_into.html) or the [From trait docs](https://doc.rust-lang.org/std/convert/trait.From.html) for more info.
