### PR TITLE
Parse improperly formatted YAML for the ruleset config.

### DIFF
--- a/crates/cli/src/model/serialization.rs
+++ b/crates/cli/src/model/serialization.rs
@@ -1,6 +1,7 @@
 use crate::model::config_file::{RuleConfig, RulesetConfig};
+use serde;
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
-use serde::Deserializer;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
@@ -31,9 +32,9 @@ where
             A: SeqAccess<'de>,
         {
             let mut out = HashMap::new();
-            while let Some(name) = seq.next_element::<String>()? {
-                if out.insert(name.clone(), RulesetConfig::default()).is_some() {
-                    return Err(Error::custom(format!("duplicate ruleset: {}", name)));
+            while let Some(nrc) = seq.next_element::<NamedRulesetConfig>()? {
+                if out.insert(nrc.name.clone(), nrc.cfg).is_some() {
+                    return Err(Error::custom(format!("duplicate ruleset: {}", nrc.name)));
                 }
             }
             Ok(out)
@@ -54,6 +55,126 @@ where
         }
     }
     deserializer.deserialize_any(RulesetConfigsVisitor {})
+}
+
+/// Holder for ruleset configurations specified in lists.
+struct NamedRulesetConfig {
+    name: String,
+    cfg: RulesetConfig,
+}
+
+/// Special deserializer for ruleset list items.
+///
+/// As we've changed the format, we are going to get a mixture of old format configurations,
+/// new format configurations, and configurations that have been converted but have syntax errors.
+///
+/// To be friendly, we try extra hard to parse the configuration file the user intended, even in
+/// the face of syntax errors:
+///
+/// This is the modern syntax:
+/// ```yaml
+/// rulesets:
+///   ruleset1:
+///   ruleset2:
+///     ignore:
+///       - "foo"
+///   ruleset3:
+/// ```
+/// This is the old syntax:
+/// ```yaml
+/// rulesets:
+///   - ruleset1
+///   - ruleset2
+///   - ruleset3
+/// ```
+/// This is an invalid syntax that we try to parse here:
+/// ```yaml
+/// rulesets:
+///   - ruleset1
+///   - ruleset2:
+///       ignore:
+///         - "foo"
+///   - ruleset3:
+///     ignore:
+///       - "foo"
+/// ```
+/// (Note the indentation for the difference between the last two rulesets.)
+impl<'de> Deserialize<'de> for NamedRulesetConfig {
+    fn deserialize<D>(deserializer: D) -> Result<NamedRulesetConfig, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NamedRulesetConfigVisitor {}
+        impl<'de> Visitor<'de> for NamedRulesetConfigVisitor {
+            type Value = NamedRulesetConfig;
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("a string or ruleset configuration")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                self.visit_string(v.to_string())
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(NamedRulesetConfig {
+                    name: v,
+                    cfg: RulesetConfig::default(),
+                })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut out = match map.next_entry::<String, RulesetConfig>()? {
+                    None => {
+                        return Err(Error::missing_field("name"));
+                    }
+                    Some((k, v)) => NamedRulesetConfig { name: k, cfg: v },
+                };
+                // If the user forgot to indent, we populate the object field by field.
+                while let Some(x) = map.next_key::<String>()? {
+                    match x.as_str() {
+                        "only" => {
+                            if out.cfg.paths.only.is_some() {
+                                return Err(Error::duplicate_field("only"));
+                            } else {
+                                out.cfg.paths.only = Some(map.next_value()?);
+                            }
+                        }
+                        "ignore" => {
+                            if !out.cfg.paths.ignore.is_empty() {
+                                return Err(Error::duplicate_field("ignore"));
+                            } else {
+                                out.cfg.paths.ignore = map.next_value()?;
+                            }
+                        }
+                        "rules" => {
+                            if !out.cfg.rules.is_empty() {
+                                return Err(Error::duplicate_field("rules"));
+                            } else {
+                                out.cfg.rules = map.next_value()?;
+                            }
+                        }
+                        "" => {
+                            // Ignore empty keys
+                        }
+                        otherwise => {
+                            return Err(Error::custom(format!("unknown field: {}", otherwise)));
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+        deserializer.deserialize_any(NamedRulesetConfigVisitor {})
+    }
 }
 
 /// Deserializer for a `RuleConfig` map which rejects duplicate rules.


### PR DESCRIPTION
## What problem are you trying to solve?

In the first approach to this, we decided to only read the ruleset config as a list of strings or as a map ("proper YAML"). However, we have observed that many people, when they convert their old configurations, build it as lists of maps.

In fact, when people write up examples of configurations from scratch, they often do that, and they are not even converting old configurations.

This suggests that we really should read these configurations and parse them as the user expects, even if they are not syntactically proper.

## What is your solution?

This PR changes the parser so it will be more forgiving and accept lists of maps as valid configuration.

Before, only these were accepted:

```yaml
rulesets:
  - rs_one
  - rs_two
```
```yaml
rulesets:
  rs_one:
  rs_two:
    only:
      - foo
```

Now, these will be accepted as well:

```
rulesets:
  - rs_one:
    only:
      - foo
  - rs_two:
      only:
        - foo
```

These will still not be accepted (note the absent colons at the end of the ruleset names):

```
rulesets:
  - rs_one
    only:
      - foo
  - rs_two
      only:
        - foo
```

## Alternatives considered

The alternative is to not accept the configuration, but that didn't work.

## What the reviewer should know
