### PR TITLE
Update time for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,7 +1,7 @@
 on:
   push:
   schedule:
-    # run every day at 19m UTC
+    # run every day at 9am UTC
     - cron:  '0 9 * * *'
 name: Run Integration tests
 jobs:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,8 +1,8 @@
 on:
   push:
   schedule:
-    # run every day at 10am UTC (5am EST)
-    - cron:  '0 11 * * *'
+    # run every day at 19m UTC
+    - cron:  '0 9 * * *'
 name: Run Integration tests
 jobs:
   integration_tests:


### PR DESCRIPTION
## What problem are you trying to solve?

Update time for integration tests, run before to make sure it executes when we wake up.