### PR TITLE
feat(server): extend the keepalive behavior to all requests 

### DIFF
--- a/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/bins/src/bin/datadog-static-analyzer-server.rs
@@ -99,7 +99,7 @@ impl Fairing for KeepAlive {
         let state = request.guard::<&State<ServerState>>().await;
 
         if let rocket::outcome::Outcome::Success(state) = state {
-            // the fairing shouldn't be added is keep alive is not enabled but just playing defensive here
+            // the fairing shouldn't be added if keep alive is not enabled but just playing defensive here
             if state.is_keepalive_enabled {
                 // mutate the keep alive ms
                 if let Ok(mut x) = state.last_ping_request_timestamp_ms.try_write() {


### PR DESCRIPTION
## What problem are you trying to solve?

Now only the ping requests are extending the life of the server if keep alive is on. No other requests matter.

## What is your solution?

Added a new fairing/middleware so that if the keep alive functionality is on, all the requests will slide the keep alive counter.

## Notes

Built on top of #126 

IDE-1896
