### PR TITLE
Adds in a -v / --version for the server CLI

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -119,6 +119,7 @@ fn rocket_main() -> _ {
     );
     opts.optopt("p", "port", "port to run the server on", "8000");
     opts.optflag("h", "help", "print this help");
+    opts.optflag("v", "version", "shows the tool version");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -126,6 +127,11 @@ fn rocket_main() -> _ {
             panic!("error when parsing arguments: {}", f)
         }
     };
+
+    if matches.opt_present("v") {
+        println!("Version: {}, revision: {}", CARGO_VERSION, VERSION);
+        exit(1);
+    }
 
     if matches.opt_present("h") {
         print_usage(&program, opts);


### PR DESCRIPTION
## What problem are you trying to solve?
Don't rely on the full HTTP server being ran to determine the version

## What is your solution?
Copy the version flag and output format from the main CLI

## Testing

```
➜  datadog-static-analyzer git:(addServerVersionFlag) cargo run --bin datadog-static-analyzer-server -- -h
warning: tree-sitter-go/src/parser.c:242:18: warning: null character(s) preserved in string literal [-Wnull-character]
warning:   [anon_sym_] = "<U+0000>",
warning:                  ^
warning: 1 warning generated.
    Finished dev [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/datadog-static-analyzer-server -h`
Usage: target/debug/datadog-static-analyzer-server [options]

Options:
    -s, --static /path/to/directory
                        directory for static files
    -p, --port 8000     port to run the server on
    -h, --help          print this help
    -v, --version       shows the tool version
```

```
➜  datadog-static-analyzer git:(addServerVersionFlag) cargo run --bin datadog-static-analyzer-server -- -v
warning: tree-sitter-go/src/parser.c:242:18: warning: null character(s) preserved in string literal [-Wnull-character]
warning:   [anon_sym_] = "<U+0000>",
warning:                  ^
warning: 1 warning generated.
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/datadog-static-analyzer-server -v`
Version: 0.0.9, revision: development
```
