### PR TITLE
/ping should be text/plain

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -85,7 +85,7 @@ async fn serve_static(
     NamedFile::open(full_path).await.ok()
 }
 
-#[rocket::get("/ping", format = "text/html")]
+#[rocket::get("/ping", format = "text/plain")]
 fn ping() -> String {
     "pong".to_string()
 }


### PR DESCRIPTION
## What problem are you trying to solve?
Set the correct Accept-Type for /ping

## What the reviewer should know
Before
```
curl -v http://127.0.0.1:8000/ping -v --header "Accept: text/plain"
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /ping HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/8.1.2
> Accept: text/plain
>
< HTTP/1.1 404 Not Found
< content-type: text/html; charset=utf-8
< server: Rocket
< x-content-type-options: nosniff
< permissions-policy: interest-cohort=()
< x-frame-options: SAMEORIGIN
< access-control-allow-origin: *
< access-control-allow-methods: POST, GET, PATCH, OPTIONS
< access-control-allow-headers: *
< access-control-allow-credentials: true
< content-length: 383
< date: Thu, 31 Aug 2023 15:01:54 GMT
<
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8">
    <title>404 Not Found</title>
</head>
<body align="center">
    <div role="main" align="center">
        <h1>404: Not Found</h1>
        <p>The requested resource could not be found.</p>
        <hr />
    </div>
    <div role="contentinfo" align="center">
        <small>Rocket</small>
    </div>
</body>
* Connection #0 to host 127.0.0.1 left intact
</html>%
```

After
```
curl -v http://127.0.0.1:8000/ping -v --header "Accept: text/plain"
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET /ping HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/8.1.2
> Accept: text/plain
>
< HTTP/1.1 200 OK
< content-type: text/plain; charset=utf-8
< server: Rocket
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< permissions-policy: interest-cohort=()
< access-control-allow-origin: *
< access-control-allow-methods: POST, GET, PATCH, OPTIONS
< access-control-allow-headers: *
< access-control-allow-credentials: true
< content-length: 4
< date: Thu, 31 Aug 2023 15:02:26 GMT
<
* Connection #0 to host 127.0.0.1 left intact
pong%
```