### PR TITLE
Add check for the versions.json correctness

### DIFF
--- a/.github/workflows/versions-check.yaml
+++ b/.github/workflows/versions-check.yaml
@@ -1,0 +1,9 @@
+on: push
+name: Check the versions.json file is correct
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Ensure versions
+        run: python -mjson.tool versions.json >/dev/null


### PR DESCRIPTION
## What problem are you trying to solve?

We want to make sure that the `versions.json` file is always correct. An invalid version would cause issue with the IDE integration team. We want to ensure we avoid this.

## What is your solution?

Enable a check at each push and ensure the file can be at least parsed.
