### PR TITLE
[STAL-1309] CLI: default to 8 cores max unless otherwise specified

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -112,7 +112,12 @@ fn main() -> Result<()> {
     opts.optopt("d", "debug", "use debug mode", "yes/no");
     opts.optopt("f", "format", "format of the output file", "json/sarif/csv");
     opts.optopt("o", "output", "output file name", "output.json");
-    opts.optopt("c", "cpus", "set the number of CPU, use to parallelize (default is the number of cores on the platform)", "--cpus 5");
+    opts.optopt(
+        "c",
+        "cpus",
+        format!("allow N CPUs at once; if unspecified, defaults to the number of logical cores on the platform or {}, whichever is less", DEFAULT_MAX_CPUS).as_str(),
+        "--cpus 5",
+    );
     opts.optmulti(
         "p",
         "ignore-path",
@@ -271,12 +276,15 @@ fn main() -> Result<()> {
     )
     .expect("unable to get the list of files to analyze");
 
-    // we try to get the amount of cpu from the system. if the user set an option to force
-    // the value. it overrides the value.
-    let num_cpus = matches
+    let num_cores_requested = matches
         .opt_str("c")
-        .map(|x| x.parse::<usize>().unwrap())
-        .unwrap_or(num_cpus::get());
+        .map(|val| {
+            val.parse::<usize>()
+                .context("unable to parse `cpus` flag as integer")
+        })
+        .transpose()?;
+    // Select the number of cores to use based on the user's CLI arg (or lack of one)
+    let num_cpus = choose_cpu_count(num_cores_requested);
 
     // build the configuration object that contains how the CLI should behave.
     let configuration = CliConfiguration {
@@ -492,4 +500,14 @@ fn main() -> Result<()> {
     file.write_all(value.as_bytes())
         .context("error when writing results")?;
     Ok(())
+}
+
+const DEFAULT_MAX_CPUS: usize = 8;
+
+/// Returns the user's requested core count, clamped to the number of logical cores on the system.
+/// If unspecified, up to [DEFAULT_MAX_CPUS] CPUs will be used.
+fn choose_cpu_count(user_input: Option<usize>) -> usize {
+    let logical_cores = num_cpus::get();
+    let cores = user_input.unwrap_or(DEFAULT_MAX_CPUS);
+    usize::min(logical_cores, cores)
 }


### PR DESCRIPTION
## What problem are you trying to solve?
The analyzer currently defaults to using every core on the user's machine for parallel computation.
Users with very high core count CI instances might be surprised by this behavior.

## What is your solution?
* Set the default max logical cores used to 8
    * This can be overriden via the CLI flag `-c`/`--cpus`, e.g. `--cpus 12`
* Chore: fix logic that allowed user to specify more CPUs than exist on the platform
* Chore: don't panic on invalid `cpus` input

## Alternatives considered

## What the reviewer should know
* Unit tests omitted