### PR TITLE
feat(server): added new yaml parser endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 derive_builder = "0.12"
 serde-sarif = "0.4"
+serde_yaml = "0.9"
 sha2 = "0.10.7"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,12 @@
+[tasks.server]
+workspace = false
+command = "cargo"
+watch = { watch = ["./bins", "./kernel", "./cli", "./server", "Cargo.toml"] }
+args = ["run", "--bin", "datadog-static-analyzer-server"]
+
+[tasks.format]
+clear = true
+workspace = false
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--all", "--", "--check"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Export rulesets from the API into a file
 cargo run --bin datadog-export-rulesets -- -r <ruleset> -o <file-to-export>
 ```
 
+### Cargo Make
+
+We're using [Cargo Make](https://sagiegurari.github.io/cargo-make/) to manage some recurrent tasks.
+
+
+### REST Client
+
+If you're using [VS Code](https://code.visualstudio.com/), you can install the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension and use the `server-request.http` file to easily test the `Static Analyzer Server`.
+
 ## Contribute
 
 See file [CONTRIBUTING.md](CONTRIBUTING.md) for more information as well as [DEVELOPMENT.md](DEVELOPMENT.md)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo run --bin datadog-export-rulesets -- -r <ruleset> -o <file-to-export>
 
 ### Cargo Make
 
-We're using [Cargo Make](https://sagiegurari.github.io/cargo-make/) to manage some recurrent tasks.
+We're using [Cargo Make](https://sagiegurari.github.io/cargo-make/) to manage some recurring tasks.
 
 
 ### REST Client

--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -18,24 +18,30 @@ name = "datadog-static-analyzer-server"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
-features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
+features = [
+  "precommit-hook",
+  "run-cargo-test",
+  "run-cargo-clippy",
+  "run-cargo-fmt",
+]
 
 [dependencies]
 # local
-cli = {path = "../cli"}
-kernel = {path = "../kernel" }
-server = {path = "../server"}
+cli = { path = "../cli" }
+kernel = { path = "../kernel" }
+server = { path = "../server" }
 # workspace
 anyhow = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 # other
 getopts = "0.2.21"
 num_cpus = "1.15.0"
 indicatif = "0.17.6"
 lazy_static = "1.4.0"
 rayon = "1.7.0"
-rocket = {version = "=0.5.0-rc.3", features = ["json"]}
+rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 
 
 # For linux and macos, we need the vendored ssl

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -79,8 +79,8 @@ fn get_revision() -> String {
     VERSION.to_string()
 }
 
-#[rocket::post("/config", data = "<request>")]
-fn config_to_json(request: String) -> Result<Value, response::status::BadRequest<String>> {
+#[rocket::post("/parse-yaml", data = "<request>")]
+fn parse_yaml(request: String) -> Result<Value, response::status::BadRequest<String>> {
     serde_yaml::from_str::<ConfigFile>(&request)
         .map(|config| json!(config))
         .map_err(|e| response::status::BadRequest(Some(e.to_string())))
@@ -248,5 +248,5 @@ fn rocket_main() -> _ {
         .mount("/", rocket::routes![get_options])
         .mount("/", rocket::routes![serve_static])
         .mount("/", rocket::routes![languages])
-        .mount("/", rocket::routes![config_to_json])
+        .mount("/", rocket::routes![parse_yaml])
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 
 [dependencies]
 # local
-kernel = {path = "../kernel" }
+kernel = { path = "../kernel" }
 # workspace
 anyhow = { workspace = true }
 base64 = { workspace = true }
@@ -13,11 +13,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 derive_builder = { workspace = true }
 serde-sarif = { workspace = true }
+serde_yaml = { workspace = true }
 # other
 git2 = "0.18.0"
 glob-match = "0.2.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-serde_yaml = "0.9.21"
 valico = "4.0.0"
 walkdir = "2.3.3"
 

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -171,9 +171,9 @@ fn match_prefix_filename(path: &Path, prefixes_list: &[String]) -> bool {
 
 // filter files to analyze for a language. It will filter the files based on the prefix or suffix.
 pub fn filter_files_for_language(files: &[PathBuf], language: &Language) -> Vec<PathBuf> {
-    let extensions = get_extensions_for_language(language).unwrap_or(vec![]);
-    let exact_matches = get_exact_filename_for_language(language).unwrap_or(vec![]);
-    let prefixes = get_prefix_for_language(language).unwrap_or(vec![]);
+    let extensions = get_extensions_for_language(language).unwrap_or_default();
+    let exact_matches = get_exact_filename_for_language(language).unwrap_or_default();
+    let prefixes = get_prefix_for_language(language).unwrap_or_default();
 
     if extensions.is_empty() && exact_matches.is_empty() && prefixes.is_empty() {
         return vec![];

--- a/cli/src/model/config_file.rs
+++ b/cli/src/model/config_file.rs
@@ -9,9 +9,15 @@ pub struct ConfigFile {
     pub rulesets: Vec<String>,
     #[serde(rename(serialize = "ignore-paths", deserialize = "ignore-paths"))]
     pub ignore_paths: Option<Vec<String>>,
-    #[serde(rename(serialize = "ignore-gitignore", deserialize = "ignore-gitignore"))]
+    #[serde(
+        rename(serialize = "ignore-gitignore", deserialize = "ignore-gitignore",),
+        skip_serializing_if = "Option::is_none"
+    )]
     pub ignore_gitignore: Option<bool>,
-    #[serde(rename(serialize = "max-file-size-kb", deserialize = "max-file-size-kb"))]
+    #[serde(
+        rename(serialize = "max-file-size-kb", deserialize = "max-file-size-kb"),
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_file_size_kb: Option<u64>,
 }
 

--- a/cli/src/model/datadog_api.rs
+++ b/cli/src/model/datadog_api.rs
@@ -66,7 +66,7 @@ impl ApiResponseRuleset {
                     severity: rule_from_api.severity,
                     pattern: rule_from_api.pattern,
                     tree_sitter_query_base64: rule_from_api.tree_sitter_query,
-                    variables: rule_from_api.variables.unwrap_or(HashMap::new()),
+                    variables: rule_from_api.variables.unwrap_or_default(),
                     tests: rule_from_api
                         .tests
                         .into_iter()

--- a/kernel/src/analysis/javascript.rs
+++ b/kernel/src/analysis/javascript.rs
@@ -190,7 +190,7 @@ pub fn execute_rule_internal(
     filename: String,
     analysis_options: &AnalysisOptions,
 ) -> RuleResult {
-    let nodes_json: String = serde_json::to_string(match_nodes).unwrap();
+    let nodes_json: String = serde_json::to_string(match_nodes).expect("Error serializing nodes");
 
     // format the JavaScript code that will be executed
     let js_code = format!(

--- a/kernel/src/analysis/tree_sitter.rs
+++ b/kernel/src/analysis/tree_sitter.rs
@@ -78,7 +78,7 @@ pub fn get_query_nodes(
     for query_match in query_result {
         let mut captures: HashMap<String, TreeSitterNode> = HashMap::new();
         let mut captures_list: HashMap<String, Vec<TreeSitterNode>> = HashMap::new();
-        for capture in query_match.captures.iter() {
+        for capture in query_match.captures {
             let capture_name_opt = query
                 .capture_names()
                 .get(usize::try_from(capture.index).unwrap());

--- a/server-requests.http
+++ b/server-requests.http
@@ -13,8 +13,8 @@ GET {{host}}/revision HTTP/1.1
 ### languages 
 GET {{host}}/languages HTTP/1.1
 
-### config to json
-POST {{host}}/config HTTP/1.1
+### yaml to json
+POST {{host}}/parse-yaml HTTP/1.1
 
 rulesets:
   - 'python-best-practices'

--- a/server-requests.http
+++ b/server-requests.http
@@ -1,0 +1,65 @@
+# @host = https://devbcn.shuttleapp.rs
+@host = http://localhost:8000
+
+### ping
+GET {{host}}/ping HTTP/1.1
+
+### version
+GET {{host}}/version HTTP/1.1
+
+### revision
+GET {{host}}/revision HTTP/1.1
+
+### languages 
+GET {{host}}/languages HTTP/1.1
+
+### config to json
+POST {{host}}/config HTTP/1.1
+
+rulesets:
+  - 'python-best-practices'
+  - 'python-security'
+  - 'python-code-style'
+  - 'python-inclusive'
+ignore-paths:
+  - 'path/to/ignore'
+  - '**.js'
+
+### Analyze
+POST {{host}}/analyze
+Content-Type: application/json
+
+{
+  "code": "MTIzID09IE5hTjsKMTIzID09PSBOYU47Ck5hTiA9PT0gImFiYyI7Ck5hTiA9PSJhYmMiOwoxMjMgIT0gTmFOOwoxMjMgIT09IE5hTjsKTmFOICE9PSAiYWJjIjsKTmFOICE9ICJhYmMiOwpOYU4gPCAiYWJjIjsKImFiYyIgPCBOYU47Ck5hTiA+ICJhYmMiOwoiYWJjIiA+IE5hTjsKTmFOIDw9ICJhYmMiOwoiYWJjIiA8PSBOYU47Ck5hTiA+PSAiYWJjIjsKImFiYyIgPj0gTmFOOwoxMjMgPT0gTnVtYmVyLk5hTjsKMTIzID09PSBOdW1iZXIuTmFOOwpOdW1iZXIuTmFOID09PSAiYWJjIjsKTnVtYmVyLk5hTiA9PSAiYWJjIjsKMTIzICE9IE51bWJlci5OYU47CjEyMyAhPT0gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiAhPT0gImFiYyI7Ck51bWJlci5OYU4gIT0gImFiYyI7Ck51bWJlci5OYU4gPCAiYWJjIjsKImFiYyIgPCBOdW1iZXIuTmFOOwpOdW1iZXIuTmFOID4gImFiYyI7CiJhYmMiID4gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiA8PSAiYWJjIjsKImFiYyIgPD0gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiA+PSAiYWJjIjsKImFiYyIgPj0gTnVtYmVyLk5hTjsKeCA9PT0gTnVtYmVyPy5OYU47CnggPT09IE51bWJlclsnTmFOJ107",
+  "filename": "invalid.js",
+  "file_encoding": "utf-8",
+  "language": "JAVASCRIPT",
+  "rules": [
+    {
+      "id": "rob/use-isnan",
+      "code": "LyoqCiAqIEEgdmlzaXQgZnVuY3Rpb24KICogQHBhcmFtIHtRdWVyeX0gbm9kZSAtIEEgbm9kZSBwYXJhbS4KICogQHBhcmFtIHtzdHJpbmd9IGZpbGVuYW1lIC0gQSBmaWxlbmFtZSBwYXJhbS4KICogQHBhcmFtIHtzdHJpbmd9IGNvZGUgLSBBIGNvZGUgcGFyYW0uCiAqIEByZXR1cm5zCiAqLwpmdW5jdGlvbiB2aXNpdChub2RlLCBmaWxlbmFtZSwgY29kZSkgewogIGNvbnN0IGV4cHJlc3Npb24gPSBub2RlLmNhcHR1cmVzWyJleHByZXNzaW9uIl07CiAgY29uc3QgaWRlbnRpZmllciA9IG5vZGUuY2FwdHVyZXNbImlkZW50aWZpZXIiXTsKCiAgLy8gVE9ETzogcmVtb3ZlIGNoZWNrIG9uY2Ugd2UgaGF2ZSBwcmVkaWNhdGVzCiAgaWYgKGV4cHJlc3Npb24gJiYgZ2V0Q29kZUZvck5vZGUoaWRlbnRpZmllciwgY29kZSkgPT09ICJOYU4iKSB7CiAgICBhZGRFcnJvcigKICAgICAgYnVpbGRFcnJvcigKICAgICAgICBleHByZXNzaW9uLnN0YXJ0LmxpbmUsCiAgICAgICAgZXhwcmVzc2lvbi5zdGFydC5jb2wsCiAgICAgICAgZXhwcmVzc2lvbi5lbmQubGluZSwKICAgICAgICBleHByZXNzaW9uLmVuZC5jb2wsCiAgICAgICAgIlVzZSB0aGUgaXNOYU4gZnVuY3Rpb24gdG8gY29tcGFyZSB3aXRoIE5hTi4iLAogICAgICApCiAgICApOwogIH0KfQo=",
+      "language": "JAVASCRIPT",
+      "severity": "ERROR",
+      "category": "BEST_PRACTICES",
+      "type": "TREE_SITTER_QUERY",
+      "entity_checked": null,
+      "regex": null,
+      "tree_sitter_query": "WwogICAgKGJpbmFyeV9leHByZXNzaW9uCiAgICAgICAgbGVmdDogWwogICAgICAgICAgICAoaWRlbnRpZmllcikgQGlkZW50aWZpZXIKICAgICAgICAgICAgKG1lbWJlcl9leHByZXNzaW9uCiAgICAgICAgICAgICAgICBwcm9wZXJ0eTogKHByb3BlcnR5X2lkZW50aWZpZXIpIEBpZGVudGlmaWVyCiAgICAgICAgICAgICkKICAgICAgICAgICAgKHN1YnNjcmlwdF9leHByZXNzaW9uCiAgICAgICAgICAgICAgICBpbmRleDogKHN0cmluZyAoc3RyaW5nX2ZyYWdtZW50KUBpZGVudGlmaWVyKQogICAgICAgICAgICApCiAgICAgICAgXSAoI2VxPyBAaWRlbnRpZmllciBOYU4pCiAgICAgICAgb3BlcmF0b3I6IFsiPiIgIj49IiAiPCIgIjw9IiAiPT0iICI9PT0iICIhPSIgIiE9PSJdCiAgICApIEBleHByZXNzaW9uCiAgICAoYmluYXJ5X2V4cHJlc3Npb24KICAgICAgICBvcGVyYXRvcjogWyI+IiAiPj0iICI8IiAiPD0iICI9PSIgIj09PSIgIiE9IiAiIT09Il0KICAgICAgICByaWdodDogWwogICAgICAgICAgICAoaWRlbnRpZmllcikgQGlkZW50aWZpZXIKICAgICAgICAgICAgKG1lbWJlcl9leHByZXNzaW9uCiAgICAgICAgICAgICAgICBwcm9wZXJ0eTogKHByb3BlcnR5X2lkZW50aWZpZXIpIEBpZGVudGlmaWVyCiAgICAgICAgICAgICkKICAgICAgICAgICAgKHN1YnNjcmlwdF9leHByZXNzaW9uCiAgICAgICAgICAgICAgICBpbmRleDogKHN0cmluZyAoc3RyaW5nX2ZyYWdtZW50KUBpZGVudGlmaWVyKQogICAgICAgICAgICApCiAgICAgICAgXSAoI2VxPyBAaWRlbnRpZmllciBOYU4pCiAgICApIEBleHByZXNzaW9uCl0g",
+      "checksum": "6a01273abe500632af11ea76d43af39a3a321bebab8527dbefb2d6f1961bb525"
+    }
+  ],
+  "options": {
+    "use_tree_sitter": true,
+    "log_output": true
+  }
+}
+
+### Tree-sitter
+POST {{host}}/get-treesitter-ast
+Content-Type: application/json
+
+{
+    "file_encoding": "utf-8",
+    "language": "JAVASCRIPT",
+    "code": "MTIzID09IE5hTjsKMTIzID09PSBOYU47Ck5hTiA9PT0gImFiYyI7Ck5hTiA9PSJhYmMiOwoxMjMgIT0gTmFOOwoxMjMgIT09IE5hTjsKTmFOICE9PSAiYWJjIjsKTmFOICE9ICJhYmMiOwpOYU4gPCAiYWJjIjsKImFiYyIgPCBOYU47Ck5hTiA+ICJhYmMiOwoiYWJjIiA+IE5hTjsKTmFOIDw9ICJhYmMiOwoiYWJjIiA8PSBOYU47Ck5hTiA+PSAiYWJjIjsKImFiYyIgPj0gTmFOOwoxMjMgPT0gTnVtYmVyLk5hTjsKMTIzID09PSBOdW1iZXIuTmFOOwpOdW1iZXIuTmFOID09PSAiYWJjIjsKTnVtYmVyLk5hTiA9PSAiYWJjIjsKMTIzICE9IE51bWJlci5OYU47CjEyMyAhPT0gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiAhPT0gImFiYyI7Ck51bWJlci5OYU4gIT0gImFiYyI7Ck51bWJlci5OYU4gPCAiYWJjIjsKImFiYyIgPCBOdW1iZXIuTmFOOwpOdW1iZXIuTmFOID4gImFiYyI7CiJhYmMiID4gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiA8PSAiYWJjIjsKImFiYyIgPD0gTnVtYmVyLk5hTjsKTnVtYmVyLk5hTiA+PSAiYWJjIjsKImFiYyIgPj0gTnVtYmVyLk5hTjsKeCA9PT0gTnVtYmVyPy5OYU47CnggPT09IE51bWJlclsnTmFOJ107"
+}

--- a/server/src/request.rs
+++ b/server/src/request.rs
@@ -9,7 +9,6 @@ use kernel::analysis::analyze::analyze;
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
 use kernel::utils::decode_base64_string;
-use std::collections::HashMap;
 
 pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
     let rules_with_invalid_language: Vec<ServerRule> = request
@@ -41,7 +40,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             checksum: r.checksum.clone().unwrap_or("".to_string()),
             pattern: r.pattern.clone(),
             tree_sitter_query_base64: r.tree_sitter_query_base64.clone(),
-            variables: r.variables.clone().unwrap_or(HashMap::new()),
+            variables: r.variables.clone().unwrap_or_default(),
             tests: vec![],
         })
         .collect();


### PR DESCRIPTION
## What problem are you trying to solve?

This PR is adding a new endpoint to the server that will parse a YAML file and return it as JSON. This will avoid having to use 3rd party libraries in the extensions, particularly in VS Code, which has JSON support out of the box.

Aside from that, the PR adds two more tools which may be useful for the developers:

- [Cargo Make](https://sagiegurari.github.io/cargo-make/): Cross OS task runner. Helpful to execute some recurring tasks, like starting the server in watch mode so it restarts when a file is changed, different clippy combinations...
- HTTP file: can be used along with some extensions ([REST Client]() in VS Code, for example) to easily test the server endpoints.

## What is your solution?

Example of REST Client:
<img width="1478" alt="image" src="https://github.com/DataDog/datadog-static-analyzer/assets/696981/8d80cae4-1dbc-4c9d-b306-5b0d70f1c62e">

I added some notes to the `Tools` section in the readme.