### PR TITLE
Add --staging flag to fetch rules from staging

### DIFF
--- a/bins/src/bin/datadog-export-rulesets.rs
+++ b/bins/src/bin/datadog-export-rulesets.rs
@@ -21,6 +21,7 @@ fn main() {
     opts.optmulti("r", "ruleset", "ruleset to fetch", "python-security");
     opts.optflag("h", "help", "print this help");
     opts.optflag("v", "version", "shows the version");
+    opts.optflag("s", "staging", "use staging");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -51,13 +52,16 @@ fn main() {
         exit(1);
     }
 
+    let use_staging = matches.opt_present("s");
     let rulesets_names = matches.opt_strs("r");
     let file_to_write = matches.opt_str("o").expect("output file");
 
     // get the rulesets from the API
     let rulesets: Vec<RuleSet> = rulesets_names
         .iter()
-        .map(|ruleset_name| get_ruleset(ruleset_name).expect("error when reading ruleset"))
+        .map(|ruleset_name| {
+            get_ruleset(ruleset_name, use_staging).expect("error when reading ruleset")
+        })
         .collect();
 
     let file = File::create(&file_to_write).expect("error when opening the output file");

--- a/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -61,6 +61,7 @@ fn main() {
 
     opts.optmulti("r", "ruleset", "rules to test", "python-security");
     opts.optflag("h", "help", "print this help");
+    opts.optflag("s", "staging", "use staging");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -74,10 +75,11 @@ fn main() {
         exit(1);
     }
 
+    let use_staging = matches.opt_present("s");
     let rulesets = matches.opt_strs("r");
     let mut num_failures = 0;
     for ruleset in rulesets {
-        match get_ruleset(ruleset.as_str()) {
+        match get_ruleset(ruleset.as_str(), use_staging) {
             Ok(r) => {
                 println!("Testing ruleset {}", r.name);
                 for rule in r.rules.clone() {

--- a/bins/src/bin/datadog-static-analyzer.rs
+++ b/bins/src/bin/datadog-static-analyzer.rs
@@ -66,6 +66,7 @@ fn print_configuration(configuration: &CliConfiguration) {
         configuration.use_configuration_file
     );
     println!("use debug        : {}", configuration.use_debug);
+    println!("use staging      : {}", configuration.use_staging);
     println!("rules languages  : {}", languages_string.join(","));
     println!("max file size    : {} kb", configuration.max_file_size_kb);
 }
@@ -113,6 +114,7 @@ fn main() -> Result<()> {
         "performance-statistics",
         "enable performance statistics",
     );
+    opts.optflag("s", "staging", "use staging");
     opts.optflag(
         "g",
         "add-git-info",
@@ -143,6 +145,7 @@ fn main() -> Result<()> {
     }
 
     let should_verify_checksum = !matches.opt_present("b");
+    let use_staging = matches.opt_present("s");
     let add_git_info = matches.opt_present("g");
     let enable_performance_statistics = matches.opt_present("x");
 
@@ -198,7 +201,7 @@ fn main() -> Result<()> {
             exit(1);
         }
 
-        let rules_from_api = get_rules_from_rulesets(&conf.rulesets);
+        let rules_from_api = get_rules_from_rulesets(&conf.rulesets, use_staging);
         rules.extend(rules_from_api.context("error when reading rules from API")?);
 
         // copy the ignore paths from the configuration file
@@ -261,6 +264,7 @@ fn main() -> Result<()> {
         rules,
         output_file,
         max_file_size_kb,
+        use_staging,
     };
 
     print_configuration(&configuration);

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -203,6 +203,7 @@ mod tests {
             num_cpus: 2, // of cpus to use for parallelism
             rules: vec![],
             max_file_size_kb: 1,
+            use_staging: false,
         };
         assert_eq!(0, filter_files_by_size(&files1, &cli_configuration).len());
 

--- a/cli/src/model/cli_configuration.rs
+++ b/cli/src/model/cli_configuration.rs
@@ -15,4 +15,5 @@ pub struct CliConfiguration {
     pub num_cpus: usize, // of cpus to use for parallelism
     pub rules: Vec<Rule>,
     pub max_file_size_kb: u64,
+    pub use_staging: bool,
 }


### PR DESCRIPTION
## What problem are you trying to solve?

Since we will be using staging to write rules, we need to be able to easily test the rules in staging.

## What is your solution?

We are introduced the flag `--staging` that will force the analyzer and other binaries to use the staging endpoint.
