### PR TITLE
Do not crash when we cannot get blame information

### DIFF
--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -413,6 +413,7 @@ fn main() -> Result<()> {
             &all_rule_results,
             &directory_to_analyze,
             add_git_info,
+            configuration.use_debug,
         ) {
             Ok(report) => {
                 serde_json::to_string(&report).expect("error when getting the SARIF report")


### PR DESCRIPTION
## What problem are you trying to solve?

The analyzer does not find the blame information sometimes. For this reason, we cannot crash when the blame information is not found. We should instead print a message when in `debug` mode.

## What is your solution?

Adapt the analyzer to prevent it to crash if the blame information cannot be found.