### PR TITLE
fix(shutdown): correctly handle rocket errors

### DIFF
--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -18,13 +18,18 @@ name = "datadog-static-analyzer-server"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default
-features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"]
+features = [
+  "precommit-hook",
+  "run-cargo-test",
+  "run-cargo-clippy",
+  "run-cargo-fmt",
+]
 
 [dependencies]
 # local
-cli = {path = "../cli"}
-kernel = {path = "../kernel" }
-server = {path = "../server"}
+cli = { path = "../cli" }
+kernel = { path = "../kernel" }
+server = { path = "../server" }
 # workspace
 anyhow = { workspace = true }
 itertools = { workspace = true }
@@ -35,7 +40,7 @@ num_cpus = "1.15.0"
 indicatif = "0.17.6"
 lazy_static = "1.4.0"
 rayon = "1.7.0"
-rocket = {version = "=0.5.0-rc.3", features = ["json"]}
+rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 
 
 # For linux and macos, we need the vendored ssl

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -5,7 +5,7 @@ use rocket::fairing::{Fairing, Info, Kind};
 use rocket::fs::NamedFile;
 use rocket::http::Header;
 use rocket::serde::json::{json, Json, Value};
-use rocket::{Build, Request as RocketRequest, Response, Rocket, Shutdown, State};
+use rocket::{Build, Ignite, Request as RocketRequest, Response, Rocket, Shutdown, State};
 use server::model::analysis_request::AnalysisRequest;
 use server::model::tree_sitter_tree_request::TreeSitterRequest;
 use server::request::process_analysis_request;
@@ -134,11 +134,15 @@ fn print_usage(program: &str, opts: Options) {
     print!("{}", opts.usage(&brief));
 }
 
-async fn spawn_rocket(rocket_build: Rocket<Build>) -> Shutdown {
+async fn spawn_rocket(
+    rocket_build: Rocket<Build>,
+) -> (
+    rocket::tokio::task::JoinHandle<Result<Rocket<Ignite>, rocket::error::Error>>,
+    Shutdown,
+) {
     let rocket = rocket_build.ignite().await.unwrap();
     let shutdown_handle = rocket.shutdown();
-    rocket::tokio::spawn(rocket.launch());
-    shutdown_handle
+    (rocket::tokio::spawn(rocket.launch()), shutdown_handle)
 }
 
 #[rocket::main]
@@ -209,6 +213,7 @@ async fn main() {
 
     // channel used to send the shutdown handler so that we can exit the server gracefully
     let (tx, rx) = channel();
+    let mut is_keepalive_enabled = false;
 
     // if we set up the keepalive mechanism (option -k)
     //   1. Get the timeout value as parameter
@@ -218,6 +223,7 @@ async fn main() {
         if let Some(keepalive_timeout) = keepalive_timeout_sec {
             let timeout_sec = keepalive_timeout.parse::<u128>().unwrap();
             let timeout_ms = timeout_sec * 1000;
+            is_keepalive_enabled = true;
 
             // thread that periodically checks if we should exit the server
             thread::spawn(move || {
@@ -257,9 +263,14 @@ async fn main() {
         .mount("/", rocket::routes![serve_static])
         .mount("/", rocket::routes![languages]);
 
-    let shutdown_handle = spawn_rocket(rocket_build).await;
-    let _ = tx.send(shutdown_handle.clone());
+    let (rocket_handle, shutdown_handle) = spawn_rocket(rocket_build).await;
 
-    // Will shutdown if the keepalive option has been passed
-    shutdown_handle.await;
+    if is_keepalive_enabled {
+        let _ = tx.send(shutdown_handle.clone());
+        // Will shutdown if the keep alive option has been passed
+        shutdown_handle.await;
+    } else {
+        // shutdown_server(shutdown_handle, false);
+        let _ = rocket_handle.await;
+    }
 }

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -172,9 +172,9 @@ fn match_prefix_filename(path: &Path, prefixes_list: &[String]) -> bool {
 
 // filter files to analyze for a language. It will filter the files based on the prefix or suffix.
 pub fn filter_files_for_language(files: &[PathBuf], language: &Language) -> Vec<PathBuf> {
-    let extensions = get_extensions_for_language(language).unwrap_or(vec![]);
-    let exact_matches = get_exact_filename_for_language(language).unwrap_or(vec![]);
-    let prefixes = get_prefix_for_language(language).unwrap_or(vec![]);
+    let extensions = get_extensions_for_language(language).unwrap_or_default();
+    let exact_matches = get_exact_filename_for_language(language).unwrap_or_default();
+    let prefixes = get_prefix_for_language(language).unwrap_or_default();
 
     if extensions.is_empty() && exact_matches.is_empty() && prefixes.is_empty() {
         return vec![];

--- a/cli/src/model/datadog_api.rs
+++ b/cli/src/model/datadog_api.rs
@@ -66,7 +66,7 @@ impl ApiResponseRuleset {
                     severity: rule_from_api.severity,
                     pattern: rule_from_api.pattern,
                     tree_sitter_query_base64: rule_from_api.tree_sitter_query,
-                    variables: rule_from_api.variables.unwrap_or(HashMap::new()),
+                    variables: rule_from_api.variables.unwrap_or_default(),
                     tests: rule_from_api
                         .tests
                         .into_iter()

--- a/server/src/request.rs
+++ b/server/src/request.rs
@@ -9,7 +9,6 @@ use kernel::analysis::analyze::analyze;
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
 use kernel::utils::decode_base64_string;
-use std::collections::HashMap;
 
 pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
     let rules_with_invalid_language: Vec<ServerRule> = request
@@ -41,7 +40,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             checksum: r.checksum.clone().unwrap_or("".to_string()),
             pattern: r.pattern.clone(),
             tree_sitter_query_base64: r.tree_sitter_query_base64.clone(),
-            variables: r.variables.clone().unwrap_or(HashMap::new()),
+            variables: r.variables.clone().unwrap_or_default(),
             tests: vec![],
         })
         .collect();


### PR DESCRIPTION
## What problem are you trying to solve?
Fixes #120 

## What is your solution?
If we're not using the `keep alive` functionality, we will just wait for the Rocket thread to finish.

If not, we will await for the first occurrence. Either the Rocket thread finishes (for instance, due to a panic...) or the keep alive functionality notifies the shutdown and causes the `shutdown handle` to finish.

## Other considerations
I took the time to fix some clippy issues. It was impossible to even commit without doing `--no-verify`. I'm afraid potential contributors may be facing the same issue.  Is that expected or are you not getting that at all when trying to commit to the repo?

IDE-1744