### PR TITLE
Update configuration file format for path-based inclusion/exclusion

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -236,7 +236,7 @@ fn main() -> Result<()> {
             exit(1);
         }
 
-        let rulesets = conf.rulesets.0.keys().cloned().collect_vec();
+        let rulesets = conf.rulesets.keys().cloned().collect_vec();
         let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging);
         rules.extend(rules_from_api.context("error when reading rules from API")?);
 

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -236,7 +236,8 @@ fn main() -> Result<()> {
             exit(1);
         }
 
-        let rules_from_api = get_rules_from_rulesets(&conf.rulesets, use_staging);
+        let rulesets = conf.rulesets.0.keys().cloned().collect_vec();
+        let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging);
         rules.extend(rules_from_api.context("error when reading rules from API")?);
 
         // copy the ignore paths from the configuration file

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -52,9 +52,7 @@ pub fn read_config_file(path: &str) -> Result<Option<model::config_file::ConfigF
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::config_file::{
-        ConfigFile, PathConfig, RuleConfig, RulesetConfig, RulesetConfigs,
-    };
+    use crate::model::config_file::{ConfigFile, PathConfig, RuleConfig, RulesetConfig};
     use std::collections::HashMap;
 
     // `rulesets` parsed as a list of ruleset names
@@ -66,10 +64,10 @@ rulesets:
   - go-best-practices
     "#;
         let expected = ConfigFile {
-            rulesets: RulesetConfigs(HashMap::from([
+            rulesets: HashMap::from([
                 ("python-security".to_string(), RulesetConfig::default()),
                 ("go-best-practices".to_string(), RulesetConfig::default()),
-            ])),
+            ]),
             ..ConfigFile::default()
         };
 
@@ -95,7 +93,7 @@ rulesets:
       random-iv:
     "#;
         let expected = ConfigFile {
-            rulesets: RulesetConfigs(HashMap::from([
+            rulesets: HashMap::from([
                 ("python-security".to_string(), RulesetConfig::default()),
                 (
                     "go-best-practices".to_string(),
@@ -120,7 +118,7 @@ rulesets:
                         )])),
                     },
                 ),
-            ])),
+            ]),
             ..ConfigFile::default()
         };
 
@@ -153,7 +151,7 @@ rulesets:
       no-then:
     "#;
         let expected = ConfigFile {
-            rulesets: RulesetConfigs(HashMap::from([
+            rulesets: HashMap::from([
                 ("python-security".to_string(), RulesetConfig::default()),
                 ("c-best-practices".to_string(), RulesetConfig::default()),
                 (
@@ -185,7 +183,7 @@ rulesets:
                         )])),
                     },
                 ),
-            ])),
+            ]),
             ..ConfigFile::default()
         };
 
@@ -274,7 +272,7 @@ rulesets:
           - "py/insecure/**"
     "#;
         let expected = ConfigFile {
-            rulesets: RulesetConfigs(HashMap::from([(
+            rulesets: HashMap::from([(
                 "python-security".to_string(),
                 RulesetConfig {
                     paths: PathConfig::default(),
@@ -288,7 +286,7 @@ rulesets:
                         },
                     )])),
                 },
-            )])),
+            )]),
             ..ConfigFile::default()
         };
 
@@ -332,10 +330,7 @@ max-file-size-kb: 512
     "#;
 
         let expected = ConfigFile {
-            rulesets: RulesetConfigs(HashMap::from([(
-                "python-security".to_string(),
-                RulesetConfig::default(),
-            )])),
+            rulesets: HashMap::from([("python-security".to_string(), RulesetConfig::default())]),
             paths: PathConfig {
                 only: Some(vec!["py/**/foo/*.py".to_string()]),
                 ignore: Some(vec!["py/testing/*.py".to_string()]),

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -258,6 +258,39 @@ rulesets:
         assert!(res.is_err());
     }
 
+    // Cannot have repeated ruleset configurations.
+    #[test]
+    fn test_cannot_parse_ruleset_config_with_repeated_names() {
+        let data = r#"
+rulesets:
+  - go-best-practices
+  - go-security
+  - go-best-practices
+    "#;
+
+        let res = parse_config_file(data);
+        assert!(res.is_err());
+        let data = r#"
+rulesets:
+  go-best-practices:
+  go-security:
+  go-best-practices:
+    "#;
+
+        let res = parse_config_file(data);
+        assert!(res.is_err());
+
+        let data = r#"
+rulesets:
+  - go-best-practices:
+  - go-security:
+  - go-best-practices:
+    "#;
+
+        let res = parse_config_file(data);
+        assert!(res.is_err());
+    }
+
     // Rule definitions can be parsed.
     #[test]
     fn test_parse_rules() {

--- a/crates/cli/src/model.rs
+++ b/crates/cli/src/model.rs
@@ -1,3 +1,4 @@
 pub mod cli_configuration;
 pub mod config_file;
 pub mod datadog_api;
+mod serialization;

--- a/crates/cli/src/model/config_file.rs
+++ b/crates/cli/src/model/config_file.rs
@@ -1,35 +1,213 @@
+use std::collections::HashMap;
 use std::fmt;
+use std::fmt::Formatter;
 
 use serde;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+// Lists of directories and glob patterns to include/exclude from the analysis.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
+pub struct PathConfig {
+    // Analyze only these directories and patterns.
+    pub only: Option<Vec<String>>,
+    // Do not analyze any of these directories and patterns.
+    pub ignore: Option<Vec<String>>,
+}
+
+// Configuration for a single rule.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
+pub struct RuleConfig {
+    // Paths to include/exclude for this rule.
+    #[serde(flatten)]
+    pub paths: PathConfig,
+}
+
+// Configuration for a ruleset.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
+pub struct RulesetConfig {
+    // Paths to include/exclude for all rules in this ruleset.
+    #[serde(flatten)]
+    pub paths: PathConfig,
+    // Rule-specific configurations.
+    pub rules: Option<HashMap<String, RuleConfig>>,
+}
+
+// Holder for ruleset configurations, to aid in (de)serialization.
+#[derive(Serialize, Debug, PartialEq, Default)]
+pub struct RulesetConfigs(pub HashMap<String, RulesetConfig>);
 
 // the configuration file from the repository
-#[derive(Deserialize, Debug, Serialize, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
 pub struct ConfigFile {
-    pub rulesets: Vec<String>,
+    // Configurations for the rulesets.
+    pub rulesets: RulesetConfigs,
+    // Paths to include/exclude from analysis.
+    #[serde(flatten)]
+    pub paths: PathConfig,
+    // For backwards compatibility. Its content will be added to paths.ignore.
     #[serde(rename(serialize = "ignore-paths", deserialize = "ignore-paths"))]
     pub ignore_paths: Option<Vec<String>>,
+    // Ignore all the paths in the .gitignore file.
     #[serde(rename(serialize = "ignore-gitignore", deserialize = "ignore-gitignore"))]
     pub ignore_gitignore: Option<bool>,
+    // Analyze only files up to this size.
     #[serde(rename(serialize = "max-file-size-kb", deserialize = "max-file-size-kb"))]
     pub max_file_size_kb: Option<u64>,
 }
 
 impl fmt::Display for ConfigFile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let rules_string = self.rulesets.join(",");
-        let ignore_path_string = match &self.ignore_paths {
-            Some(i) => i.join(","),
-            None => "".to_string(),
-        };
-        write!(
-            f,
-            "rulesets: {}, ignore paths: {}, ignore .gitignore: {}",
-            rules_string,
-            ignore_path_string,
-            self.ignore_gitignore
-                .map(|v| v.to_string())
-                .unwrap_or("undefined".to_string())
-        )
+        write!(f, "{:?}", self)
+    }
+}
+
+// Used as an intermediate deserialization step when lists of maps are involved.
+struct NamedRulesetConfig {
+    pub name: String,
+    pub cfg: RulesetConfig,
+}
+
+// Special deserializer for RulesetConfigs.
+// For backwards compatibility, we want to support lists of strings and maps from name to ruleset
+// config. Also, to be forgiving of mistakes, we want to support lists of maps (see
+// NamedRulesetConfig's deserializer for more details).
+impl<'de> Deserialize<'de> for RulesetConfigs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RulesetConfigsVisitor {}
+        impl<'de> Visitor<'de> for RulesetConfigsVisitor {
+            type Value = RulesetConfigs;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str(
+                    "a list of strings, map of string to ruleset configuration, or list of maps",
+                )
+            }
+
+            // Deserialize a list using the NamedRulesetConfig deserializer.
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut out = RulesetConfigs(HashMap::new());
+                while let Some(rc) = seq.next_element::<NamedRulesetConfig>()? {
+                    out.0.insert(rc.name, rc.cfg);
+                }
+                Ok(out)
+            }
+
+            // Deserialize a map. The values are RulesetConfig.
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut out = RulesetConfigs(HashMap::new());
+                while let Some((k, v)) = map.next_entry::<String, RulesetConfig>()? {
+                    out.0.insert(k, v);
+                }
+                Ok(out)
+            }
+        }
+        deserializer.deserialize_any(RulesetConfigsVisitor {})
+    }
+}
+
+// Deserializer for NamedRulesetConfig.
+// This handles three cases:
+// 1. A string is deserialized as a RulesetConfig without options.
+// 2. A single-element map from a name to a RulesetConfig is converted to a NamedRulesetConfig.
+// 3. A map with more than 1 element is deserialized elementwise and its content populated into
+//    a NamedRulesetConfig.
+// The last case sounds weird, but is intended to account for the case where the user forgets
+// to indent the map.
+// We go through all this trouble for backwards compatibility: previous versions of the static
+// analyzer use a string list for the `rulesets` configuration field, but new versions want to
+// be able to use a map. Therefore, we need to be able to deserialize both. And we know that
+// users may make mistakes if they ever need to change from a string list to a map, so we try
+// hard to accommodate them.
+impl<'de> Deserialize<'de> for NamedRulesetConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NamedRulesetConfigVisitor {}
+        impl<'de> Visitor<'de> for NamedRulesetConfigVisitor {
+            type Value = NamedRulesetConfig;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str(
+                    "a string, ruleset configuration, or map from string to ruleset configuration",
+                )
+            }
+
+            // String. Build a NamedRulesetConfig without options.
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                self.visit_string(v.to_string())
+            }
+
+            // String. Build a NamedRulesetConfig without options.
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(NamedRulesetConfig {
+                    name: v,
+                    cfg: RulesetConfig::default(),
+                })
+            }
+
+            // Map. See the description above.
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut out = match map.next_entry::<String, RulesetConfig>()? {
+                    None => {
+                        return Err(Error::missing_field("name"));
+                    }
+                    Some((k, v)) => NamedRulesetConfig { name: k, cfg: v },
+                };
+                // If the user forgot to indent, we populate the object field by field.
+                while let Some(x) = map.next_key::<String>()? {
+                    match x.as_str() {
+                        "only" => {
+                            if out.cfg.paths.only.is_some() {
+                                return Err(Error::duplicate_field("only"));
+                            } else {
+                                out.cfg.paths.only = Some(map.next_value()?);
+                            }
+                        }
+                        "ignore" => {
+                            if out.cfg.paths.ignore.is_some() {
+                                return Err(Error::duplicate_field("ignore"));
+                            } else {
+                                out.cfg.paths.ignore = Some(map.next_value()?);
+                            }
+                        }
+                        "rules" => {
+                            if out.cfg.rules.is_some() {
+                                return Err(Error::duplicate_field("rules"));
+                            } else {
+                                out.cfg.rules = Some(map.next_value()?);
+                            }
+                        }
+                        "" => {
+                            // Ignore empty keys
+                        }
+                        otherwise => {
+                            return Err(Error::custom(format!("unknown field: {}", otherwise)));
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+        deserializer.deserialize_any(NamedRulesetConfigVisitor {})
     }
 }

--- a/crates/cli/src/model/config_file.rs
+++ b/crates/cli/src/model/config_file.rs
@@ -4,7 +4,7 @@ use serde;
 use serde::{Deserialize, Serialize};
 
 // the configuration file from the repository
-#[derive(Deserialize, Debug, Serialize)]
+#[derive(Deserialize, Debug, Serialize, PartialEq)]
 pub struct ConfigFile {
     pub rulesets: Vec<String>,
     #[serde(rename(serialize = "ignore-paths", deserialize = "ignore-paths"))]

--- a/crates/cli/src/model/config_file.rs
+++ b/crates/cli/src/model/config_file.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::fmt::Formatter;
+
+use crate::model::serialization::deserialize_rulesetconfigs;
 
 use serde;
-use serde::de::{Error, MapAccess, SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 // Lists of directories and glob patterns to include/exclude from the analysis.
 #[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
@@ -33,15 +33,12 @@ pub struct RulesetConfig {
     pub rules: Option<HashMap<String, RuleConfig>>,
 }
 
-// Holder for ruleset configurations, to aid in (de)serialization.
-#[derive(Serialize, Debug, PartialEq, Default)]
-pub struct RulesetConfigs(pub HashMap<String, RulesetConfig>);
-
 // the configuration file from the repository
 #[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
 pub struct ConfigFile {
     // Configurations for the rulesets.
-    pub rulesets: RulesetConfigs,
+    #[serde(deserialize_with = "deserialize_rulesetconfigs")]
+    pub rulesets: HashMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.
     #[serde(flatten)]
     pub paths: PathConfig,
@@ -59,155 +56,5 @@ pub struct ConfigFile {
 impl fmt::Display for ConfigFile {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-// Used as an intermediate deserialization step when lists of maps are involved.
-struct NamedRulesetConfig {
-    pub name: String,
-    pub cfg: RulesetConfig,
-}
-
-// Special deserializer for RulesetConfigs.
-// For backwards compatibility, we want to support lists of strings and maps from name to ruleset
-// config. Also, to be forgiving of mistakes, we want to support lists of maps (see
-// NamedRulesetConfig's deserializer for more details).
-impl<'de> Deserialize<'de> for RulesetConfigs {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct RulesetConfigsVisitor {}
-        impl<'de> Visitor<'de> for RulesetConfigsVisitor {
-            type Value = RulesetConfigs;
-
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                formatter.write_str(
-                    "a list of strings, map of string to ruleset configuration, or list of maps",
-                )
-            }
-
-            // Deserialize a list using the NamedRulesetConfig deserializer.
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let mut out = RulesetConfigs(HashMap::new());
-                while let Some(rc) = seq.next_element::<NamedRulesetConfig>()? {
-                    out.0.insert(rc.name, rc.cfg);
-                }
-                Ok(out)
-            }
-
-            // Deserialize a map. The values are RulesetConfig.
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let mut out = RulesetConfigs(HashMap::new());
-                while let Some((k, v)) = map.next_entry::<String, RulesetConfig>()? {
-                    out.0.insert(k, v);
-                }
-                Ok(out)
-            }
-        }
-        deserializer.deserialize_any(RulesetConfigsVisitor {})
-    }
-}
-
-// Deserializer for NamedRulesetConfig.
-// This handles three cases:
-// 1. A string is deserialized as a RulesetConfig without options.
-// 2. A single-element map from a name to a RulesetConfig is converted to a NamedRulesetConfig.
-// 3. A map with more than 1 element is deserialized elementwise and its content populated into
-//    a NamedRulesetConfig.
-// The last case sounds weird, but is intended to account for the case where the user forgets
-// to indent the map.
-// We go through all this trouble for backwards compatibility: previous versions of the static
-// analyzer use a string list for the `rulesets` configuration field, but new versions want to
-// be able to use a map. Therefore, we need to be able to deserialize both. And we know that
-// users may make mistakes if they ever need to change from a string list to a map, so we try
-// hard to accommodate them.
-impl<'de> Deserialize<'de> for NamedRulesetConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct NamedRulesetConfigVisitor {}
-        impl<'de> Visitor<'de> for NamedRulesetConfigVisitor {
-            type Value = NamedRulesetConfig;
-
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                formatter.write_str(
-                    "a string, ruleset configuration, or map from string to ruleset configuration",
-                )
-            }
-
-            // String. Build a NamedRulesetConfig without options.
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                self.visit_string(v.to_string())
-            }
-
-            // String. Build a NamedRulesetConfig without options.
-            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                Ok(NamedRulesetConfig {
-                    name: v,
-                    cfg: RulesetConfig::default(),
-                })
-            }
-
-            // Map. See the description above.
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let mut out = match map.next_entry::<String, RulesetConfig>()? {
-                    None => {
-                        return Err(Error::missing_field("name"));
-                    }
-                    Some((k, v)) => NamedRulesetConfig { name: k, cfg: v },
-                };
-                // If the user forgot to indent, we populate the object field by field.
-                while let Some(x) = map.next_key::<String>()? {
-                    match x.as_str() {
-                        "only" => {
-                            if out.cfg.paths.only.is_some() {
-                                return Err(Error::duplicate_field("only"));
-                            } else {
-                                out.cfg.paths.only = Some(map.next_value()?);
-                            }
-                        }
-                        "ignore" => {
-                            if out.cfg.paths.ignore.is_some() {
-                                return Err(Error::duplicate_field("ignore"));
-                            } else {
-                                out.cfg.paths.ignore = Some(map.next_value()?);
-                            }
-                        }
-                        "rules" => {
-                            if out.cfg.rules.is_some() {
-                                return Err(Error::duplicate_field("rules"));
-                            } else {
-                                out.cfg.rules = Some(map.next_value()?);
-                            }
-                        }
-                        "" => {
-                            // Ignore empty keys
-                        }
-                        otherwise => {
-                            return Err(Error::custom(format!("unknown field: {}", otherwise)));
-                        }
-                    }
-                }
-                Ok(out)
-            }
-        }
-        deserializer.deserialize_any(NamedRulesetConfigVisitor {})
     }
 }

--- a/crates/cli/src/model/config_file.rs
+++ b/crates/cli/src/model/config_file.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::model::serialization::deserialize_rulesetconfigs;
+use crate::model::serialization::{deserialize_ruleconfigs, deserialize_rulesetconfigs};
 
 use serde;
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,7 @@ pub struct RulesetConfig {
     #[serde(flatten)]
     pub paths: PathConfig,
     // Rule-specific configurations.
+    #[serde(default, deserialize_with = "deserialize_ruleconfigs")]
     pub rules: Option<HashMap<String, RuleConfig>>,
 }
 

--- a/crates/cli/src/model/serialization.rs
+++ b/crates/cli/src/model/serialization.rs
@@ -36,7 +36,9 @@ where
         {
             let mut out = HashMap::new();
             while let Some(rc) = seq.next_element::<NamedRulesetConfig>()? {
-                out.insert(rc.name, rc.cfg);
+                if out.insert(rc.name.clone(), rc.cfg).is_some() {
+                    return Err(Error::custom(format!("duplicate ruleset: {}", rc.name)));
+                }
             }
             Ok(out)
         }
@@ -48,7 +50,9 @@ where
         {
             let mut out = HashMap::new();
             while let Some((k, v)) = map.next_entry::<String, RulesetConfig>()? {
-                out.insert(k, v);
+                if out.insert(k.clone(), v).is_some() {
+                    return Err(Error::custom(format!("duplicate ruleset: {}", k)));
+                }
             }
             Ok(out)
         }

--- a/crates/cli/src/model/serialization.rs
+++ b/crates/cli/src/model/serialization.rs
@@ -1,0 +1,154 @@
+use crate::model::config_file::RulesetConfig;
+use serde::de::{Error, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Formatter;
+
+// Used as an intermediate deserialization step when lists of maps are involved.
+struct NamedRulesetConfig {
+    name: String,
+    cfg: RulesetConfig,
+}
+
+// Special deserializer for a RulesetConfig map.
+// For backwards compatibility, we want to support lists of strings and maps from name to ruleset
+// config. Also, to be forgiving of mistakes, we want to support lists of maps (see
+// NamedRulesetConfig's deserializer for more details).
+pub fn deserialize_rulesetconfigs<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, RulesetConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct RulesetConfigsVisitor {}
+    impl<'de> Visitor<'de> for RulesetConfigsVisitor {
+        type Value = HashMap<String, RulesetConfig>;
+
+        fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            formatter.write_str("a list of strings or map from string to ruleset configuration")
+        }
+
+        // Deserialize a list using the NamedRulesetConfig deserializer.
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut out = HashMap::new();
+            while let Some(rc) = seq.next_element::<NamedRulesetConfig>()? {
+                out.insert(rc.name, rc.cfg);
+            }
+            Ok(out)
+        }
+
+        // Deserialize a map. The values are RulesetConfig.
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut out = HashMap::new();
+            while let Some((k, v)) = map.next_entry::<String, RulesetConfig>()? {
+                out.insert(k, v);
+            }
+            Ok(out)
+        }
+    }
+    deserializer.deserialize_any(RulesetConfigsVisitor {})
+}
+
+// Deserializer for NamedRulesetConfig.
+// This handles three cases:
+// 1. A string is deserialized as a RulesetConfig without options.
+// 2. A single-element map from a name to a RulesetConfig is converted to a NamedRulesetConfig.
+// 3. A map with more than 1 element is deserialized elementwise and its content populated into
+//    a NamedRulesetConfig.
+// The last case sounds weird, but is intended to account for the case where the user forgets
+// to indent the map.
+// We go through all this trouble for backwards compatibility: previous versions of the static
+// analyzer use a string list for the `rulesets` configuration field, but new versions want to
+// be able to use a map. Therefore, we need to be able to deserialize both. And we know that
+// users may make mistakes if they ever need to change from a string list to a map, so we try
+// hard to accommodate them.
+impl<'de> Deserialize<'de> for NamedRulesetConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NamedRulesetConfigVisitor {}
+        impl<'de> Visitor<'de> for NamedRulesetConfigVisitor {
+            type Value = NamedRulesetConfig;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str(
+                    "a string, ruleset configuration, or map from string to ruleset configuration",
+                )
+            }
+
+            // String. Build a NamedRulesetConfig without options.
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                self.visit_string(v.to_string())
+            }
+
+            // String. Build a NamedRulesetConfig without options.
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(NamedRulesetConfig {
+                    name: v,
+                    cfg: RulesetConfig::default(),
+                })
+            }
+
+            // Map. See the description above.
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut out = match map.next_entry::<String, RulesetConfig>()? {
+                    None => {
+                        return Err(Error::missing_field("name"));
+                    }
+                    Some((k, v)) => NamedRulesetConfig { name: k, cfg: v },
+                };
+                // If the user forgot to indent, we populate the object field by field.
+                while let Some(x) = map.next_key::<String>()? {
+                    match x.as_str() {
+                        "only" => {
+                            if out.cfg.paths.only.is_some() {
+                                return Err(Error::duplicate_field("only"));
+                            } else {
+                                out.cfg.paths.only = Some(map.next_value()?);
+                            }
+                        }
+                        "ignore" => {
+                            if out.cfg.paths.ignore.is_some() {
+                                return Err(Error::duplicate_field("ignore"));
+                            } else {
+                                out.cfg.paths.ignore = Some(map.next_value()?);
+                            }
+                        }
+                        "rules" => {
+                            if out.cfg.rules.is_some() {
+                                return Err(Error::duplicate_field("rules"));
+                            } else {
+                                out.cfg.rules = Some(map.next_value()?);
+                            }
+                        }
+                        "" => {
+                            // Ignore empty keys
+                        }
+                        otherwise => {
+                            return Err(Error::custom(format!("unknown field: {}", otherwise)));
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+        deserializer.deserialize_any(NamedRulesetConfigVisitor {})
+    }
+}

--- a/misc/integration-test-js-ts.sh
+++ b/misc/integration-test-js-ts.sh
@@ -18,7 +18,6 @@ echo " - jsx-react" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - tsx-react" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - javascript-node-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - typescript-node-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
-echo " - javascript-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
 ./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
 


### PR DESCRIPTION
## What problem are you trying to solve?
We are going to enable and disable rules on a path/file pattern basis.

## What is your solution?
This PR updates the configuration file to accept the new format.

The new format is backwards compatible, so existing configurations will still work.

The new configuration directives are not implemented, so they won't work even if the user adds them.

## Alternatives considered

## What the reviewer should know
The documentation for the format will be updated when the functionality is enabled.