### PR TITLE
prevent unecessary execution of visit function

### DIFF
--- a/kernel/src/analysis/tree_sitter.rs
+++ b/kernel/src/analysis/tree_sitter.rs
@@ -86,15 +86,18 @@ pub fn get_query_nodes(
                     .push(node.clone());
             }
         }
-        match_nodes.push(MatchNode {
-            captures: captures.clone(),
-            captures_list: captures_list.clone(),
-            context: MatchNodeContext {
-                code: Some(code.to_string()),
-                filename: filename.to_string(),
-                variables: variables.clone(),
-            },
-        });
+
+        if !captures.is_empty() {
+            match_nodes.push(MatchNode {
+                captures: captures.clone(),
+                captures_list: captures_list.clone(),
+                context: MatchNodeContext {
+                    code: Some(code.to_string()),
+                    filename: filename.to_string(),
+                    variables: variables.clone(),
+                },
+            });
+        }
     }
     match_nodes
 }


### PR DESCRIPTION
## What problem are you trying to solve?

Today, some rules have unecessary matches as reported by @dastrong. We need to ensure there is a capture before we trigger the `visit` function.

## What is your solution?

Make sure there is a capture before we start the `visit` function. Add a test to make sure we do not have any regression.