### PR TITLE
[STAL-1260] Generate configuration digest for diff-aware scanning

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,7 +4,6 @@ base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 20
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 glob-match,https://crates.io/crates/glob-match,MIT, Copyright (c) 2023 Devon Govett
-hashes,https://github.com/RustCrypto/hashes,Apache-2, Copyright (c) 2016 RustCrypto contributors
 indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,6 +4,7 @@ base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 20
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 glob-match,https://crates.io/crates/glob-match,MIT, Copyright (c) 2023 Devon Govett
+hashes,https://github.com/RustCrypto/hashes,Apache-2, Copyright (c) 2016 RustCrypto contributors
 indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -496,6 +496,7 @@ fn main() -> Result<()> {
             &directory_to_analyze,
             add_git_info,
             configuration.use_debug,
+            configuration.generate_diff_aware_digest(),
         ) {
             Ok(report) => {
                 serde_json::to_string(&report).expect("error when getting the SARIF report")

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_yaml = "0.9.21"
 valico = "4.0.0"
 walkdir = "2.3.3"
+md5 = "0.7.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 derive_builder = { workspace = true }
 serde-sarif = { workspace = true }
+sha2 = { workspace = true }
 # other
 git2 = "0.18.0"
 glob-match = "0.2.1"
@@ -22,7 +23,6 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde_yaml = "0.9.21"
 valico = "4.0.0"
 walkdir = "2.3.3"
-md5 = "0.7.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -40,11 +40,7 @@ impl CliConfiguration {
             self.source_subdirectories.join(",")
         );
         // compute the hash using sha2
-        Sha256::digest(full_config_string.into_bytes())
-            .as_slice()
-            .iter()
-            .map(|x| format!("{:x?}", x))
-            .collect::<String>()
+        format!("{:x}", Sha256::digest(full_config_string.as_bytes()))
     }
 }
 
@@ -91,7 +87,7 @@ mod tests {
         };
         assert_eq!(
             cli_configuration.generate_diff_aware_digest(),
-            "f1c6525be466a8fc4038d6a183e9f782b32fc7b9afc7eef61cae53265aee4"
+            "f1c65205be466a08fc4038d6a183e9f782b32fc7b9afc7eef61cae53265aee04"
         );
     }
 }

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -1,5 +1,6 @@
 use kernel::model::common::OutputFormat;
 use kernel::model::rule::Rule;
+use sha2::{Digest, Sha256};
 
 /// represents the CLI configuratoin
 #[derive(Clone)]
@@ -38,7 +39,12 @@ impl CliConfiguration {
             self.max_file_size_kb,
             self.source_subdirectories.join(",")
         );
-        format!("{:x}", md5::compute(full_config_string))
+        // compute the hash using sha2
+        Sha256::digest(full_config_string.into_bytes())
+            .as_slice()
+            .iter()
+            .map(|x| format!("{:x?}", x))
+            .collect::<String>()
     }
 }
 
@@ -85,7 +91,7 @@ mod tests {
         };
         assert_eq!(
             cli_configuration.generate_diff_aware_digest(),
-            "5d7273dec32b80788b4d3eac46c866f0"
+            "f1c6525be466a8fc4038d6a183e9f782b32fc7b9afc7eef61cae53265aee4"
         );
     }
 }

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -24,7 +24,11 @@ impl CliConfiguration {
     /// to run the analysis. To compute the digest, we take the attributes that are important to
     /// run and replicate the analysis such as the ignored paths and rules.
     pub fn generate_diff_aware_digest(&self) -> String {
-        let rules_string: Vec<String> = self.rules.iter().map(|r| r.to_string()).collect();
+        let rules_string: Vec<String> = self
+            .rules
+            .iter()
+            .map(|r| r.get_config_hash_string())
+            .collect();
 
         let full_config_string = format!(
             "{}:{}:{}::{}:{}",
@@ -81,7 +85,7 @@ mod tests {
         };
         assert_eq!(
             cli_configuration.generate_diff_aware_digest(),
-            "0b95aaf4f78299151673f12017952546"
+            "5d7273dec32b80788b4d3eac46c866f0"
         );
     }
 }

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -481,14 +481,14 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
-            "woliejfowiejf".to_string(),
+            "5d7273dec32b80788b4d3eac46c866f0".to_string(),
         )
         .expect("generate sarif report");
 
         let sarif_report_to_string = serde_json::to_value(sarif_report).unwrap();
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:woliejfowiejf"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
+            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:5d7273dec32b80788b4d3eac46c866f0"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
         );
 
         // validate the schema
@@ -553,14 +553,14 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
-            "woliejfowiejf".to_string(),
+            "5d7273dec32b80788b4d3eac46c866f0".to_string(),
         )
         .expect("generate sarif report");
 
         let sarif_report_to_string = serde_json::to_value(sarif_report).unwrap();
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:woliejfowiejf"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
+            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:5d7273dec32b80788b4d3eac46c866f0"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
         );
 
         // validate the schema
@@ -627,7 +627,7 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
-            "woliejfowiejf".to_string(),
+            "5d7273dec32b80788b4d3eac46c866f0".to_string(),
         )
         .expect("generate sarif report");
         assert!(sarif_report

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -34,6 +34,7 @@ pub struct SarifGenerationOptions {
     pub add_git_info: bool,
     pub git_repo: Option<Rc<Repository>>,
     pub debug: bool,
+    pub config_digest: String,
 }
 
 impl IntoSarif for &Rule {
@@ -168,7 +169,7 @@ impl IntoSarif for &Edit {
 }
 
 // Generate the tool section that reports all the rules being run
-fn generate_tool_section(rules: &[Rule]) -> Result<Tool> {
+fn generate_tool_section(rules: &[Rule], options: &SarifGenerationOptions) -> Result<Tool> {
     let driver: ToolComponent = ToolComponentBuilder::default()
         .name("datadog-static-analyzer")
         .information_uri("https://www.datadoghq.com")
@@ -177,6 +178,15 @@ fn generate_tool_section(rules: &[Rule]) -> Result<Tool> {
                 .iter()
                 .map(|e| e.into_sarif())
                 .collect::<Vec<ReportingDescriptor>>(),
+        )
+        .properties(
+            PropertyBagBuilder::default()
+                .tags(vec![format!(
+                    "DATADOG_DIFF_AWARE_CONFIG_DIGEST:{}",
+                    options.config_digest
+                )])
+                .build()
+                .unwrap(),
         )
         .build()?;
 
@@ -356,6 +366,7 @@ pub fn generate_sarif_report(
     directory: &String,
     add_git_info: bool,
     debug: bool,
+    config_digest: String,
 ) -> Result<Sarif> {
     // if we enable git info, we are then getting the repository object. We put that
     // into an `Arc` object to be able to clone the object.
@@ -374,10 +385,11 @@ pub fn generate_sarif_report(
         add_git_info,
         git_repo: repository,
         debug,
+        config_digest,
     };
 
     let run = RunBuilder::default()
-        .tool(generate_tool_section(rules)?)
+        .tool(generate_tool_section(rules, &options)?)
         .results(generate_results(rules, rules_results, options)?)
         .build()?;
 
@@ -469,14 +481,14 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
+            "woliejfowiejf".to_string(),
         )
         .expect("generate sarif report");
 
         let sarif_report_to_string = serde_json::to_value(sarif_report).unwrap();
-        println!("{}", sarif_report_to_string);
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
+            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"myfile"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"myfile"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:woliejfowiejf"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
         );
 
         // validate the schema
@@ -541,14 +553,14 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
+            "woliejfowiejf".to_string(),
         )
         .expect("generate sarif report");
 
         let sarif_report_to_string = serde_json::to_value(sarif_report).unwrap();
-        println!("{}", sarif_report_to_string);
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
+            serde_json::json!({"runs":[{"results":[{"fixes":[{"artifactChanges":[{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"replacements":[{"deletedRegion":{"endColumn":6,"endLine":6,"startColumn":6,"startLine":6},"insertedContent":{"text":"newcontent"}}]}],"description":{"text":"myfix"}}],"level":"error","locations":[{"physicalLocation":{"artifactLocation":{"uri":"my%20file/in%20my%20directory"},"region":{"endColumn":4,"endLine":3,"startColumn":2,"startLine":1}}}],"message":{"text":"violation message"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:BEST_PRACTICES","CWE:1234"]},"ruleId":"my-rule","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:woliejfowiejf"]},"rules":[{"fullDescription":{"text":"awesome rule"},"helpUri":"https://docs.datadoghq.com/static_analysis/rules/my-rule","id":"my-rule","properties":{"tags":["CWE:1234"]},"shortDescription":{"text":"short description"}}]}}}],"version":"2.1.0"})
         );
 
         // validate the schema
@@ -615,6 +627,7 @@ mod tests {
             &"mydir".to_string(),
             false,
             false,
+            "woliejfowiejf".to_string(),
         )
         .expect("generate sarif report");
         assert!(sarif_report

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -239,6 +239,13 @@ impl Rule {
         hasher.update(self.code_base64.clone().as_bytes());
         format!("{:x}", hasher.finalize())
     }
+
+    /// Produce a string that is used to get the config_hash. The generated string should change
+    /// if we think that the rules change and may trigger new results.
+    pub fn get_config_hash_string(&self) -> String {
+        let pattern_string = self.pattern.clone().unwrap_or("no pattern".to_string());
+        format!("{}:{}:{}", self.name, pattern_string, self.code_base64).to_string()
+    }
 }
 
 impl fmt::Display for Rule {


### PR DESCRIPTION
## What problem are you trying to solve?

When running diff-aware scanning, we need to generate digest of the configuration to know on what configuration the run has been done. This way, we make sure that when doing diff-aware scanning, we are using the same configuration. A user that modifies the configuration cannot have diff-aware scanning.

## What is your solution?

We are generating a digest of the configuration and insert it into the SARIF report. The digest is a `md5` digest of the configuration and the configuration includes the directories used to scan the repository as well as the list of rules (so that if a rule change, we are not doing a diff-aware scan).

## What the reviewer should know

Added a dependency on the `md5` crate and added if in the `LICENSE-3rdparty.csv`