### PR TITLE
[STAL-1046] Optimize grammar fetching

### DIFF
--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,8 +1,9 @@
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::Command;
 
-fn run<F>(name: &str, mut configure: F) -> ExitStatus
+/// Executes a [Command], returning true if the command finished with exit status 0, otherwise false
+fn run<F>(name: &str, mut configure: F) -> bool
 where
     F: FnMut(&mut Command) -> &mut Command,
 {
@@ -12,6 +13,7 @@ where
     configured
         .status()
         .unwrap_or_else(|_| panic!("failed to execute {configured:?}"))
+        .success()
 }
 
 fn main() {
@@ -54,7 +56,7 @@ fn main() {
             compilation_unit: "tree-sitter-c-sharp".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-c-sharp.git".to_string(),
             commit_hash: "dd5e59721a5f8dae34604060833902b882023aaf".to_string(),
-            build_dir: ["tree-sitter-c-sharp", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
@@ -63,7 +65,7 @@ fn main() {
             compilation_unit: "tree-sitter-dockerfile".to_string(),
             repository: "https://github.com/camdencheek/tree-sitter-dockerfile.git".to_string(),
             commit_hash: "33e22c33bcdbfc33d42806ee84cfd0b1248cc392".to_string(),
-            build_dir: ["tree-sitter-dockerfile", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,
         },
@@ -72,7 +74,7 @@ fn main() {
             compilation_unit: "tree-sitter-go".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-go.git".to_string(),
             commit_hash: "ff86c7f1734873c8c4874ca4dd95603695686d7a".to_string(),
-            build_dir: ["tree-sitter-go", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,
         },
@@ -81,7 +83,7 @@ fn main() {
             compilation_unit: "tree-sitter-hcl".to_string(),
             repository: "https://github.com/MichaHoffmann/tree-sitter-hcl.git".to_string(),
             commit_hash: "e135399cb31b95fac0760b094556d1d5ce84acf0".to_string(),
-            build_dir: ["tree-sitter-hcl", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
@@ -90,7 +92,7 @@ fn main() {
             compilation_unit: "tree-sitter-kotlin".to_string(),
             repository: "https://github.com/fwcd/tree-sitter-kotlin.git".to_string(),
             commit_hash: "0ef87892401bb01c84b40916e1f150197bc134b1".to_string(),
-            build_dir: ["tree-sitter-kotlin", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
@@ -99,7 +101,7 @@ fn main() {
             compilation_unit: "tree-sitter-java".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-java.git".to_string(),
             commit_hash: "2b57cd9541f9fd3a89207d054ce8fbe72657c444".to_string(),
-            build_dir: ["tree-sitter-java", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,
         },
@@ -108,7 +110,7 @@ fn main() {
             compilation_unit: "tree-sitter-javascript".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-javascript.git".to_string(),
             commit_hash: "f1e5a09b8d02f8209a68249c93f0ad647b228e6e".to_string(),
-            build_dir: ["tree-sitter-javascript", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
@@ -117,7 +119,7 @@ fn main() {
             compilation_unit: "tree-sitter-json".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-json.git".to_string(),
             commit_hash: "3fef30de8aee74600f25ec2e319b62a1a870d51e".to_string(),
-            build_dir: ["tree-sitter-json", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,
         },
@@ -126,7 +128,7 @@ fn main() {
             compilation_unit: "tree-sitter-python".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-python.git".to_string(),
             commit_hash: "4bfdd9033a2225cc95032ce77066b7aeca9e2efc".to_string(),
-            build_dir: ["tree-sitter-python", "src"].iter().collect(),
+            build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
@@ -134,7 +136,7 @@ fn main() {
             name: "tree-sitter-rust".to_string(),
             compilation_unit: "tree-sitter-rust".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-rust.git".to_string(),
-            build_dir: ["tree-sitter-rust", "src"].iter().collect(),
+            build_dir: "src".into(),
             commit_hash: "79456e6080f50fc1ca7c21845794308fa5d35a51".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
@@ -143,7 +145,7 @@ fn main() {
             name: "tree-sitter-typescript".to_string(),
             compilation_unit: "tree-sitter-typescript".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-typescript.git".to_string(),
-            build_dir: ["tree-sitter-typescript", "tsx", "src"].iter().collect(),
+            build_dir: "tsx/src".into(),
             commit_hash: "d847898fec3fe596798c9fda55cb8c05a799001a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
@@ -152,7 +154,7 @@ fn main() {
             name: "tree-sitter-yaml".to_string(),
             compilation_unit: "tree-sitter-yaml-parser".to_string(),
             repository: "https://github.com/ikatyang/tree-sitter-yaml.git".to_string(),
-            build_dir: ["tree-sitter-yaml", "src"].iter().collect(),
+            build_dir: "src".into(),
             commit_hash: "0e36bed171768908f331ff7dff9d956bae016efb".to_string(),
             files: vec!["parser.c".to_string()],
             cpp: false,
@@ -161,7 +163,7 @@ fn main() {
             name: "tree-sitter-yaml".to_string(),
             compilation_unit: "tree-sitter-yaml-scanner".to_string(),
             repository: "https://github.com/ikatyang/tree-sitter-yaml.git".to_string(),
-            build_dir: ["tree-sitter-yaml", "src"].iter().collect(),
+            build_dir: "src".into(),
             commit_hash: "0e36bed171768908f331ff7dff9d956bae016efb".to_string(),
             files: vec!["scanner.cc".to_string()],
             cpp: true,
@@ -170,7 +172,7 @@ fn main() {
             name: "tree-sitter-ruby".to_string(),
             compilation_unit: "tree-sitter-ruby-parser".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-ruby".to_string(),
-            build_dir: ["tree-sitter-ruby", "src"].iter().collect(),
+            build_dir: "src".into(),
             commit_hash: "4d9ad3f010fdc47a8433adcf9ae30c8eb8475ae7".to_string(),
             files: vec!["parser.c".to_string()],
             cpp: false,
@@ -179,40 +181,37 @@ fn main() {
             name: "tree-sitter-ruby".to_string(),
             compilation_unit: "tree-sitter-ruby-scanner".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-ruby".to_string(),
-            build_dir: ["tree-sitter-ruby", "src"].iter().collect(),
+            build_dir: "src".into(),
             commit_hash: "4d9ad3f010fdc47a8433adcf9ae30c8eb8475ae7".to_string(),
             files: vec!["scanner.cc".to_string()],
             cpp: true,
         },
     ];
 
-    // for each project
-    //  1. Check if already clone. It not, clone it
-    //  2. `checkout` the specified hash
-    //  3. Build the project
-    for tree_sitter_project in tree_sitter_projects {
-        if !Path::new(tree_sitter_project.name.as_str()).exists() {
-            run("git", |command| {
-                command
-                    .arg("clone")
-                    .arg(tree_sitter_project.repository.as_str())
-                    .arg(tree_sitter_project.name.as_str())
-            });
+    // For each project:
+    // 1. Check if the source is already present in the folder. It not, fetch it at the specified hash via git
+    // 2. Build the project
+    let base_dir = env::current_dir().unwrap();
+    for proj in &tree_sitter_projects {
+        let project_dir = format!("{}@{}", &proj.name, &proj.commit_hash);
+        if !Path::new(&project_dir).exists() {
+            assert!(run("mkdir", |cmd| { cmd.arg(&project_dir) }));
+            env::set_current_dir(&project_dir).unwrap();
+            assert!(run("git", |cmd| { cmd.args(["init", "-q"]) }));
+            assert!(run("git", |cmd| {
+                cmd.args(["remote", "add", "origin", &proj.repository])
+            }));
+            assert!(run("git", |cmd| {
+                cmd.args(["fetch", "-q", "--depth", "1", "origin", &proj.commit_hash])
+            }));
+            assert!(run("git", |cmd| {
+                cmd.args(["checkout", "-q", "FETCH_HEAD"])
+            }));
+            assert!(run("rm", |cmd| { cmd.args(["-rf", ".git"]) }));
+            env::set_current_dir(&base_dir).unwrap();
         }
-        let base_dir = env::current_dir().expect("should be able to get current dir");
-        env::set_current_dir(Path::new(&tree_sitter_project.name))
-            .expect("should be able to switch directories");
-        let checkout_status = run("git", |command| {
-            command.args(["checkout", &tree_sitter_project.commit_hash])
-        });
-        assert_eq!(
-            checkout_status.code(),
-            Some(0),
-            "[{}] Unable to checkout `{}`",
-            &tree_sitter_project.name,
-            &tree_sitter_project.commit_hash,
-        );
-        env::set_current_dir(base_dir).expect("should be able to switch directories");
-        compile_project(&tree_sitter_project);
+        env::set_current_dir(&project_dir).unwrap();
+        compile_project(proj);
+        env::set_current_dir(&base_dir).unwrap();
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
Cloning each tree-sitter grammar's entire repository is inefficient in terms of CPU and bandwidth

## What is your solution?
Fetch each repo only at the specified hash ("--depth 1")
|            | Time  | Ingress   |
| ---------- | ----- | --------- |
| **Before** | 5m02s | 720 MiB   |
| **After**  | 9s    | 10.15 MiB |