### PR TITLE
Escape filename in sarif reports

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -8,6 +8,7 @@ indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronach
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean McArthur
+percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ serde-sarif = { workspace = true }
 # other
 git2 = "0.18.0"
 glob-match = "0.2.1"
+percent-encoding = "2.3.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_yaml = "0.9.21"
 valico = "4.0.0"


### PR DESCRIPTION
## What problem are you trying to solve?

Customers reports that some SARIF generated files do not upload. The reason is because the format of the URI for the file is not compliant with the schema. 

Example of upload

```
datadog-ci sarif upload --env julien-test --service plopage /tmp/output.sarif                                                                                                                                                                                                                                                                              11:05:54
❌ Invalid SARIF report file [/tmp/output.sarif].
The report is not a valid JSON or is not compliant with the SARIF json schema v2.1.0.
Errors: /runs/0/results/0/fixes/0/artifactChanges/0/artifactLocation/uri: must match format "uri-reference"
⚠️ Cannot find valid SARIF report files to upload in /tmp/output.sarif for service datadog-ios.
Check the files exist and are valid.
```

## What is your solution?

Encode the filename using percent formatting using [this crate](https://docs.rs/percent-encoding/latest/percent_encoding/index.html).

New generated files against the same repo works now

```
datadog-ci sarif upload --env julien-test --service plopage /tmp/output.sarif                                                                                                                                                                                                                                                                              11:09:44
Starting upload with concurrency 20.
Will upload SARIF report file /tmp/output.sarif
service: datadog-ios
Uploading SARIF report in /tmp/output.sarif
✅ Uploaded 1 files in 0.435 seconds.
=================================================================================================
```


