### PR TITLE
Add CWE to the SARIF report

### DIFF
--- a/cli/src/datadog_utils.rs
+++ b/cli/src/datadog_utils.rs
@@ -77,7 +77,13 @@ pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
         serde_json::from_str::<ApiResponse>(response_text.as_ref().unwrap().as_str());
 
     match api_response {
-        Ok(d) => Ok(d.clone().into_ruleset()),
+        Ok(d) => {
+            let mut ruleset = d.clone().into_ruleset();
+            // Let's make sure if the CWE is an empty string, we set it to none
+            let fixed_rules = ruleset.rules.iter_mut().map(|r| r.fix_cwe()).collect();
+            ruleset.rules = fixed_rules;
+            Ok(ruleset)
+        }
         Err(e) => {
             eprintln!("Error when parsing the ruleset {} {:?}", ruleset_name, e);
             eprintln!("{}", response_text.as_ref().unwrap().as_str());

--- a/cli/src/model/datadog_api.rs
+++ b/cli/src/model/datadog_api.rs
@@ -63,6 +63,7 @@ impl ApiResponseRuleset {
                     entity_checked: rule_from_api.entity_checked,
                     code_base64: rule_from_api.code,
                     category: rule_from_api.category,
+                    cwe: rule_from_api.cwe,
                     severity: rule_from_api.severity,
                     pattern: rule_from_api.pattern,
                     tree_sitter_query_base64: rule_from_api.tree_sitter_query,

--- a/cli/src/sarif/sarif_utils.rs
+++ b/cli/src/sarif/sarif_utils.rs
@@ -67,6 +67,14 @@ impl IntoSarif for &Rule {
             builder.short_description(text);
         }
 
+        if let Some(cwe) = self.cwe.as_ref() {
+            let props = PropertyBagBuilder::default()
+                .tags(vec![format!("CWE:{}", cwe)])
+                .build()
+                .unwrap();
+            builder.properties(props);
+        }
+
         builder.help_uri(self.get_url()).build().unwrap()
     }
 }
@@ -221,16 +229,20 @@ fn generate_results(
         .flat_map(|rule_result| {
             // if we find the rule for this violation, get the id, level and category
             let mut result_builder = ResultBuilder::default();
-            let mut category_tags = vec![];
+            let mut tags = vec![];
 
             if let Some(rule_index) = rules.iter().position(|r| r.name == rule_result.rule_name) {
-                let category =
-                    format!("DATADOG_CATEGORY:{}", rules[rule_index].category).to_uppercase();
+                let rule = &rules[rule_index];
+                let category = format!("DATADOG_CATEGORY:{}", rule.category).to_uppercase();
 
                 result_builder.rule_index(i64::try_from(rule_index).unwrap());
-                result_builder.level(get_level_from_severity(rules[rule_index].severity));
-                category_tags.push(category);
-                // Why not json_serde::to_value?
+                result_builder.level(get_level_from_severity(rule.severity));
+                tags.push(category);
+
+                // If there is a CWE, add it
+                if let Some(cwe) = &rule.cwe {
+                    tags.push(format!("CWE:{}", cwe));
+                }
             }
 
             let options = options_orig.clone();
@@ -307,7 +319,7 @@ fn generate_results(
                     )
                     .properties(
                         PropertyBagBuilder::default()
-                            .tags(category_tags.clone())
+                            .tags(tags.clone())
                             .build()
                             .unwrap(),
                     )
@@ -397,6 +409,7 @@ mod tests {
             .entity_checked(None)
             .rule_type(RuleType::TreeSitterQuery)
             .severity(RuleSeverity::Error)
+            .cwe(Some("1234".to_string()))
             .variables(HashMap::new())
             .tests(vec![])
             .build()
@@ -446,7 +459,7 @@ mod tests {
         println!("{}", sarif_report_to_string);
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/continuous_integration/static_analysis/rules/my-rule","id":"my-rule","shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
+            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/continuous_integration/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
         );
 
         // validate the schema
@@ -471,6 +484,7 @@ mod tests {
             .rule_type(RuleType::TreeSitterQuery)
             .severity(RuleSeverity::Error)
             .variables(HashMap::new())
+            .cwe(None)
             .tests(vec![])
             .build()
             .unwrap();

--- a/server/src/request.rs
+++ b/server/src/request.rs
@@ -35,6 +35,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             severity: r.severity.unwrap_or(RuleSeverity::Warning),
             language: r.language,
             rule_type: r.rule_type,
+            cwe: None,
             entity_checked: r.entity_checked,
             code_base64: r.code_base64.clone(),
             checksum: r.checksum.clone().unwrap_or("".to_string()),


### PR DESCRIPTION
## What problem are you trying to solve?

When we write the SARIF report, we also add the CWE in
- the violation object (as a property)
- the rule (as a property)


## What is your solution?

Add the `CWE` in both the violation object and the rule. The report looks like the JSON below. We also filter when the CWE is an empty string and fix it to be `null`.

```json
{
  "runs": [
    {
      "results": [
        {
          "fixes": [
            {
              "artifactChanges": [
                {
                  "artifactLocation": {
                    "uri": "myfile"
                  },
                  "replacements": [
                    {
                      "deletedRegion": {
                        "endColumn": 6,
                        "endLine": 6,
                        "startColumn": 6,
                        "startLine": 6
                      },
                      "insertedContent": {
                        "text": "newcontent"
                      }
                    }
                  ]
                }
              ],
              "description": {
                "text": "myfix"
              }
            }
          ],
          "level": "error",
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "myfile"
                },
                "region": {
                  "endColumn": 4,
                  "endLine": 3,
                  "startColumn": 2,
                  "startLine": 1
                }
              }
            }
          ],
          "message": {
            "text": "violation message"
          },
          "partialFingerprints": {},
          "properties": {
            "tags": [
              "DATADOG_CATEGORY:BEST_PRACTICES",
              "CWE:1234"
            ]
          },
          "ruleId": "my-rule",
          "ruleIndex": 0
        }
      ],
      "tool": {
        "driver": {
          "informationUri": "https://www.datadoghq.com",
          "name": "datadog-static-analyzer",
          "rules": [
            {
              "fullDescription": {
                "text": "awesome rule"
              },
              "helpUri": "https://docs.datadoghq.com/continuous_integration/static_analysis/rules/my-rule",
              "id": "my-rule",
              "properties": {
                "tags": [
                  "CWE:1234"
                ]
              },
              "shortDescription": {
                "text": "short description"
              }
            }
          ]
        }
      }
    }
  ],
  "version": "2.1.0"
}
```



