### PR TITLE
fix(exit): correct exit codes for non-error ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
-members = [
-    "bins",
-    "cli",
-    "kernel",
-    "server"
-]
+members = ["bins", "cli", "kernel", "server"]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.1"

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -130,12 +130,12 @@ fn rocket_main() -> _ {
 
     if matches.opt_present("v") {
         println!("Version: {}, revision: {}", CARGO_VERSION, VERSION);
-        exit(1);
+        exit(0);
     }
 
     if matches.opt_present("h") {
         print_usage(&program, opts);
-        exit(1);
+        exit(0);
     }
 
     let server_configuration = ServerConfiguration {

--- a/cli/src/sarif/sarif_utils.rs
+++ b/cli/src/sarif/sarif_utils.rs
@@ -9,7 +9,7 @@ use serde_sarif::sarif::{
 };
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::rc::Rc;
 
 use kernel::model::rule::RuleSeverity;
 use kernel::model::{
@@ -30,7 +30,7 @@ trait IntoSarif {
 #[derive(Clone)]
 pub struct SarifGenerationOptions {
     pub add_git_info: bool,
-    pub git_repo: Option<Arc<Repository>>,
+    pub git_repo: Option<Rc<Repository>>,
     pub debug: bool,
 }
 
@@ -316,13 +316,13 @@ pub fn generate_sarif_report(
 ) -> Result<Sarif> {
     // if we enable git info, we are then getting the repository object. We put that
     // into an `Arc` object to be able to clone the object.
-    let repository: Option<Arc<Repository>> = if add_git_info {
+    let repository: Option<Rc<Repository>> = if add_git_info {
         let repo = Repository::open(directory.as_str());
         if repo.is_err() {
             eprintln!("Invalid Git repository in {}", directory);
             panic!("Please provide a valid Git repository or disable Git integration");
         }
-        Some(Arc::new(repo.expect("cannot open repository")))
+        Some(Rc::new(repo.expect("cannot open repository")))
     } else {
         None
     };


### PR DESCRIPTION
## What problem are you trying to solve?

Not sure why we are exiting with 1 in some valid use cases. I found this while integrating the server into VS Code. The exit code made the commands receive an error.

## What is your solution?

Changed exit to 0 to avoid node errors when spawing the process.

## Alternatives considered

For what I can see, there are other places in the codebase that could potentially run into the same kind of issues. Nonetheless, I've focused this PR into the IDE related codebase.

## What the reviewer should know

This PR is built on top of #77 but due to the fact that I must have a fork in order to contribute I cannot seem to make chained PRs.

So please, review #77 first, and merge it before this one. I'll rebase if needed.

IDE-1596