### PR TITLE
Fix compilation warnings.

### DIFF
--- a/crates/bins/Cargo.toml
+++ b/crates/bins/Cargo.toml
@@ -40,7 +40,7 @@ getopts = "0.2.21"
 num_cpus = "1.15.0"
 indicatif = "0.17.6"
 rayon = "1.7.0"
-rocket = { version = "=0.5.0-rc.3", features = ["json"] }
+rocket = { version = "=0.5.0", features = ["json"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 uuid = { version = "1.6.1", features = ["v4"] }
 

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -34,7 +34,7 @@ fn test_rule(rule: &Rule, test: &RuleTest) -> Result<String> {
     if analyze_result.is_empty() {
         Err(Error::msg("no violation result"))
     } else {
-        let first_results = analyze_result.get(0).unwrap();
+        let first_results = analyze_result.first().unwrap();
 
         if first_results.violations.len() != test.annotation_count as usize {
             let error =


### PR DESCRIPTION
## What problem are you trying to solve?
Compilation warnings caused the pre-push hook to fail, preventing creation of pull requests.

## What is your solution?
* Update rocket to 0.5.0 since RC3 was known to cause those 'unused import' warnings.
* Use `.first()` instead of `.get(0)`

## Alternatives considered

## What the reviewer should know
