### PR TITLE
[STAL-626] Display a list of violations at the end of each run.

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,6 +9,7 @@ itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertoo
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean McArthur
 percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
+prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD 3-Clause,Copyright (c) 2022, Pierre-Henri Symoneaux
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,7 +9,7 @@ itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertoo
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers
 num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean McArthur
 percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
-prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD 3-Clause,Copyright (c) 2022, Pierre-Henri Symoneaux
+prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD-3-Clause,Copyright (c) 2022 Pierre-Henri Symoneaux
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld

--- a/crates/bins/Cargo.toml
+++ b/crates/bins/Cargo.toml
@@ -39,7 +39,6 @@ tracing = { workspace = true }
 getopts = "0.2.21"
 num_cpus = "1.15.0"
 indicatif = "0.17.6"
-prettytable-rs = "0.10.0"
 rayon = "1.7.0"
 rocket = { version = "=0.5.0", features = ["json"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }

--- a/crates/bins/Cargo.toml
+++ b/crates/bins/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { workspace = true }
 getopts = "0.2.21"
 num_cpus = "1.15.0"
 indicatif = "0.17.6"
+prettytable-rs = "0.10.0"
 rayon = "1.7.0"
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -440,7 +440,7 @@ fn main() -> Result<()> {
             "rule", "filename", "location", "category", "severity", "message"
         ]);
         for rule_result in &all_rule_results {
-            if rule_result.violations.len() > 0 {
+            if !rule_result.violations.is_empty() {
                 for violation in &rule_result.violations {
                     let position = format!(
                         "{}:{}-{}:{}",

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -115,7 +115,7 @@ fn main() -> Result<()> {
     opts.optopt("o", "output", "output file name", "output.json");
     opts.optflag(
         "",
-        "print_violations",
+        "print-violations",
         "print a list with all the violations that were found",
     );
     opts.optopt("c", "cpus", "set the number of CPU, use to parallelize (default is the number of cores on the platform)", "--cpus 5");
@@ -171,7 +171,7 @@ fn main() -> Result<()> {
     let use_staging = matches.opt_present("s");
     let add_git_info = matches.opt_present("g");
     let enable_performance_statistics = matches.opt_present("x");
-    let print_violations = matches.opt_present("print_violations");
+    let print_violations = matches.opt_present("print-violations");
 
     let output_format = match matches.opt_str("f") {
         Some(f) => match f.as_str() {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -432,7 +432,10 @@ fn main() -> Result<()> {
     if nb_violations > 0 {
         let mut table = Table::new();
         let format = format::FormatBuilder::new()
-            .separator(format::LinePosition::Title, format::LineSeparator::new('-', '-', '-', '-'))
+            .separator(
+                format::LinePosition::Title,
+                format::LineSeparator::new('-', '-', '-', '-'),
+            )
             .padding(1, 1)
             .build();
         table.set_format(format);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ serde-sarif = { workspace = true }
 git2 = "0.18.0"
 glob-match = "0.2.1"
 percent-encoding = "2.3.1"
+prettytable-rs = "0.10.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_yaml = "0.9.21"
 valico = "4.0.0"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate prettytable;
+
 pub mod config_file;
 pub mod constants;
 pub mod csv;
@@ -6,3 +9,4 @@ pub mod file_utils;
 pub mod model;
 pub mod rule_utils;
 pub mod sarif;
+pub mod violations_table;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate prettytable;
-
 pub mod config_file;
 pub mod constants;
 pub mod csv;

--- a/crates/cli/src/violations_table.rs
+++ b/crates/cli/src/violations_table.rs
@@ -1,7 +1,7 @@
 use kernel::model::rule::RuleResult;
-use prettytable::{format, Table};
+use prettytable::{format, row, Table};
 
-pub fn print_violations_table(rule_results: &Vec<RuleResult>) {
+pub fn print_violations_table(rule_results: &[RuleResult]) {
     let mut table = Table::new();
     let format = format::FormatBuilder::new()
         .separator(

--- a/crates/cli/src/violations_table.rs
+++ b/crates/cli/src/violations_table.rs
@@ -1,0 +1,39 @@
+use kernel::model::rule::RuleResult;
+use prettytable::{format, Table};
+
+pub fn print_violations_table(rule_results: &Vec<RuleResult>) {
+    let mut table = Table::new();
+    let format = format::FormatBuilder::new()
+        .separator(
+            format::LinePosition::Title,
+            format::LineSeparator::new('-', '-', '-', '-'),
+        )
+        .padding(1, 1)
+        .build();
+    table.set_format(format);
+    table.set_titles(row![
+        "rule", "filename", "location", "category", "severity", "message"
+    ]);
+    for rule_result in rule_results {
+        if !rule_result.violations.is_empty() {
+            for violation in &rule_result.violations {
+                let position = format!(
+                    "{}:{}-{}:{}",
+                    violation.start.line,
+                    violation.start.col,
+                    violation.end.line,
+                    violation.end.col
+                );
+                table.add_row(row![
+                    rule_result.rule_name,
+                    rule_result.filename,
+                    position,
+                    violation.category.to_string(),
+                    violation.severity.to_string(),
+                    violation.message
+                ]);
+            }
+        }
+    }
+    table.printstd();
+}


### PR DESCRIPTION
## What problem are you trying to solve?
After the analyzer is run, the standard output only says that "N violations were found", but the actual list of violations must be found elsewhere, which creates unnecessary friction.

## What is your solution?
Display the list of found violations as a table at the end of the run.

Uses the `prettytable-rs` crate, which can lay the table out automatically and also has formatting options to avoid displaying too many borders.

## Alternatives considered

## What the reviewer should know
