### PR TITLE
Add progress bar in the CLI

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,6 +4,7 @@ base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 20
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 glob-match,https://crates.io/crates/glob-match,MIT, Copyright (c) 2023 Devon Govett
+indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean McArthur

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = { workspace = true }
 # other
 getopts = "0.2.21"
 num_cpus = "1.15.0"
+indicatif = "0.17.6"
 rayon = "1.7.0"
 rocket = {version = "=0.5.0-rc.3", features = ["json"]}
 

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -9,6 +9,7 @@ use walkdir::WalkDir;
 
 static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::JavaScript, &["js", "jsx"]),
+    (Language::Dockerfile, &["docker", "dockerfile"]),
     (Language::Python, &["py", "py3"]),
     (Language::Rust, &["rs"]),
     (Language::TypeScript, &["ts", "tsx"]),


### PR DESCRIPTION
## What problem are you trying to solve?

We want to add a progress bar in the command line.

## What is your solution?

Use the [indicatif](https://docs.rs/indicatif/latest/indicatif/) library to show the progress. We do not use colors as it could sometimes not render well in logs.

## Testing

![Screenshot 2023-09-03 at 4 23 34 PM](https://github.com/DataDog/datadog-static-analyzer/assets/993972/328e7f61-57d8-4113-85b9-b36f49ec0884)


## What the reviewer should know

 - Fixed a bug to make sure we report issues all all languages, not only the latest one.
 - Also enable the progress bar only when not in debug mode. Otherwise, it puts too much information on the terminal.
