### PR TITLE
[STAL-1168] Enabling go for the CLI

### DIFF
--- a/.github/workflows/production-rules.yaml
+++ b/.github/workflows/production-rules.yaml
@@ -31,6 +31,10 @@ jobs:
             jsx-react javascript-aws javascript-best-practices javascript-browser-security javascript-code-style javascript-common-security javascript-express javascript-inclusive javascript-node-security \
             java-best-practices java-code-style java-security \
             csharp-best-practices csharp-inclusive csharp-security \
+            go-best-practices go-security \
+            ruby-best-practices ruby-code-style \
+            rspec-best-practices rspec-code-style \
+            rails-best-practice \
             # docker-best-practices (see STAL-607)\
             do \
             python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -r $ruleset ; \

--- a/.github/workflows/production-rules.yaml
+++ b/.github/workflows/production-rules.yaml
@@ -34,7 +34,7 @@ jobs:
             go-best-practices go-security \
             ruby-best-practices ruby-code-style \
             rspec-best-practices rspec-code-style \
-            rails-best-practice \
+            rails-best-practices \
             # docker-best-practices (see STAL-607)\
             do \
             python misc/test-production-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -r $ruleset ; \

--- a/cli/src/file_utils.rs
+++ b/cli/src/file_utils.rs
@@ -10,6 +10,7 @@ use walkdir::WalkDir;
 static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Csharp, &["cs"]),
     (Language::Dockerfile, &["docker", "dockerfile"]),
+    (Language::Go, &["go"]),
     (Language::Java, &["java"]),
     (Language::JavaScript, &["js", "jsx"]),
     (Language::Kotlin, &["kt", "kts"]),


### PR DESCRIPTION
## What problem are you trying to solve?

We want the CLI to work for Go rules

## What is your solution?

1. Enable the language
2. Add all production rules to be tested in the CI pipeline.
