### PR TITLE
upgrade deno + handle unauthenticated requests

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -14,7 +14,7 @@ serde-sarif = { workspace = true }
 sha2 = { workspace = true }
 
 # other
-deno_core = "0.198.0"
+deno_core = "0.200.0"
 lazy_static = "1.4.0"
 serde_v8 = "0.111.0"
 tree-sitter = "0.20.10"

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -17,7 +17,7 @@ const JAVASCRIPT_EXECUTION_TIMEOUT_MS: u64 = 5000;
 lazy_static! {
     static ref STARTUP_DATA: Vec<u8> = {
         let code: FastString = FastString::from_static(include_str!("./js/stella.js"));
-        let mut rt = JsRuntimeForSnapshot::new(Default::default(), Default::default());
+        let mut rt = JsRuntimeForSnapshot::new(RuntimeOptions::default());
         rt.execute_script("common_js", code).unwrap();
         rt.snapshot().to_vec()
     };


### PR DESCRIPTION
## What problem are you trying to solve?

Upgrade deno + handle unauthenticated requests

## What is your solution?

1. Make the code compliant with the latest version of deno
2. If the `DD_APP_KEY` or `DD_API_KEY` variables are not defined, do not send any key and send an authenticated request to datadog.
