### PR TITLE
Filter files by size

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -1,7 +1,8 @@
 use cli::config_file::read_config_file;
 use cli::datadog_utils::get_rules_from_rulesets;
 use cli::file_utils::{
-    are_subdirectories_safe, filter_files_for_language, get_files, read_files_from_gitignore,
+    are_subdirectories_safe, filter_files_by_size, filter_files_for_language, get_files,
+    read_files_from_gitignore,
 };
 use cli::model::config_file::ConfigFile;
 use cli::rule_utils::{get_languages_for_rules, get_rulesets_from_file};
@@ -351,8 +352,10 @@ fn main() -> Result<()> {
         .unwrap()
         .as_secs();
 
+    let files_filtered_by_size = filter_files_by_size(&files_to_analyze, &configuration);
+
     for language in &languages {
-        let files_for_language = filter_files_for_language(&files_to_analyze, language);
+        let files_for_language = filter_files_for_language(&files_filtered_by_size, language);
 
         println!(
             "Analyzing {} {:?} files",

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -242,21 +242,22 @@ pub fn filter_files_by_size(files: &[PathBuf], configuration: &CliConfiguration)
         .iter()
         .filter(|f| {
             let metadata = fs::metadata(f);
-            let too_big = &metadata
+            let too_big = metadata
                 .as_ref()
                 .map(|x| x.len() > max_len_bytes)
                 .unwrap_or(false);
 
-            if configuration.use_debug {
+            if configuration.use_debug && too_big {
                 eprintln!(
-                    "File {} too big (size {} bytes, max size {} kb)",
+                    "File {} too big (size {} bytes, max size {} kb ({} bytes))",
                     f.display(),
                     &metadata.map(|x| x.len()).unwrap_or(0),
-                    configuration.max_file_size_kb
+                    configuration.max_file_size_kb,
+                    max_len_bytes
                 )
             }
 
-            f.is_file() && !*too_big
+            f.is_file() && !too_big
         })
         .cloned()
         .collect();


### PR DESCRIPTION
## What problem are you trying to solve?

We want to filter the larger files and avoid scanning files larger than a given size.

## What is your solution?

We already had the function `filter_files_by_size`. We just need to plumb it correctly. This PR correctly plugins the function in the pipeline.
