### PR TITLE
add support for gitignore

### DIFF
--- a/cli/resources/test/gitignore/test1
+++ b/cli/resources/test/gitignore/test1
@@ -1,0 +1,145 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+ddtrace/appsec/_ddwaf.cpp
+ddtrace/appsec/include
+ddtrace/appsec/share
+ddtrace/profiling/collector/_task.c
+ddtrace/profiling/_threading.c
+ddtrace/profiling/collector/_traceback.c
+ddtrace/profiling/collector/stack.c
+ddtrace/profiling/exporter/pprof.c
+ddtrace/profiling/_build.c
+ddtrace/internal/datadog/profiling/ddup.cpp
+ddtrace/internal/_encoding.c
+ddtrace/internal/_rand.c
+ddtrace/internal/_tagset.c
+*.so
+*.a
+
+# Cython annotate HTML files
+ddtrace/**/*.html
+
+# Dynamic binary libraries
+ddtrace/appsec/ddwaf/libddwaf/
+libddwaf*.sha256
+ddtrace/internal/datadog/profiling/libdatadog/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+*.whl
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.ddtox/
+.ddriot/
+.coverage
+.coverage.*
+.cache
+test-results/
+coverage.xml
+coverage.json
+*,cover
+.hypothesis/
+.pytest_cache/
+test.db
+.benchmarks/**/*.json
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+_readthedocs/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule*
+
+# docker-compose env file
+# it must be versioned to keep track of backing services defaults
+!.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Vim
+*.swp
+# IDEA
+.idea/
+
+# VS Code
+.vscode/
+
+# Riot
+.riot/venv*
+.riot/requirements/*.in
+
+# Auto-generated version file
+ddtrace/_version.py
+
+# Benchmarks
+artifacts/
+
+# IAST cpp
+ddtrace/appsec/iast/_taint_tracking/cmake-build-debug/*
+ddtrace/appsec/iast/_taint_tracking/_deps/*
+ddtrace/appsec/iast/_taint_tracking/CMakeFiles/*
+
+# CircleCI generated config
+.circleci/config.gen.yml

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -73,11 +73,6 @@ pub fn get_files(directory: &str, paths_to_ignore: &[String]) -> Result<Vec<Path
                 .and_then(|p| p.to_str())
                 .ok_or_else(|| anyhow::Error::msg("should get the path"))?;
             if glob_match(path_to_ignore.as_str(), relative_path) {
-                println!(
-                    "file {} excluded by match {}",
-                    path_to_ignore.as_str(),
-                    relative_path
-                );
                 should_include = false;
             }
         }

--- a/cli/src/model/cli_configuration.rs
+++ b/cli/src/model/cli_configuration.rs
@@ -6,6 +6,7 @@ use kernel::model::rule::Rule;
 pub struct CliConfiguration {
     pub use_debug: bool,
     pub use_configuration_file: bool,
+    pub ignore_gitignore: bool,
     pub source_directory: String,
     pub ignore_paths: Vec<String>,
     pub rules_file: Option<String>,

--- a/cli/src/model/config_file.rs
+++ b/cli/src/model/config_file.rs
@@ -9,6 +9,8 @@ pub struct ConfigFile {
     pub rulesets: Vec<String>,
     #[serde(rename(serialize = "ignore-paths", deserialize = "ignore-paths"))]
     pub ignore_paths: Option<Vec<String>>,
+    #[serde(rename(serialize = "ignore-gitignore", deserialize = "ignore-gitignore"))]
+    pub ignore_gitignore: Option<bool>,
 }
 
 impl fmt::Display for ConfigFile {
@@ -20,8 +22,12 @@ impl fmt::Display for ConfigFile {
         };
         write!(
             f,
-            "rulesets: {}, ignore paths: {}",
-            rules_string, ignore_path_string
+            "rulesets: {}, ignore paths: {}, ignore .gitignore: {}",
+            rules_string,
+            ignore_path_string,
+            self.ignore_gitignore
+                .map(|v| v.to_string())
+                .unwrap_or("undefined".to_string())
         )
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

1. We need to add support to ignore directories from `.gitignore`
2. This mechanism can be disabled using the directive `ignore_gitignore` in the `static-analysis.datadog.yml` file

## What is your solution?

1. Ignore all directories from the `.gitignore` file
2. Add an attribute `ignore-gitignore` in the `static-analysis.datadog.yml` to disable the logic
3. print all ignored paths in the tool configuration section

## What the reviewer should know

We skipped all entries with `!` in the `.gitignore` file. The reason is that it filters all files when using it. For example, on [dd-trace-py](https://github.com/DataDog/dd-trace-py), the entry `!.env` skipped all files. We are therefore ignoring such entries for now.