### PR TITLE
Add integration tests for production rules

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Test all production rules
         run: |
           cargo build -r && \
-          apt-get python3-requests && \
+          apt-get install python3-requests && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+  schedule:
+    # run every day at 10am UTC (5am EST)
+    - cron:  '0 11 * * *'
 name: Run Integration tests
 jobs:
   integration_tests:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Test all production rules
         run: |
           cargo build -r && \
-          apt-get install python3-requests && \
+          sudo apt-get install python3-requests && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -16,5 +16,11 @@ jobs:
             components: clippy
             override: true
             default: true
-      - name: Run Integration tests
-        run: ./misc/integration-test.sh
+      - name: Run Integration tests that the analyzer works with a repo
+        run: ./misc/integration-test-repo.sh
+      - name: Test all production rules
+        run: |
+          cargo build -r \
+          sudo apt-get python3-requests \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,7 +20,7 @@ jobs:
         run: ./misc/integration-test-repo.sh
       - name: Test all production rules
         run: |
-          cargo build -r \
-          apt-get python3-requests \
-          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices \
+          cargo build -r && \
+          apt-get python3-requests && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Test all production rules
         run: |
           cargo build -r \
-          sudo apt-get python3-requests \
+          apt-get python3-requests \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -23,4 +23,33 @@ jobs:
           cargo build -r && \
           sudo apt-get install python3-requests && \
           python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-best-practices && \
-          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-code-style && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-design && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-django && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-flask && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-inclusive && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-pandas && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r python-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r tsx-react && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-aws && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-best-practices && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-browser-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-code-style && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-common-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-express && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-inclusive && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r typescript-node-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-aws && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-best-practices && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-browser-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-code-style && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-common-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-express && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-inclusive && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r javascript-node-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r jsx-react && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r java-best-practices && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r java-code-style && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r java-security && \
+          python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server  -r docker-best-practices 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ kernel/tree-sitter-*/
 
 # IntelliJ
 .idea
+
+venv

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -9,6 +9,7 @@ use walkdir::WalkDir;
 
 static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::JavaScript, &["js", "jsx"]),
+    (Language::Java, &["java"]),
     (Language::Dockerfile, &["docker", "dockerfile"]),
     (Language::Python, &["py", "py3"]),
     (Language::Rust, &["rs"]),

--- a/misc/integration-test-repo.sh
+++ b/misc/integration-test-repo.sh
@@ -6,6 +6,8 @@
 # 3. Check that we get the SHA of the commit and the category in the output SARIF file.
 
 cargo build -r
+
+## First, test a repository
 REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}"

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -1,0 +1,178 @@
+# This script is used only for CI/CD purposes
+# We assume that everything is correctly built and available in the `target` directory.
+import base64
+import json
+import optparse
+import os.path
+import shlex
+import shutil
+import subprocess
+import tempfile
+
+import requests
+import sys
+
+parser = optparse.OptionParser()
+parser.add_option(
+    "-r", "--ruleset", dest="ruleset", help="ruleset to test",
+)
+parser.add_option(
+    "-c", "--cli-bin", dest="clibin", help="path to cli binary",
+)
+parser.add_option(
+    "-s", "--server-bin", dest="serverbin", help="path to server binary",
+)
+
+(options, args) = parser.parse_args()
+
+if not options.ruleset:
+    print("please specify a rule to test with option -r ")
+    sys.exit(1)
+
+if not options.clibin:
+    print("please specify cli binary with option -c")
+    sys.exit(1)
+
+if not options.serverbin:
+    print("please specify cli binary with option -s")
+    sys.exit(1)
+
+if not os.path.isfile(options.clibin):
+    print(f"file {options.clibin} does not exists")
+    sys.exit(1)
+
+if not os.path.isfile(options.serverbin):
+    print(f"file {options.serverbin} does not exists")
+    sys.exit(1)
+
+def fetch_ruleset(ruleset_name: str):
+    """
+    Fetch a ruleset from the datadog public API
+    :param ruleset_name:
+    :param site:
+    :return:
+    """
+    url: str = f"https://api.datadoghq.com/api/v2/static-analysis/rulesets/{ruleset_name}"
+
+
+    response = requests.get(url, timeout=10)
+
+    if response.status_code != 200:
+        print(f"ruleset {ruleset_name} not found")
+        sys.exit(1)
+
+    return response.json()
+
+
+def start_server():
+    pass
+
+def stop_server():
+    pass
+
+def test_ruleset_server(ruleset):
+    pass
+
+
+def transform_rule(rule):
+    """
+    Make sure we adapt the rule and put the right elements in the JSON file before passing it
+    to the analyzer
+    """
+    return {
+        "name": rule['name'],
+        "description": rule['description'],
+        "category": rule['category'],
+        "severity": rule['severity'],
+        "rule_type": rule['type'],
+        "language": rule['language'],
+        "tests": [],
+        "tree_sitter_query": rule['tree_sitter_query'],
+        'code': rule['code'],
+        'variables': {},
+        'checksum': rule['checksum']
+    }
+
+def test_ruleset_cli(ruleset):
+    """
+    Test a ruleset for the CLI.
+
+    For each test of each rule, write the test, invoke the rule and compare the number of violations
+    with the number of expected violations.
+
+    If there is a violation mismatch (e.g. what is detected does not match what is expected, exit the process)
+
+    :param ruleset:
+    :return:
+    """
+    print(f"Testing ruleset {ruleset['data']['id']}")
+    rules = ruleset['data']['attributes']['rules']
+
+    # Temporary directory to test, we will remove at the end
+    testdir = tempfile.mkdtemp()
+    for rule in rules:
+        print(f"   Testing rule {rule['name']}")
+        ruledir = os.path.join(testdir, rule['name'])
+        os.makedirs(ruledir)
+
+        # for each test of the rule
+        for test in rule['tests']:
+            test_code = test['code']
+            test_file = test['filename']
+            test_annotations_count = int(test['annotation_count'])
+            test_file_path = os.path.join(ruledir, test_file)
+            test_dirname = os.path.dirname(test_file_path)
+
+            # make sure all directories for the test file are created in case there is a test
+            # file with a directory inside
+            if not os.path.exists(test_dirname):
+                os.makedirs(os.path.dirname(test_file_path))
+            test_results_file = os.path.join(ruledir, f"{test_file}.results")
+            test_rules_file = os.path.join(ruledir, f"{test_file}.datadog.rules")
+            with open(test_file_path, "w") as f:
+                f.write(base64.b64decode(test_code).decode('utf-8'))
+
+            # Write the rule as a JSON object
+            with open(test_rules_file, "w") as f:
+                r = {
+                    'name': ruleset['data']['id'],
+                    'description': ruleset['data']['attributes']['description'],
+                    'rules': [transform_rule(rule)],
+                }
+                rulesets = [r]
+                f.write(json.dumps(rulesets))
+
+            # Invoke the tool, do not print anything
+            cmd = f"{options.clibin} -r {test_rules_file} -i {ruledir} -o {test_results_file} -f json"
+            subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+            # check that the number of violations match the number of expected annotations
+            with open(test_results_file) as results_file:
+                results = results_file.read()
+                test_results = json.loads(results)
+                results_annotations_count = len(test_results[0]['violations'])
+                if results_annotations_count != test_annotations_count:
+                    print(f"number of annotations mistmatch for rule {rule['name']}")
+                    print(f"Expected number of annotations: {test_annotations_count}")
+                    print(f"Got number of annotations: {results_annotations_count}")
+                    print(f"Command executed: {cmd}")
+                    sys.exit(1)
+            os.remove(test_file_path)
+
+
+    # remove directory to test
+    shutil.rmtree(testdir)
+
+
+ruleset = fetch_ruleset(options.ruleset)
+
+if ruleset is None:
+    print("ruleset not found")
+    sys.exit(1)
+
+test_ruleset_cli(ruleset)
+# start_server()
+# test_ruleset_server(ruleset)
+# stop_server()
+
+sys.exit(0)

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -150,7 +150,11 @@ def test_ruleset_cli(ruleset):
             with open(test_results_file) as results_file:
                 results = results_file.read()
                 test_results = json.loads(results)
-                results_annotations_count = len(test_results[0]['violations'])
+                if len(test_results) == 0:
+                    results_annotations_count = 0
+                else:
+                    results_annotations_count = len(test_results[0]['violations'])
+
                 if results_annotations_count != test_annotations_count:
                     print(f"number of annotations mistmatch for rule {rule['name']}")
                     print(f"Expected number of annotations: {test_annotations_count}")

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -205,9 +205,10 @@ def test_ruleset_cli(ruleset):
                 results = results_file.read()
                 test_results = json.loads(results)
                 if len(test_results) == 0:
-                    results_annotations_count = 0
-                else:
-                    results_annotations_count = len(test_results[0]['violations'])
+                    print(f"rule {rule['name']}, test {test_file} does not create results")
+                    sys.exit(1)
+
+                results_annotations_count = len(test_results[0]['violations'])
 
                 if results_annotations_count != test_annotations_count:
                     print(f"number of annotations mistmatch for rule {rule['name']}")


### PR DESCRIPTION
## What problem are you trying to solve?

We want to make sure that all rules released in production are working in both the CLI and the server.

## What is your solution?

The solution showed in this PR is for the **CLI ONLY**.

A python script (`test-production-rules.py`) test production rules and verify that the number of expected annotations match the number of violations reported by the CLI.

We will do a follow-up to test the server.


