### PR TITLE
Pin `cc` to 1.0.83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ derive_builder = "0.12"
 serde-sarif = "0.4"
 sha2 = "0.10.7"
 tracing = "0.1.40"
+
+# We're getting instability in macOS CI with cc 1.0.85, so pin to 1.0.83 until we can investigate further
+[patch.crates-io]
+cc = { git = "https://github.com/rust-lang/cc-rs", tag = "1.0.83" }


### PR DESCRIPTION
## What problem are you trying to solve?
The `cc` crate recently released 1.0.85, and it's causing the `openssl-sys` crate to fail to build on our macOS CI instances (both aarch64 and x86_64). Some tree-sitter grammars we use have a very permissive semver @ "1.0", so it's auto-pulling in the latest version.

## What is your solution?
Triage by temporarily pinning cc to 1.0.83. 
## Alternatives considered

## What the reviewer should know
We don't use `cc` anywhere else outside compiling the tree-sitter grammars, so there are no side effects.

Also, we should investigate further so we can submit a helpful and detailed upstream bug report.
