### PR TITLE
[STAL-1051] remove unpublished version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -56,62 +56,6 @@
                 }
             }
         },
-        "0.2.0": {
-            "cli": {
-                "windows": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-                },
-                "linux": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-                },
-                "macos": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-x86_64-apple-darwin.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-aarch64-apple-darwin.zip"
-                }
-            },
-            "server": {
-                "windows": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
-                },
-                "linux": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
-                },
-                "macos": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.2.0/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
-                }
-            }
-        },
-        "0.1.9": {
-            "cli": {
-                "windows": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
-                },
-                "linux": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
-                },
-                "macos": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-x86_64-apple-darwin.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-aarch64-apple-darwin.zip"
-                }
-            },
-            "server": {
-                "windows": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
-                },
-                "linux": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
-                },
-                "macos": {
-                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
-                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.1.9/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
-                }
-            }
-        },
         "0.1.8": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
## What problem are you trying to solve?

We never published version `0.2.0` and `0.1.9`. Therefore, they should not be in the `versions.json`

## What is your solution?

Remove these versions from the `versions.json` file.