### PR TITLE
chore(server): add launch debug configuration for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'datadog-static-analyzer-server'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=datadog-static-analyzer-server",
+          "--package=datadog-static-analyzer"
+        ],
+        "filter": {
+          "name": "datadog-static-analyzer-server",
+          "kind": "bin"
+        }
+      },
+      "args": ["-p", "9090", "-e"],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
## What problem are you trying to solve?

While working in the static analysis integration for VS Code I find useful to debug the server to get insights on some of the errors.

## What is your solution?

I added a launch configuration for vs code to start a debug session for the server.

## What the reviewer should know

I know this works only for VS Code and maybe the owners of the repo don't want to commit IDE related files, but since VS Code is widely used I pushed this for your consideration.