### PR TITLE
Exit the server gracefully

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bins", "cli", "kernel", "server"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.1.5": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.5/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
         "0.1.4": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
## What problem are you trying to solve?

Some server processes are still alive in the IDE despite the keepalive timeout has been hit.

## What is your solution?

Instead of calling `exit()`, we are correctly shutting down the rocket server when we hit a keepalive timeout so that the socket and all other important resources are cleaned up.

If all fails, we call `abort()` to abort the process.
