### PR TITLE
fix(stable): tests not passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
-members = [
-    "bins",
-    "cli",
-    "kernel",
-    "server"
-]
+members = ["bins", "cli", "kernel", "server"]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.1"

--- a/cli/src/sarif/sarif_utils.rs
+++ b/cli/src/sarif/sarif_utils.rs
@@ -9,7 +9,7 @@ use serde_sarif::sarif::{
 };
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::rc::Rc;
 
 use kernel::model::rule::RuleSeverity;
 use kernel::model::{
@@ -30,7 +30,7 @@ trait IntoSarif {
 #[derive(Clone)]
 pub struct SarifGenerationOptions {
     pub add_git_info: bool,
-    pub git_repo: Option<Arc<Repository>>,
+    pub git_repo: Option<Rc<Repository>>,
     pub debug: bool,
 }
 
@@ -316,13 +316,13 @@ pub fn generate_sarif_report(
 ) -> Result<Sarif> {
     // if we enable git info, we are then getting the repository object. We put that
     // into an `Arc` object to be able to clone the object.
-    let repository: Option<Arc<Repository>> = if add_git_info {
+    let repository: Option<Rc<Repository>> = if add_git_info {
         let repo = Repository::open(directory.as_str());
         if repo.is_err() {
             eprintln!("Invalid Git repository in {}", directory);
             panic!("Please provide a valid Git repository or disable Git integration");
         }
-        Some(Arc::new(repo.expect("cannot open repository")))
+        Some(Rc::new(repo.expect("cannot open repository")))
     } else {
         None
     };


### PR DESCRIPTION
## What problem are you trying to solve?

There are some issues affecting potential contributors working with the latest stable version. 

1. The workspace resolver must be explicitly set. 
2. There are new clippy warnings that would block the pipeline.

Note: all this came up while I was trying to prepare another PR for the IDE integration. I wasn't able to push because of the local tests. I'll prepare right away after this one, and will make it dependant on it.

## What is your solution?

1. I set the workspace resolver to 2.

2. I changed the usage of `Arc` for `Rc`.  It seems that `Arc` was not needed as far as I could see given that we're not using threads or any sort of parallellism. The main complain from Clippy was that the wrapped type (`Repository`) was not `Send` and `Sync`.

## Alternatives considered

## What the reviewer should know
