### PR TITLE
feat(server): added new keepalive custom header

### DIFF
--- a/bins/Cargo.toml
+++ b/bins/Cargo.toml
@@ -38,7 +38,6 @@ serde_json = { workspace = true }
 getopts = "0.2.21"
 num_cpus = "1.15.0"
 indicatif = "0.17.6"
-lazy_static = "1.4.0"
 rayon = "1.7.0"
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 

--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -9,5 +9,6 @@ pub const ERROR_CODE_NO_ROOT_NODE: &str = "no-root-node";
 pub const ERROR_CHECKSUM_MISMATCH: &str = "checksum-mismatch";
 
 pub const SERVER_HEADER_SHUTDOWN_ENABLED: &str = "X-static-analyzer-server-shutdown-enabled";
+pub const SERVER_HEADER_KEEPALIVE_ENABLED: &str = "X-static-analyzer-server-keepalive-enabled";
 pub const SERVER_HEADER_SERVER_VERSION: &str = "X-static-analyzer-server-version";
 pub const SERVER_HEADER_SERVER_REVISION: &str = "X-static-analyzer-server-revision";


### PR DESCRIPTION
## What problem are you trying to solve?

Similar to what we introduced in #125 it would be valuable to us to have information about the keepalive functionality in preparation for when we're dealing with web scenarios or servers that are not controlled by us.

## What is your solution?

Added a new custom header `X-static-analyzer-server-keepalive-enabled` with that information.

## Other refactors / comments

The PR also unifies the server state and gets rid of the `lazy-static` dependency, as we don't need it for our purposes given that we can rely on Rocket state.

DE-1900