### PR TITLE
feat(shutdown): add new shutdown endpoint under a flag

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::fs::NamedFile;
 use rocket::futures::FutureExt;
-use rocket::http::Header;
+use rocket::http::{Header, Status};
 use rocket::serde::json::{json, Json, Value};
 use rocket::{Build, Ignite, Request as RocketRequest, Response, Rocket, Shutdown, State};
 use server::model::analysis_request::AnalysisRequest;
@@ -18,8 +18,6 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{env, process, thread};
 
-pub struct CORS;
-
 /// get the current timestamp
 fn get_current_timestamp_ms() -> u128 {
     SystemTime::now()
@@ -27,6 +25,8 @@ fn get_current_timestamp_ms() -> u128 {
         .unwrap()
         .as_millis()
 }
+
+pub struct CORS;
 
 // Adding CORS for the server.
 // See https://stackoverflow.com/questions/62412361/how-to-set-up-cors-or-options-for-rocket-rs
@@ -48,6 +48,25 @@ impl Fairing for CORS {
         ));
         response.set_header(Header::new("Access-Control-Allow-Headers", "*"));
         response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
+    }
+}
+
+#[rocket::get("/shutdown")]
+fn shutdown_get(server_configuration: &State<ServerConfiguration>) -> Status {
+    if server_configuration.is_shutdown_enabled {
+        Status::NoContent
+    } else {
+        Status::Forbidden
+    }
+}
+
+#[rocket::post("/shutdown")]
+fn shutdown_post(server_configuration: &State<ServerConfiguration>, shutdown: Shutdown) -> Status {
+    if server_configuration.is_shutdown_enabled {
+        shutdown.notify();
+        Status::Ok
+    } else {
+        Status::Forbidden
     }
 }
 
@@ -107,6 +126,7 @@ fn get_options() -> String {
 
 struct ServerConfiguration {
     static_directory: Option<String>,
+    is_shutdown_enabled: bool,
 }
 
 struct ServerState {
@@ -166,6 +186,7 @@ async fn main() {
         "how many seconds without a request the server will exit",
         "90",
     );
+    opts.optflag("e", "enable-shutdown", "enables the shutdown endpoint");
     opts.optflag("h", "help", "print this help");
     opts.optflag("v", "version", "shows the tool version");
 
@@ -188,6 +209,7 @@ async fn main() {
 
     let server_configuration = ServerConfiguration {
         static_directory: matches.opt_str("s"),
+        is_shutdown_enabled: matches.opt_present("e"),
     };
 
     let mut rocket_configuration = rocket::config::Config::default();
@@ -262,14 +284,16 @@ async fn main() {
         .mount("/", rocket::routes![ping])
         .mount("/", rocket::routes![get_options])
         .mount("/", rocket::routes![serve_static])
-        .mount("/", rocket::routes![languages]);
+        .mount("/", rocket::routes![languages])
+        .mount("/", rocket::routes![shutdown_get])
+        .mount("/", rocket::routes![shutdown_post]);
 
     let (rocket_handle, shutdown_handle) = spawn_rocket(rocket_build).await;
 
     if is_keepalive_enabled {
         let _ = tx.send(shutdown_handle.clone());
         // Will shutdown if the keep alive option has been passed
-        // of if the rocket thread stops.
+        // or if the rocket thread stops.
         rocket::futures::select! {
             a = shutdown_handle.fuse() => a,
             _ = rocket_handle.fuse() => ()

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -64,7 +64,7 @@ fn shutdown_get(server_configuration: &State<ServerConfiguration>) -> Status {
 fn shutdown_post(server_configuration: &State<ServerConfiguration>, shutdown: Shutdown) -> Status {
     if server_configuration.is_shutdown_enabled {
         shutdown.notify();
-        Status::Ok
+        Status::NoContent
     } else {
         Status::Forbidden
     }

--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -51,6 +51,55 @@ impl Fairing for CORS {
     }
 }
 
+/// The shutdown endpoint, when a GET request is received, will return a 204 code if the shutdown mechanism is enabled.
+/// It will return a 403 code otherwise.
+///
+/// The shutdown mechanism is optional, and the user starting the server decides
+/// whether to enable it or not by using the `-e` or `--enable-shutdown` flag.
+///
+/// # Examples
+///
+/// To enable this feature we should start the server with the `-e` flag.
+///
+/// ```sh
+/// ./datadog-static-analyzer-server -p 9090 -k 30 -e
+/// ```
+///
+/// Then if we do
+/// ```sh
+/// curl -i localhost:9090/shutdown
+/// ````
+///
+/// We should receive something like this:
+/// ```txt
+/// HTTP/1.1 204 No Content
+/// server: Rocket
+/// x-content-type-options: nosniff
+/// x-frame-options: SAMEORIGIN
+/// permissions-policy: interest-cohort=()
+/// access-control-allow-origin: *
+/// access-control-allow-methods: POST, GET, PATCH, OPTIONS
+/// access-control-allow-headers: *
+/// access-control-allow-credentials: true
+/// content-length: 0
+/// date: Tue, 31 Oct 2023 08:50:17 GMT
+/// ```
+///
+/// If the server was not started with the `-e` flag, then we should receive something like this:
+/// ```txt
+/// HTTP/1.1 403 Forbidden
+/// content-type: text/html; charset=utf-8
+/// server: Rocket
+/// permissions-policy: interest-cohort=()
+/// x-content-type-options: nosniff
+/// x-frame-options: SAMEORIGIN
+/// access-control-allow-origin: *
+/// access-control-allow-methods: POST, GET, PATCH, OPTIONS
+/// access-control-allow-headers: *
+/// access-control-allow-credentials: true
+/// content-length: 385
+/// date: Tue, 31 Oct 2023 08:52:06 GMT
+// ```
 #[rocket::get("/shutdown")]
 fn shutdown_get(server_configuration: &State<ServerConfiguration>) -> Status {
     if server_configuration.is_shutdown_enabled {
@@ -60,6 +109,13 @@ fn shutdown_get(server_configuration: &State<ServerConfiguration>) -> Status {
     }
 }
 
+/// The shutdown endpoint, when receiving a POST request, will SHUTDOWN the server and return a 204 code if the shutdown mechanism is enabled.
+/// It will return a 403 code otherwise.
+///
+/// The shutdown mechanism is optional, and the user starting the server decides
+/// whether to enable it or not by using the `-e` or `--enable-shutdown` flag.
+///
+/// Please, refer to the [`shutdown_get`] function's examples section to see how this would work.
 #[rocket::post("/shutdown")]
 fn shutdown_post(server_configuration: &State<ServerConfiguration>, shutdown: Shutdown) -> Status {
     if server_configuration.is_shutdown_enabled {

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -97,10 +97,10 @@ pub fn get_files(
     let directory_to_walk: String = match subdirectory {
         Some(sd) => {
             let sd_str = sd.as_str();
-            let p = Path::new(directory.clone()).join(sd_str.clone());
+            let p = Path::new(directory).join(sd_str);
             p.as_os_str().to_str().unwrap().to_string()
         }
-        None => directory.clone().to_string(),
+        None => directory.to_string(),
     };
 
     for entry in WalkDir::new(directory_to_walk.as_str()) {


### PR DESCRIPTION
## What problem are you trying to solve?

In the IDE we have to deal with some scenarios where the server must be restarted. This basically means that we have to kill the server and restart it again. The most prominent use case for this scenario is when we receive a new binary update.

The main problem here is that we may need to restart the server from an IDE instance that didn't spawn the process, so we need to use several strategies to share the process id amongst instances which are error prone or not reliable. Specifically, in VS Code, we have some constraints around that. 

Aside from that, we have to use different approaches for each of the OS we support in some of the cases, so with this proposed solution we think we would greatly simplify our problem.

- It would allow for all the IDEs to use it, without having to replicate the logic of killing the process from random instances.
- It would reduce the dependencies on 3rd party libraries to help us mitigate the multiple OS support.
- We would be able to reliably shutdown the server the moment we want.

## What is your solution?

We have added a new flag `-e` that when present will enable a new `shutdown` endpoint. By doing this, the user will decide whether they need this behaviour or not.

The endpoint will accept both the verbs `GET` and `POST` and will return a 403 (Forbidden) if the flag `-e` is not present. Other wise:

- GET: will get a 204 if the server can be shutdown. This is handy in some cases where we want to understand if the server is killable or not (i.e. showing a command to stop it or not...)
- POST: will return a 200 and shutdown the server.

## Other comments

I fixed some clippy warnings that were avoiding me to commit properly because of the pre-commit hook.

IDE-1896