### PR TITLE
feat(headers): add custom headers with server information

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -7,6 +7,9 @@ use rocket::futures::FutureExt;
 use rocket::http::{Header, Status};
 use rocket::serde::json::{json, Json, Value};
 use rocket::{Build, Ignite, Request as RocketRequest, Response, Rocket, Shutdown, State};
+use server::constants::{
+    SERVER_HEADER_SERVER_REVISION, SERVER_HEADER_SERVER_VERSION, SERVER_HEADER_SHUTDOWN_ENABLED,
+};
 use server::model::analysis_request::AnalysisRequest;
 use server::model::tree_sitter_tree_request::TreeSitterRequest;
 use server::request::process_analysis_request;
@@ -67,19 +70,13 @@ impl Fairing for CustomHeaders {
 
         if let rocket::outcome::Outcome::Success(server_configuration) = state {
             response.set_header(Header::new(
-                "X-static-analyzer-server-shutdown-enabled",
+                SERVER_HEADER_SHUTDOWN_ENABLED,
                 server_configuration.is_shutdown_enabled.to_string(),
             ));
         }
 
-        response.set_header(Header::new(
-            "X-static-analyzer-server-version",
-            get_version(),
-        ));
-        response.set_header(Header::new(
-            "X-static-analyzer-server-revision",
-            get_revision(),
-        ));
+        response.set_header(Header::new(SERVER_HEADER_SERVER_VERSION, get_version()));
+        response.set_header(Header::new(SERVER_HEADER_SERVER_REVISION, get_revision()));
     }
 }
 

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -7,3 +7,7 @@ pub const ERROR_CODE_LANGUAGE_MISMATCH: &str = "language-mismatch";
 // no root node when trying to get the AST
 pub const ERROR_CODE_NO_ROOT_NODE: &str = "no-root-node";
 pub const ERROR_CHECKSUM_MISMATCH: &str = "checksum-mismatch";
+
+pub const SERVER_HEADER_SHUTDOWN_ENABLED: &str = "X-static-analyzer-server-shutdown-enabled";
+pub const SERVER_HEADER_SERVER_VERSION: &str = "X-static-analyzer-server-version";
+pub const SERVER_HEADER_SERVER_REVISION: &str = "X-static-analyzer-server-revision";


### PR DESCRIPTION
## What problem are you trying to solve?

While integrating the static analyzer with VS Code we found it would be useful to get some extra information about the server in each request so we can optimize the amount of request we do to the server itself.

For instance, if a particular instance of VS Code is pinging to a server that has been updated by another instance, we may have the case where some instances are not aware that they're pinging now to a different version of the server.

Now, we have abused some of the VS Code APIs to broadcast this to the rest of the instances, so they can react accordingly and clear their cached information (supported languages...).

Although this works, we cannot guarantee that these messages are properly broadcasted in a timely manner. In the end, we're using an API that was not conceived for that. 

So the idea for us would be to get rid of this mechanism and pivot to another strategy where we would check if we're querying the right version of the server and react accordingly per instance if we're not.

Unfortunately, this it's also not optimal as we would have to do 2 requests always. One to check the version, another one being the actual request.

## What is your solution?

Just by adding some custom headers to all the responses we could get that kind of information for free. So the solution is create a middleware that would add some custom headers:

- `X-static-analyzer-server-version`:  version of the server
- `X-static-analyzer-server-revision`: revision of the server
- `X-static-analyzer-server-shutdown-enabled`: "true" or "false", will be also useful for us. 

## Comments

This PR is based on #124 

<img width="872" alt="image" src="https://github.com/DataDog/datadog-static-analyzer/assets/696981/ea0002b9-1fe4-4773-adbb-7d6667d7a5f7">


IDE-1900