### PR TITLE
Update server and cli separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Set the version
         shell: bash
         run: sed  "s/development/$GITHUB_SHA/g" kernel/src/constants.rs > bla && rm kernel/src/constants.rs && mv bla kernel/src/constants.rs
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - name: Release the CLI
+        uses: taiki-e/upload-rust-binary-action@v1
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
@@ -69,3 +70,21 @@ jobs:
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.GITHUB_TOKEN }}
           archive: 'datadog-static-analyzer-$target'
+      - name: Release the server
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: datadog-static-analyzer-server
+          # (optional) On which platform to distribute the `.tar.gz` file.
+          # [default value: unix]
+          # [possible values: all, unix, windows, none]
+          tar: none
+          # (optional) On which platform to distribute the `.zip` file.
+          # [default value: windows]
+          # [possible values: all, unix, windows, none]
+          zip: all
+          target: ${{ matrix.target }}
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          archive: 'datadog-static-analyzer-server-$target'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.8"
+version = "0.0.9"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -3,10 +3,10 @@
         "0.0.9": {
             "windows": {
                 "cli": {
-                  "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
                 },
                 "server": {
-                  "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
                 }
             },
             "linux": {
@@ -30,4 +30,6 @@
                 }
             }
         }
+    }
+
 }

--- a/versions.json
+++ b/versions.json
@@ -1,71 +1,33 @@
 {
-  "0": [
-    {
-      "0.0.8": {
-        "windows": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.8/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-        },
-        "linux": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.8/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.8/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-        },
-        "macos": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.8/datadog-static-analyzer-x86_64-apple-darwin.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.8/datadog-static-analyzer-aarch64-apple-darwin.zip"
+    "0": {
+        "0.0.9": {
+            "windows": {
+                "cli": {
+                  "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "server": {
+                  "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                }
+            },
+            "linux": {
+                "cli": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "server": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                }
+            },
+            "macos": {
+                "cli": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                },
+                "server": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
         }
-      },
-      "0.0.7": {
-        "windows": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.7/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-        },
-        "linux": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.7/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.7/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-        },
-        "macos": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.7/datadog-static-analyzer-x86_64-apple-darwin.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.7/datadog-static-analyzer-aarch64-apple-darwin.zip"
-        }
-      },
-      "0.0.6": {
-        "windows": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.6/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-        },
-        "linux": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.6/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.6/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-        },
-        "macos": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.6/datadog-static-analyzer-x86_64-apple-darwin.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.6/datadog-static-analyzer-aarch64-apple-darwin.zip"
-        }
-      },
-      "0.0.5": {
-        "windows": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-        },
-        "linux": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-        },
-        "macos": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-x86_64-apple-darwin.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.5/datadog-static-analyzer-aarch64-apple-darwin.zip"
-        }
-      },
-      "0.0.4": {
-        "windows": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-        },
-        "linux": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-        },
-        "macos": {
-          "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-x86_64-apple-darwin.zip",
-          "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.4/datadog-static-analyzer-aarch64-apple-darwin.zip"
-        }
-      }
-    }
-  ]
 }

--- a/versions.json
+++ b/versions.json
@@ -1,35 +1,32 @@
 {
     "0": {
         "0.0.9": {
-            "windows": {
-                "cli": {
+            "cli": {
+                "windows": {
                     "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
                 },
-                "server": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
-                }
-            },
-            "linux": {
-                "cli": {
+                "linux": {
                     "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
                     "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
                 },
-                "server": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
-                }
-            },
-            "macos": {
-                "cli": {
+                "macos": {
                     "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-x86_64-apple-darwin.zip",
                     "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
                 },
-                "server": {
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
                     "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
                     "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.0.9/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
## What problems are you trying to solve?

1. We want to avoid having an array in `versions.json` and have a dictionary 
2. Have another release to upload the server on the release

## What is your solution?

1. Define the version in a dictionary
3. Add the server artifact in `versions.json`
4. Release the cli in `datadog-static-analyzer` (what the CI/CD consumes today) and the server in `datadog-static-analyzer-server`

