### PR TITLE
feat(server): improve error codes

### DIFF
--- a/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -48,7 +48,8 @@ pub fn prepare_rocket() -> (Rocket<Build>, ServerState, Sender<Shutdown>) {
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
-            panic!("error when parsing arguments: {}", f)
+            eprintln!("error when parsing arguments: {}", f);
+            process::exit(22); // invalid argument code
         }
     };
 


### PR DESCRIPTION
## What problem are you trying to solve?

For the IDEs to understand some of the common server failures properly we need better exit codes.

For instance, when the port is already bound, the server was panicking, which in rust means 101, so we were unable to make sense of this panic compared to others like the one the server was throwing when the parameters are unknown.


## What is your solution?

Removed some of those panics and handled the errors by exiting with a more meaningful error code.


## What the reviewer should know

If this gets merged it would be nice to do a release as VS Code will leverage those error codes to better assist the user.

IDE-2014
