### PR TITLE
[STAL-1259] filter violation for specific rule

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -40,11 +40,8 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
     };
 
     for line in code.lines() {
-        let line_without_whitespaces: String = line
-            .clone()
-            .chars()
-            .filter(|c| !c.is_whitespace())
-            .collect();
+        let line_without_whitespaces: String =
+            line.chars().filter(|c| !c.is_whitespace()).collect();
         for p in &disabling_patterns {
             if line_without_whitespaces.contains(p) {
                 // get the rulesets/rules being referenced on the line

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -492,4 +492,39 @@ def foo(arg1):
         let result = results.get(0).unwrap();
         assert!(result.violations.is_empty());
     }
+
+    #[test]
+    fn test_get_lines_to_ignore() {
+        // no-dd-sa ruleset1/rule1 on line 3 so we ignore line 4 for ruleset1/rule1
+        // no-dd-sa on line 7 so we ignore all rules on line 8
+        let code = "foo\n\n# no-dd-sa ruleset1/rule1\n\nbar\n\n# no-dd-sa\n";
+
+        let lines_to_ignore = get_lines_to_ignore(code, &Language::Python);
+
+        // test lines to ignore for all rules
+        assert_eq!(1, lines_to_ignore.lines_to_ignore.len());
+        assert!(!lines_to_ignore.lines_to_ignore.contains(&1));
+        assert!(lines_to_ignore.lines_to_ignore.contains(&8));
+
+        // test lines to ignore for some rules
+        assert_eq!(1, lines_to_ignore.lines_to_ignore_per_rule.len());
+        assert!(lines_to_ignore.lines_to_ignore_per_rule.contains_key(&4));
+        assert_eq!(
+            1,
+            lines_to_ignore
+                .lines_to_ignore_per_rule
+                .get(&4)
+                .unwrap()
+                .len()
+        );
+        assert_eq!(
+            "ruleset1/rule1",
+            lines_to_ignore
+                .lines_to_ignore_per_rule
+                .get(&4)
+                .unwrap()
+                .get(0)
+                .unwrap()
+        );
+    }
 }

--- a/crates/static-analysis-kernel/src/model/analysis.rs
+++ b/crates/static-analysis-kernel/src/model/analysis.rs
@@ -24,10 +24,10 @@ pub struct LinesToIgnore {
 }
 
 impl LinesToIgnore {
-    // return if a specific rule should be ignored
-    // rule_name is the full rule name like rule1/rule2
-    // line is the line of the violation
-    // lines_to_ignore is the list of lines to ignore for all rules or per rules
+    /// return if a specific rule should be ignored
+    ///  - rule_name is the full rule name like rule1/rule2
+    ///  - line is the line of the violation
+    /// returns true if the rule should be ignored
     pub fn should_filter_rule(&self, rule_name: &str, line: u32) -> bool {
         if self.lines_to_ignore.contains(&line) {
             return true;


### PR DESCRIPTION
## What problem are you trying to solve?

We want users to be able to filter violation for a specific ruleset. If users only put `#no-dd-sa`, all violations are filtered on the next line. If the user puts `#no-dd-sa ruleset1/rule2`, only `ruleset1/rule2` is filtered.

## What is your solution?

When we analyze a file, we first build the list of

1. lines to ignore all rules
2. lines to ignore only some rules

After the engine execution, we filter the results according to this list.


## Testing

Tested locally with [this file](https://github.com/juli1/rosie-tests/blob/main/yaml_load.py).

If putting `#no-dd-sa` on line 2, I get

```
Found 4 violations in 5 files using 91 rules within 1 secs
```

If putting `#no-dd-sa   python-security/yaml-load` on line 2, I get

```
Found 4 violations in 5 files using 91 rules within 1 secs
```

If put nothing, I get

```
Found 5 violations in 5 files using 91 rules within 1 secs
```
