### PR TITLE
Running without static-analysis.datadog.yml file

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -363,7 +363,9 @@ fn main() -> Result<()> {
 
     for language in &languages {
         let files_for_language = filter_files_for_language(&files_to_analyze, language);
-
+        if files_for_language.is_empty() {
+            continue;
+        }
         // we only use the progress bar when the debug mode is not active, otherwise, it puts
         // too much information on the screen.
         let progress_bar = if !configuration.use_debug {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -361,7 +361,6 @@ fn main() -> Result<()> {
     let files_filtered_by_size = filter_files_by_size(&files_to_analyze, &configuration);
 
     for language in &languages {
-
         let files_for_language = filter_files_for_language(&files_filtered_by_size, language);
 
         if files_for_language.is_empty() {

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -163,13 +163,4 @@ mod tests {
         assert_eq!(get_datadog_site(true), STAGING_DATADOG_SITE);
         assert_eq!(get_datadog_site(false), DEFAULT_DATADOG_SITE);
     }
-
-    #[test]
-    fn test_get_default_rulesets() {
-        let default_ruleset =
-            get_all_default_rulesets(false).expect("get default rulesets from API");
-        assert!(default_ruleset.len() >= 24);
-        let rules_count: usize = default_ruleset.iter().map(|r| r.rules.len()).sum();
-        assert!(rules_count > 100);
-    }
 }

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -17,10 +17,6 @@ const DEFAULT_RULESETS_LANGAGES: &[&str] = &[
     "JAVASCRIPT",
     "KOTLIN",
     "PYTHON",
-    "RUBY",
-    "SWIFT",
-    "TYPESCRIPT",
-    "YAML",
 ];
 
 // Get all the rules from different rulesets from Datadog
@@ -69,7 +65,7 @@ pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
     let api_key = get_datadog_variable_value("API_KEY");
 
     let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}",
+        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false",
         site, ruleset_name
     );
 
@@ -172,5 +168,14 @@ mod tests {
     fn test_get_datadog_site() {
         assert_eq!(get_datadog_site(true), STAGING_DATADOG_SITE);
         assert_eq!(get_datadog_site(false), DEFAULT_DATADOG_SITE);
+    }
+
+    #[test]
+    fn test_get_default_rulesets() {
+        let default_ruleset =
+            get_all_default_rulesets(false).expect("get default rulesets from API");
+        assert!(default_ruleset.len() >= 24);
+        let rules_count: usize = default_ruleset.iter().map(|r| r.rules.len()).sum();
+        assert!(rules_count > 100);
     }
 }

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -9,7 +9,7 @@ use crate::model::datadog_api::{ApiResponse, ApiResponseDefaultRuleset};
 const STAGING_DATADOG_SITE: &str = "datad0g.com";
 const DEFAULT_DATADOG_SITE: &str = "datadoghq.com";
 
-const DEFAULT_RULESETS_LANGAGES: &[&str] = &[
+const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "CSHARP",
     "DOCKERFILE",
     "GO",
@@ -17,6 +17,7 @@ const DEFAULT_RULESETS_LANGAGES: &[&str] = &[
     "JAVASCRIPT",
     "KOTLIN",
     "PYTHON",
+    "TYPESCRIPT",
 ];
 
 // Get all the rules from different rulesets from Datadog
@@ -144,7 +145,7 @@ pub fn get_default_rulesets_name_for_language(
 /// Get all the default rulesets available at DataDog. Take all the language
 /// from `DEFAULT_RULESETS_LANGAGES` and get their rulesets
 pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
-    let rules: Vec<RuleSet> = DEFAULT_RULESETS_LANGAGES
+    let rules: Vec<RuleSet> = DEFAULT_RULESETS_LANGUAGES
         .iter()
         .flat_map(|language| {
             let ruleset_names =

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -6,6 +6,23 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ApiDefaultRulesetAttributes {
+    #[serde(rename = "rulesets")]
+    pub rulesets: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ApiDefaultRuleset {
+    pub id: String,
+    pub attributes: ApiDefaultRulesetAttributes,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ApiResponseDefaultRuleset {
+    pub data: ApiDefaultRuleset,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ApiResponseRuleTest {
     pub annotation_count: u32,
     pub filename: String,

--- a/misc/integration-test-docker.sh
+++ b/misc/integration-test-docker.sh
@@ -8,6 +8,17 @@ REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone https://github.com/juli1/dd-sa-dockerfile.git "${REPO_DIR}"
 
+echo "Try without the static-analysis.datadog.yml file"
+rm -f "${REPO_DIR}/static-analysis.datadog.yml"
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "fail to analyze docker repository"
+  exit 1
+fi
+
+echo "Try with the static-analysis.datadog.yml file"
+
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - docker-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 

--- a/misc/integration-test-docker.sh
+++ b/misc/integration-test-docker.sh
@@ -10,10 +10,19 @@ git clone https://github.com/juli1/dd-sa-dockerfile.git "${REPO_DIR}"
 
 echo "Try without the static-analysis.datadog.yml file"
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze docker repository"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
+
+echo "Found $RES errors on first run"
+
+if [ "$RES" -lt "12" ]; then
+  echo "not enough errors found without the static-analysis.datadog.yml file"
   exit 1
 fi
 
@@ -22,10 +31,19 @@ echo "Try with the static-analysis.datadog.yml file"
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - docker-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze docker repository"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+
+echo "Found $RES errors on first run"
+
+if [ "$RES" -lt "8" ]; then
+  echo "not enough errors found with the static-analysis.datadog.yml file"
   exit 1
 fi
 

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -10,10 +10,19 @@ git clone https://github.com/gothinkster/django-realworld-example-app.git "${REP
 
 # Test without the static-analysis.datadog.yml file
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze django repository"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
+
+echo "Found $RES errors on first run"
+
+if [ "$RES" -lt "18" ]; then
+  echo "not enough errors found"
   exit 1
 fi
 
@@ -25,10 +34,19 @@ echo " - python-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-django" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze django repository"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+
+echo "Found $RES errors on second run"
+
+if [ "$RES" -lt "18" ]; then
+  echo "not enough errors found"
   exit 1
 fi
 

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -8,6 +8,17 @@ REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone https://github.com/gothinkster/django-realworld-example-app.git "${REPO_DIR}"
 
+# Test without the static-analysis.datadog.yml file
+rm -f "${REPO_DIR}/static-analysis.datadog.yml"
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "fail to analyze django repository"
+  exit 1
+fi
+
+# Test with the static-analysis.datadog.yml file
+
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to run the analyzer with the default rules, regardless if there is a `static-analysis.datadog.yml` or not.

## What is your solution?

Load all the default rules at startup-time by using the default ruleset endpoint and run the tool on all of them.
Also display a disclaimer if no file is passed and invite the user to read our documentation.


## Testing

 - [x] Add integration tests
 - [x] Add unit tests 
