### PR TITLE
[STAL-1046] (Cont'd) Reorganize fetched tree-sitter grammars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ Cargo.lock
 # files from vim
 *~
 
-# tree-sitter sources
-kernel/tree-sitter-*/
+# tree-sitter grammar sources
+kernel/.vendor/
 
 # IntelliJ
 .idea

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -193,9 +193,9 @@ fn main() {
     // 2. Build the project
     let base_dir = env::current_dir().unwrap();
     for proj in &tree_sitter_projects {
-        let project_dir = format!("{}@{}", &proj.name, &proj.commit_hash);
+        let project_dir = format!(".vendor/{}@{}", &proj.name, &proj.commit_hash);
         if !Path::new(&project_dir).exists() {
-            assert!(run("mkdir", |cmd| { cmd.arg(&project_dir) }));
+            assert!(run("mkdir", |cmd| { cmd.args(["-p", &project_dir]) }));
             env::set_current_dir(&project_dir).unwrap();
             assert!(run("git", |cmd| { cmd.args(["init", "-q"]) }));
             assert!(run("git", |cmd| {


### PR DESCRIPTION
This is a continuation of https://github.com/DataDog/datadog-static-analyzer/pull/185

When we fetch tree-sitter grammars, we currently save them as siblings of our `src` directory, like so:
(Note: the fetched directories are included in `.gitignore`)
**Before**
```
kernel
├── build.rs
├── Cargo.toml
├── src
│   ...
│   ├── analysis.rs
│   └── lib.rs
├── tree-sitter-c-sharp@dd5e59721a5f8dae34604060833902b882023aaf
├── tree-sitter-dockerfile@33e22c33bcdbfc33d42806ee84cfd0b1248cc392
...
└── tree-sitter-yaml@0e36bed171768908f331ff7dff9d956bae016efb
```

This PR moves all the fetched grammars to their own subfolder, like so:
(Now the `.vendor` folder is included in `.gitignore`)
**After**
```
kernel
├── .vendor
│   ├── tree-sitter-c-sharp@dd5e59721a5f8dae34604060833902b882023aaf
│   ├── tree-sitter-dockerfile@33e22c33bcdbfc33d42806ee84cfd0b1248cc392
│   ...
│   └── tree-sitter-yaml@0e36bed171768908f331ff7dff9d956bae016efb
├── build.rs
├── Cargo.toml
└── src
    ...
    ├── analysis.rs
    └── lib.rs
```

Having organization like this makes build scripts more straightforward to author.
