### PR TITLE
[STAL-1265] support multiple subdirectories

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -1,6 +1,8 @@
 use cli::config_file::read_config_file;
 use cli::datadog_utils::get_rules_from_rulesets;
-use cli::file_utils::{filter_files_for_language, get_files, read_files_from_gitignore};
+use cli::file_utils::{
+    are_subdirectories_safe, filter_files_for_language, get_files, read_files_from_gitignore,
+};
 use cli::model::config_file::ConfigFile;
 use cli::rule_utils::{get_languages_for_rules, get_rulesets_from_file};
 use itertools::Itertools;
@@ -185,7 +187,7 @@ fn main() -> Result<()> {
     let mut ignore_paths: Vec<String> = Vec::new();
     let ignore_paths_from_options = matches.opt_strs("p");
     let directory_to_analyze_option = matches.opt_str("i");
-    let subdirectories_to_analyze_option = matches.opt_strs("u");
+    let subdirectories_to_analyze = matches.opt_strs("u");
 
     let rules_file = matches.opt_str("r");
 
@@ -200,6 +202,11 @@ fn main() -> Result<()> {
 
     if !directory_path.is_dir() {
         eprintln!("directory to analyze is not correct");
+        exit(1)
+    }
+
+    if !are_subdirectories_safe(directory_path, &subdirectories_to_analyze) {
+        eprintln!("sub-directories are not safe and point outside of the repository");
         exit(1)
     }
 
@@ -259,7 +266,7 @@ fn main() -> Result<()> {
 
     let files_to_analyze = get_files(
         directory_to_analyze.as_str(),
-        subdirectories_to_analyze_option.clone(),
+        subdirectories_to_analyze.clone(),
         &ignore_paths,
     )
     .expect("unable to get the list of files to analyze");
@@ -277,7 +284,7 @@ fn main() -> Result<()> {
         use_configuration_file,
         ignore_gitignore,
         source_directory: directory_to_analyze.clone(),
-        source_subdirectories: subdirectories_to_analyze_option.clone(),
+        source_subdirectories: subdirectories_to_analyze.clone(),
         ignore_paths,
         rules_file,
         output_format,

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -60,11 +60,8 @@ fn print_configuration(configuration: &CliConfiguration) {
     println!("#rules loaded       : {}", configuration.rules.len());
     println!("source directory    : {}", configuration.source_directory);
     println!(
-        "source subdirectory : {}",
-        configuration
-            .source_subdirectory
-            .clone()
-            .unwrap_or("none".to_string())
+        "subdirectories      : {}",
+        configuration.source_subdirectories.clone().join(",")
     );
     println!("output file         : {}", configuration.output_file);
     println!("output format       : {}", output_format_str);
@@ -98,7 +95,7 @@ fn main() -> Result<()> {
         "directory to scan (valid existing directory)",
         "/path/to/code/to/analyze",
     );
-    opts.optopt(
+    opts.optmulti(
         "u",
         "subdirectory",
         "subdirectory to scan within the repository",
@@ -188,7 +185,7 @@ fn main() -> Result<()> {
     let mut ignore_paths: Vec<String> = Vec::new();
     let ignore_paths_from_options = matches.opt_strs("p");
     let directory_to_analyze_option = matches.opt_str("i");
-    let subdirectory_to_analyze_option = matches.opt_str("u");
+    let subdirectories_to_analyze_option = matches.opt_strs("u");
 
     let rules_file = matches.opt_str("r");
 
@@ -262,7 +259,7 @@ fn main() -> Result<()> {
 
     let files_to_analyze = get_files(
         directory_to_analyze.as_str(),
-        subdirectory_to_analyze_option.clone(),
+        subdirectories_to_analyze_option.clone(),
         &ignore_paths,
     )
     .expect("unable to get the list of files to analyze");
@@ -280,7 +277,7 @@ fn main() -> Result<()> {
         use_configuration_file,
         ignore_gitignore,
         source_directory: directory_to_analyze.clone(),
-        source_subdirectory: subdirectory_to_analyze_option.clone(),
+        source_subdirectories: subdirectories_to_analyze_option.clone(),
         ignore_paths,
         rules_file,
         output_format,

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -85,11 +85,12 @@ pub fn read_files_from_gitignore(source_directory: &str) -> Result<Vec<String>> 
     read_files_from_gitignore_internal(&gitignore_path)
 }
 
-// get the files to analyze from the directory. This function walks the directory
-// to analyze recursively and gets all the files.
+/// get the files to analyze from the directory. This function walks the directory
+/// to analyze recursively and gets all the files.
+/// if passed, subdirectories_to_analyze are subdirectories within the directory.
 pub fn get_files(
     directory: &str,
-    subdirectory: Option<String>,
+    subdirectories_to_analyze: Vec<String>,
     paths_to_ignore: &[String],
 ) -> Result<Vec<PathBuf>> {
     let mut files_to_return: Vec<PathBuf> = vec![];
@@ -97,58 +98,64 @@ pub fn get_files(
     // This is the directory that contains the .git files, we do not need to keep them.
     let git_directory = format!("{}/.git", &directory);
 
-    let directory_to_walk: String = match subdirectory {
-        Some(sd) => {
-            let sd_str = sd.as_str();
-            let p = Path::new(directory).join(sd_str);
-            p.as_os_str().to_str().unwrap().to_string()
-        }
-        None => directory.to_string(),
+    let directories_to_walk: Vec<String> = if !subdirectories_to_analyze.is_empty() {
+        subdirectories_to_analyze
+            .iter()
+            .map(|p| {
+                let sd_str = p.as_str();
+                let p = Path::new(directory).join(sd_str);
+                p.as_os_str().to_str().unwrap().to_string()
+            })
+            .collect()
+    } else {
+        vec![directory.to_string()]
     };
 
-    for entry in WalkDir::new(directory_to_walk.as_str()) {
-        let dir_entry = entry?;
-        let entry = dir_entry.path();
+    for directory_to_walk in directories_to_walk {
+        for entry in WalkDir::new(directory_to_walk.as_str()) {
+            let dir_entry = entry?;
+            let entry = dir_entry.path();
 
-        // we only include if this is a file and not a symlink
-        // we should NEVER follow symlink for security reason (an attacker could then
-        // attempt to add a symlink outside the repo and read content outside of the
-        // repo with a custom rule.
-        let mut should_include = entry.is_file() && !entry.is_symlink();
-        let path_buf = entry.to_path_buf();
+            // we only include if this is a file and not a symlink
+            // we should NEVER follow symlink for security reason (an attacker could then
+            // attempt to add a symlink outside the repo and read content outside of the
+            // repo with a custom rule.
+            let mut should_include = entry.is_file() && !entry.is_symlink();
+            let path_buf = entry.to_path_buf();
 
-        // check if the path should be ignored by a glob or not.
-        for path_to_ignore in paths_to_ignore {
-            // skip empty path to ignore
-            if path_to_ignore.is_empty() {
-                continue;
+            // check if the path should be ignored by a glob or not.
+            for path_to_ignore in paths_to_ignore {
+                // skip empty path to ignore
+                if path_to_ignore.is_empty() {
+                    continue;
+                }
+
+                let relative_path_str = path_buf
+                    .strip_prefix(directory)
+                    .ok()
+                    .and_then(|p| p.to_str())
+                    .ok_or_else(|| anyhow::Error::msg("should get the path"))?;
+                if glob_match(path_to_ignore.as_str(), relative_path_str) {
+                    should_include = false;
+                }
+
+                let relative_path_res = path_buf.strip_prefix(directory);
+
+                if let Ok(relative_path) = relative_path_res {
+                    if relative_path.starts_with(Path::new(path_to_ignore.as_str())) {
+                        should_include = false;
+                    }
+                }
             }
 
-            let relative_path_str = path_buf
-                .strip_prefix(directory)
-                .ok()
-                .and_then(|p| p.to_str())
-                .ok_or_else(|| anyhow::Error::msg("should get the path"))?;
-            if glob_match(path_to_ignore.as_str(), relative_path_str) {
+            // do not include the git directory.
+            if entry.starts_with(git_directory.as_str()) {
                 should_include = false;
             }
 
-            let relative_path_res = path_buf.strip_prefix(directory);
-
-            if let Ok(relative_path) = relative_path_res {
-                if relative_path.starts_with(Path::new(path_to_ignore.as_str())) {
-                    should_include = false;
-                }
+            if should_include {
+                files_to_return.push(entry.to_path_buf());
             }
-        }
-
-        // do not include the git directory.
-        if entry.starts_with(git_directory.as_str()) {
-            should_include = false;
-        }
-
-        if should_include {
-            files_to_return.push(entry.to_path_buf());
         }
     }
     Ok(files_to_return)
@@ -277,7 +284,7 @@ mod tests {
             use_configuration_file: true,
             ignore_gitignore: true,
             source_directory: "bla".to_string(),
-            source_subdirectory: None,
+            source_subdirectories: vec![],
             ignore_paths: vec![],
             rules_file: None,
             output_format: Sarif, // SARIF or JSON
@@ -319,7 +326,7 @@ mod tests {
         let empty_paths_to_ignore = vec![];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &empty_paths_to_ignore,
         );
         assert!(files.is_ok());
@@ -335,7 +342,7 @@ mod tests {
         let ignore_paths = vec!["**/src/**/lib.rs".to_string()];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &ignore_paths,
         );
         assert!(files.is_ok());
@@ -357,7 +364,7 @@ mod tests {
         let empty_paths_to_ignore = vec![];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            Some(subdirectory.into_os_string().into_string().unwrap()),
+            vec![subdirectory.into_os_string().into_string().unwrap()],
             &empty_paths_to_ignore,
         );
 
@@ -377,7 +384,7 @@ mod tests {
         let ignore_paths = vec!["src".to_string()];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &ignore_paths,
         );
         assert!(files.is_ok());
@@ -393,7 +400,7 @@ mod tests {
         let ignore_paths = vec!["src/lib.rs".to_string()];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &ignore_paths,
         );
         assert!(files.is_ok());
@@ -409,7 +416,7 @@ mod tests {
         let ignore_paths = vec!["foo".to_string()];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &ignore_paths,
         );
         assert!(files.is_ok());
@@ -450,7 +457,7 @@ mod tests {
         let empty_paths_to_ignore = vec![];
         let files = get_files(
             current_path.display().to_string().as_str(),
-            None,
+            vec![],
             &empty_paths_to_ignore,
         );
         assert!(files.is_ok());

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -267,6 +267,7 @@ mod tests {
     use super::*;
     use kernel::model::common::OutputFormat::Sarif;
     use std::collections::HashMap;
+    use std::env;
     use std::path::Path;
 
     #[test]
@@ -292,16 +293,19 @@ mod tests {
 
     #[test]
     fn test_are_subdirectories_safe() {
-        let directory = Path::new("/tmp");
-        assert!(!are_subdirectories_safe(
-            directory,
-            &vec!["../".to_string()]
-        ));
+        // Create temporary directories and have a directory called plop inside.
+        let directory_dir = env::temp_dir();
+        let plop_dir = directory_dir.join("plop");
+        if !Path::exists(plop_dir.as_path()) {
+            fs::create_dir(&plop_dir).expect("can create dir");
+        }
+
+        let directory = directory_dir.as_path();
+        assert!(!are_subdirectories_safe(directory, &["../".to_string()]));
         assert!(are_subdirectories_safe(directory, &vec![]));
-        assert!(are_subdirectories_safe(
-            directory,
-            &vec!["../tmp".to_string()]
-        ));
+        assert!(are_subdirectories_safe(directory, &["plop".to_string()]));
+
+        fs::remove_dir(plop_dir).expect("cannot remove dir")
     }
 
     /// Filter files bigger than one kilobyte and make sure files

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -8,7 +8,7 @@ pub struct CliConfiguration {
     pub use_configuration_file: bool,
     pub ignore_gitignore: bool,
     pub source_directory: String,
-    pub source_subdirectory: Option<String>,
+    pub source_subdirectories: Vec<String>,
     pub ignore_paths: Vec<String>,
     pub rules_file: Option<String>,
     pub output_format: OutputFormat, // SARIF or JSON


### PR DESCRIPTION
## What problem are you trying to solve?

We want to support multiple subdirectories to analyze with the static analyzer

## What is your solution?

Support multiple `--subdirectory` options.

## Testing.

```
cargo run --bin datadog-static-analyzer -- -i <directory>-o /tmp/plop.json -u <subdir1> -u <subdir2>
417/417Found 527 violations in 442 files using 73 rules within 30 secs
```

```
cargo run --bin datadog-static-analyzer -- -i <directory>-o /tmp/plop.json -u <subdir1>
148/148Found 103 violations in 159 files using 73 rules within 4 secs
```


```
cargo run --bin datadog-static-analyzer -- -o /tmp/plop.json  -i /Users/julien.delange/dd/dd-source --subdirectory domains/static-analysis --subdirectory domains/ci-app --subdirectory ../../
sub-directories are not safe and point outside of the repository
```