### PR TITLE
feat(server): add new version guard validation

### DIFF
--- a/server/src/constants.rs
+++ b/server/src/constants.rs
@@ -8,7 +8,8 @@ pub const ERROR_CODE_LANGUAGE_MISMATCH: &str = "language-mismatch";
 pub const ERROR_CODE_NO_ROOT_NODE: &str = "no-root-node";
 pub const ERROR_CHECKSUM_MISMATCH: &str = "checksum-mismatch";
 
-pub const SERVER_HEADER_SHUTDOWN_ENABLED: &str = "X-static-analyzer-server-shutdown-enabled";
-pub const SERVER_HEADER_KEEPALIVE_ENABLED: &str = "X-static-analyzer-server-keepalive-enabled";
-pub const SERVER_HEADER_SERVER_VERSION: &str = "X-static-analyzer-server-version";
-pub const SERVER_HEADER_SERVER_REVISION: &str = "X-static-analyzer-server-revision";
+pub const SERVER_HEADER_SHUTDOWN_ENABLED: &str = "X-Static-Analyzer-Server-Shutdown-Enabled";
+pub const SERVER_HEADER_KEEPALIVE_ENABLED: &str = "X-Static-Analyzer-Server-Keepalive-Enabled";
+pub const SERVER_HEADER_SERVER_VERSION: &str = "X-Static-Analyzer-Server-Version";
+pub const SERVER_HEADER_SERVER_REVISION: &str = "X-Static-Analyzer-Server-Revision";
+pub const SERVER_HEADER_SERVER_EXPECTED_VERSION: &str = "X-Static-Analyzer-Server-Expected-Version";


### PR DESCRIPTION
## What problem are you trying to solve?

In some binary update scenarios we may have VS Code instances which may not be notified of a server restart. This could cause some requests being sent to the new server running with the expectation of it being the old version. As this instances may have cached some information from the previous server which may not be relevant anymore, they should ping the server for the version all the time in order to control this. 

A way to mitigate this, is the solution proposed below.

See related [JIRA ticket](https://datadoghq.atlassian.net/browse/IDE-1913) for more information.

## What is your solution?

Added a new guard which will check the existence of the `X-Static-Analyzer-Server-Expected-Version`. If it's not there, the request will continue as expected. If it's there, it will check that the version matches the one from the server and will return a `BadRequest` code if they don't match.

Note that this behavior is totally opt-in. If the header is not sent, no validation will happen.

## Alternatives considered

## What the reviewer should know

IDE-1913