### PR TITLE
fix(cli): remove DD_ prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bins", "cli", "kernel", "server"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 
 [profile.release]
 lto = true

--- a/cli/src/datadog_utils.rs
+++ b/cli/src/datadog_utils.rs
@@ -39,7 +39,7 @@ fn get_datadog_site(use_staging: bool) -> String {
     if use_staging {
         STAGING_DATADOG_SITE.to_string()
     } else {
-        get_datadog_variable_value("DD_SITE").unwrap_or(DEFAULT_DATADOG_SITE.to_string())
+        get_datadog_variable_value("SITE").unwrap_or(DEFAULT_DATADOG_SITE.to_string())
     }
 }
 

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.1.7": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.7/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
         "0.1.6": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
## What problem are you trying to solve?

When we run an analysis with a `DD_SITE` env var set, we're mistakenly using the default site.

This is because `get_datadog_variable_value` adds `DD_` and `DATADOG_` prefixes to the string it accepts, so currently we end up looking for a variable named either `DD_DD_SITE` or `DATADOG_DD_SITE`.

## What is your solution?

Remove `DD_` from `DD_SITE`, so the `get_datadog_site` behaves properly.

## Alternatives considered

Leave it be.

## What the reviewer should know

None.