### PR TITLE
add SHA to SARIF report

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,5 +1,5 @@
 on: push
-name: Check Code
+name: Run Integration tests
 jobs:
   integration_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,20 @@
+on: push
+name: Check Code
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+      DD_SITE: ${{ secrets.DD_SITE }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Stable + Rustfmt + Clippy
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+            override: true
+            default: true
+      - name: Run Integration tests
+        run: ./misc/integration-test.sh

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,6 +2,7 @@ Component,Origin,License,Copyright
 anyhow,https://crates.io/crates/anyhow,MIT,Copyright (c) 2019 David Tolnay
 base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 2015 Alice Maz
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
+git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 glob-match,https://crates.io/crates/glob-match,MIT, Copyright (c) 2023 Devon Govett
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -104,6 +104,11 @@ fn main() -> Result<()> {
         "performance-statistics",
         "enable performance statistics",
     );
+    opts.optflag(
+        "g",
+        "add-git-info",
+        "add Git information to the SARIF report",
+    );
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -129,7 +134,7 @@ fn main() -> Result<()> {
     }
 
     let should_verify_checksum = !matches.opt_present("b");
-
+    let add_git_info = matches.opt_present("g");
     let enable_performance_statistics = matches.opt_present("x");
 
     let output_format = match matches.opt_str("f") {
@@ -389,8 +394,12 @@ fn main() -> Result<()> {
         OutputFormat::Json => {
             serde_json::to_string(&all_rule_results).expect("error when getting the JSON report")
         }
-        OutputFormat::Sarif => match generate_sarif_report(&configuration.rules, &all_rule_results)
-        {
+        OutputFormat::Sarif => match generate_sarif_report(
+            &configuration.rules,
+            &all_rule_results,
+            &directory_to_analyze,
+            add_git_info,
+        ) {
             Ok(report) => {
                 serde_json::to_string(&report).expect("error when getting the SARIF report")
             }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 derive_builder = { workspace = true }
 serde-sarif = { workspace = true }
 # other
+git2 = "0.17.2"
 glob-match = "0.2.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_yaml = "0.9.21"

--- a/cli/src/sarif/sarif_utils.rs
+++ b/cli/src/sarif/sarif_utils.rs
@@ -23,6 +23,9 @@ trait IntoSarif {
     fn into_sarif(self) -> Self::SarifType;
 }
 
+// Options to use when to generate the SARIF reports.
+// if `add_git_info` is true, the git_repo should not be
+// optional and will be used to get the SHA of the violations.
 #[derive(Clone)]
 pub struct SarifGenerationOptions {
     pub add_git_info: bool,

--- a/misc/integration-test.sh
+++ b/misc/integration-test.sh
@@ -1,27 +1,37 @@
 #!/bin/bash
 
+# This integration test for datadog-static-analyzer
+# 1. Check out a basic repo
+# 2. Run the latest version of the analyzer on it
+# 3. Check that we get the SHA of the commit and the category in the output SARIF file.
 
 cargo build -r
 REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}"
 ./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" --debug yes -b -f sarif -x -g
+
+# Getting the category of the fist violation detected (all violations in this report are security)
 CATEGORY=$(jq '.runs[0].results[0].properties.tags[0]' "${REPO_DIR}/results.json")
-FIRST_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/subprocess-shell-true")).properties.tags[1]' "${REPO_DIR}/results.json")
-SECOND_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/yaml-load")).properties.tags[1]' "${REPO_DIR}/results.json")
+
+# Getting the SHA of the violation detected by the rule python-security/subprocess-shell-true
+FIRST_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/subprocess-shell-true")).partialFingerprints["SHA"]' "${REPO_DIR}/results.json")
+
+# Getting the SHA of the violation detected by the rule python-security/yaml-load
+SECOND_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/yaml-load")).partialFingerprints["SHA"]' "${REPO_DIR}/results.json")
 
 if [ "${CATEGORY}" != "\"DATADOG_CATEGORY:SECURITY\"" ]; then
   echo "invalid category ${CATEGORY}"
   exit 1
 fi
 
-if [ "${FIRST_SHA}" != "\"SHA:5509900dc490cedbe2bb64afaf43478e24ad144b\"" ]; then
+if [ "${FIRST_SHA}" != "\"5509900dc490cedbe2bb64afaf43478e24ad144b\"" ]; then
   echo "invalid first SHA ${FIRST_SHA}"
   exit 1
 fi
 
 
-if [ "${SECOND_SHA}" != "\"SHA:8c5080ff058d5d34961b9941ef498fc238be1caf\"" ]; then
+if [ "${SECOND_SHA}" != "\"8c5080ff058d5d34961b9941ef498fc238be1caf\"" ]; then
   echo "invalid second SHA ${SECOND_SHA}"
   exit 1
 fi

--- a/misc/integration-test.sh
+++ b/misc/integration-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+
+cargo build -r
+REPO_DIR=$(mktemp -d)
+export REPO_DIR
+git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}"
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" --debug yes -b -f sarif -x -g
+CATEGORY=$(jq '.runs[0].results[0].properties.tags[0]' "${REPO_DIR}/results.json")
+FIRST_SHA=$(jq '.runs[0].results[0].properties.tags[1]' "${REPO_DIR}/results.json")
+SECOND_SHA=$(jq '.runs[0].results[1].properties.tags[1]' "${REPO_DIR}/results.json")
+
+if [ "${CATEGORY}" != "\"DATADOG_CATEGORY:SECURITY\"" ]; then
+  echo "invalid category ${CATEGORY}"
+  exit 1
+fi
+
+if [ "${FIRST_SHA}" != "\"SHA:5509900dc490cedbe2bb64afaf43478e24ad144b\"" ]; then
+  echo "invalid first SHA ${FIRST_SHA}"
+  exit 1
+fi
+
+
+if [ "${SECOND_SHA}" != "\"SHA:8c5080ff058d5d34961b9941ef498fc238be1caf\"" ]; then
+  echo "invalid second SHA ${SECOND_SHA}"
+  exit 1
+fi
+
+exit 0

--- a/misc/integration-test.sh
+++ b/misc/integration-test.sh
@@ -26,4 +26,6 @@ if [ "${SECOND_SHA}" != "\"SHA:8c5080ff058d5d34961b9941ef498fc238be1caf\"" ]; th
   exit 1
 fi
 
+echo "All tests passed"
+
 exit 0

--- a/misc/integration-test.sh
+++ b/misc/integration-test.sh
@@ -7,8 +7,8 @@ export REPO_DIR
 git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}"
 ./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" --debug yes -b -f sarif -x -g
 CATEGORY=$(jq '.runs[0].results[0].properties.tags[0]' "${REPO_DIR}/results.json")
-FIRST_SHA=$(jq '.runs[0].results[0].properties.tags[1]' "${REPO_DIR}/results.json")
-SECOND_SHA=$(jq '.runs[0].results[1].properties.tags[1]' "${REPO_DIR}/results.json")
+FIRST_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/subprocess-shell-true")).properties.tags[1]' "${REPO_DIR}/results.json")
+SECOND_SHA=$(jq '.runs[0].results[] | select( .ruleId | contains("python-security/yaml-load")).properties.tags[1]' "${REPO_DIR}/results.json")
 
 if [ "${CATEGORY}" != "\"DATADOG_CATEGORY:SECURITY\"" ]; then
   echo "invalid category ${CATEGORY}"


### PR DESCRIPTION
## What problem are you trying to solve?

We want to add the SHA related to a violation in the SARIF report.

## What is your solution?

1. We are adding a `-g` option
2. When the `-g` option is specific, we add the `SHA` for a violation by running `git blame` on it

This has been tested against the repository https://github.com/juli1/rosie-tests (see the section on integration tests below).

## What the reviewer should know

Since it's hard to have unit tests for such a feature, we added a script for doing integration tests. This integration test script is found in `misc/integration-test.sh`. It is added in our GitHub actions.

This scripts
 - Get the repository https://github.com/juli1/rosie-tests
 - Run the new stella with the `-g` option
 - Check that the SHA and the CATEGORY tags are in the report