### PR TITLE
fix(cli): remove edit type end positions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bins", "cli", "kernel", "server"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 
 [profile.release]
 lto = true

--- a/cli/src/sarif/sarif_utils.rs
+++ b/cli/src/sarif/sarif_utils.rs
@@ -100,8 +100,22 @@ impl IntoSarif for &Edit {
                     sarif::RegionBuilder::default()
                         .start_line(self.start.line)
                         .start_column(self.start.col)
-                        .end_line(self.start.line)
-                        .end_column(self.start.col)
+                        .end_line(
+                            self.end
+                                .clone()
+                                .unwrap_or(
+                                    PositionBuilder::default().line(0).col(0).build().unwrap(),
+                                )
+                                .line,
+                        )
+                        .end_column(
+                            self.end
+                                .clone()
+                                .unwrap_or(
+                                    PositionBuilder::default().line(0).col(0).build().unwrap(),
+                                )
+                                .col,
+                        )
                         .build()
                         .unwrap(),
                 )

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.1.8": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.8/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
         "0.1.7": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
## What problem are you trying to solve?

A result in a SARIF report using the remove edit type incorrectly reports the start position for the end positions. 

## What is your solution?

First, use the actual end positions.

Second, since the field is an option, either get the value or set a default position just like we do for an update edit type.

## Alternatives considered

None.

## What the reviewer should know

Related to: STAL-834

Here's a before and after screenshot of an analysis I ran locally showing the correct ending positions.
<img width="1089" alt="Screenshot 2023-11-22 at 10 20 33 PM" src="https://github.com/DataDog/datadog-static-analyzer/assets/33348592/316c8d36-d4b8-48f6-8541-5ed983fddf52">
