### PR TITLE
[STAL-1418] Violation fingerprints

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -369,7 +369,7 @@ fn main() -> Result<()> {
     // check if we do a diff-aware scan
     let diff_aware_parameters: Option<DiffAwareData> = if diff_aware_requested {
         match configuration.generate_diff_aware_request_data() {
-            Ok(params) => match get_diff_aware_information(params) {
+            Ok(params) => match get_diff_aware_information(&params) {
                 Ok(d) => {
                     if configuration.use_debug {
                         println!(
@@ -388,7 +388,7 @@ fn main() -> Result<()> {
                     Some(d)
                 }
                 Err(e) => {
-                    eprintln!("diff aware not enabled (error when receiving diff-aware data from Datadog), proceeding with full scan.");
+                    eprintln!("diff aware not enabled (error when receiving diff-aware data from Datadog with config hash {}, sha {}), proceeding with full scan.", &params.config_hash, &params.sha);
                     if configuration.use_debug {
                         eprintln!("error when trying to enabled diff-aware scanning: {:?}", e);
                     }

--- a/crates/cli/src/constants.rs
+++ b/crates/cli/src/constants.rs
@@ -4,4 +4,7 @@ pub static DATADOG_HEADER_APP_KEY: &str = "dd-application-key";
 pub static DATADOG_HEADER_API_KEY: &str = "dd-api-key";
 pub static HEADER_CONTENT_TYPE: &str = "Content-Type";
 pub static HEADER_CONTENT_TYPE_APPLICATION_JSON: &str = "application/json";
+pub static SARIF_PROPERTY_DATADOG_FINGERPRINT: &str = "DATADOG_FINGERPRINT";
+pub static SARIF_PROPERTY_SHA: &str = "SHA";
+
 pub static DEFAULT_MAX_FILE_SIZE_KB: u64 = 200;

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -177,7 +177,7 @@ pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
 /// to analyze and the base sha (e.g. the sha we used in the past to find
 /// the list of files). Those information will later be added in the
 /// results.
-pub fn get_diff_aware_information(arguments: DiffAwareRequestArguments) -> Result<DiffAwareData> {
+pub fn get_diff_aware_information(arguments: &DiffAwareRequestArguments) -> Result<DiffAwareData> {
     let site = get_datadog_site(false);
     let app_key = get_datadog_variable_value("APP_KEY")?;
     let api_key = get_datadog_variable_value("API_KEY")?;
@@ -195,10 +195,10 @@ pub fn get_diff_aware_information(arguments: DiffAwareRequestArguments) -> Resul
             request_type: "diff_aware_request".to_string(),
             attributes: DiffAwareRequestDataAttributes {
                 id: request_uuid.clone(),
-                repository_url: arguments.repository_url,
-                sha: arguments.sha,
-                branch: arguments.branch,
-                config_hash: arguments.config_hash,
+                repository_url: arguments.repository_url.clone(),
+                sha: arguments.sha.clone(),
+                branch: arguments.branch.clone(),
+                config_hash: arguments.config_hash.clone(),
             },
         },
     };

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -318,11 +318,12 @@ pub fn filter_files_by_diff_aware_info(
 ///  SHA2(<file-location-in-repository> - <characters-in-directory> - <content-of-code-line> - <number of characters in line>)
 pub fn get_fingerprint_for_violation(
     violation: &Violation,
-    repository_root: &str,
-    file: &str,
+    repository_root: &Path,
+    file: &Path,
     use_debug: bool,
 ) -> Option<String> {
-    let path = Path::new(repository_root).join(file);
+    let path = repository_root.join(file);
+    let filename = file.to_str().unwrap_or("");
     if !path.exists() || !path.is_file() {
         return None;
     }
@@ -337,8 +338,8 @@ pub fn get_fingerprint_for_violation(
                     .collect::<String>();
                 let hash_content = format!(
                     "{}-{}-{}-{}",
-                    file,
-                    file.len(),
+                    filename,
+                    filename.len(),
                     line_content_stripped,
                     line_content_stripped.len()
                 );
@@ -410,8 +411,8 @@ mod tests {
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
             &violation,
-            &directory_string,
-            "resources/test/gitignore/test1",
+            Path::new(directory_string.as_str()),
+            Path::new("resources/test/gitignore/test1"),
             false,
         );
         assert!(!fingerprint.is_none());
@@ -422,8 +423,8 @@ mod tests {
 
         let fingerprint_unknown_file = get_fingerprint_for_violation(
             &violation,
-            &directory_string,
-            "path/does/not/exists",
+            Path::new(directory_string.as_str()),
+            Path::new("path/does/not/exists"),
             false,
         );
         assert!(fingerprint_unknown_file.is_none());

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -331,7 +331,10 @@ pub fn get_fingerprint_for_violation(
     match read_to_string(&path) {
         Ok(file_content) => match file_content.lines().nth(line - 1) {
             Some(line_content) => {
-                let line_content_stripped = line_content.replace(' ', "");
+                let line_content_stripped = line_content
+                    .chars()
+                    .filter(|ch| !ch.is_whitespace())
+                    .collect::<String>();
                 let hash_content = format!(
                     "{}-{}-{}-{}",
                     file,

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -348,8 +348,8 @@ fn generate_results(
 
                 let fingerprint_option = get_fingerprint_for_violation(
                     violation,
-                    options.repository_directory.as_str(),
-                    rule_result.filename.as_str(),
+                    Path::new(options.repository_directory.as_str()),
+                    Path::new(rule_result.filename.as_str()),
                     options.debug,
                 );
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::rc::Rc;
+
 use anyhow::Result;
 use base64::Engine;
 use git2::{BlameOptions, Repository};
@@ -9,17 +13,15 @@ use serde_sarif::sarif::{
     Tool, ToolBuilder, ToolComponent, ToolComponentBuilder,
 };
 
-use std::collections::BTreeMap;
-use std::path::Path;
-use std::rc::Rc;
-
-use crate::model::datadog_api::DiffAwareData;
 use kernel::model::rule::RuleSeverity;
 use kernel::model::{
     common::PositionBuilder,
     rule::{Rule, RuleResult},
     violation::{Edit, EditType},
 };
+
+use crate::file_utils::get_fingerprint_for_violation;
+use crate::model::datadog_api::DiffAwareData;
 
 trait IntoSarif {
     type SarifType;
@@ -37,6 +39,7 @@ pub struct SarifGenerationOptions {
     pub debug: bool,
     pub config_digest: String,
     pub diff_aware_parameters: Option<DiffAwareData>,
+    pub repository_directory: String,
 }
 
 impl IntoSarif for &Rule {
@@ -342,10 +345,26 @@ fn generate_results(
                     violation.start.line as usize,
                     &options,
                 );
-                let partial_fingerprints: BTreeMap<String, String> = match sha_option {
-                    Some(s) => BTreeMap::from([("SHA".to_string(), s)]),
-                    None => BTreeMap::new(),
-                };
+
+                let fingerprint_option = get_fingerprint_for_violation(
+                    violation,
+                    options.repository_directory.as_str(),
+                    rule_result.filename.as_str(),
+                    options.debug,
+                );
+
+                let partial_fingerprints: BTreeMap<String, String> =
+                    match (sha_option, fingerprint_option) {
+                        (Some(sha), Some(fp)) => BTreeMap::from([
+                            ("SHA".to_string(), sha),
+                            ("FINGERPRINT".to_string(), fp),
+                        ]),
+                        (None, Some(fp)) => {
+                            BTreeMap::from([("DATADOG_FINGERPRINT".to_string(), fp)])
+                        }
+                        (Some(sha), None) => BTreeMap::from([("SHA".to_string(), sha)]),
+                        _ => BTreeMap::new(),
+                    };
 
                 Ok(result_builder
                     .clone()
@@ -402,6 +421,7 @@ pub fn generate_sarif_report(
         debug,
         config_digest,
         diff_aware_parameters,
+        repository_directory: directory.clone(),
     };
 
     let run = RunBuilder::default()
@@ -417,16 +437,19 @@ pub fn generate_sarif_report(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+
     use assert_json_diff::assert_json_eq;
+    use serde_json::{from_str, Value};
+    use valico::json_schema;
+
     use kernel::model::{
         common::{Language, PositionBuilder},
         rule::{RuleBuilder, RuleCategory, RuleResultBuilder, RuleSeverity, RuleType},
         violation::{EditBuilder, EditType, FixBuilder as RosieFixBuilder, ViolationBuilder},
     };
-    use serde_json::{from_str, Value};
-    use std::collections::HashMap;
-    use valico::json_schema;
+
+    use super::*;
 
     /// Validate JSON data against the SARIF schema
     fn validate_data(v: &Value) -> bool {

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -357,7 +357,7 @@ fn generate_results(
                     match (sha_option, fingerprint_option) {
                         (Some(sha), Some(fp)) => BTreeMap::from([
                             ("SHA".to_string(), sha),
-                            ("FINGERPRINT".to_string(), fp),
+                            ("DATADOG_FINGERPRINT".to_string(), fp),
                         ]),
                         (None, Some(fp)) => {
                             BTreeMap::from([("DATADOG_FINGERPRINT".to_string(), fp)])

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -13,6 +13,7 @@ use serde_sarif::sarif::{
     Tool, ToolBuilder, ToolComponent, ToolComponentBuilder,
 };
 
+use crate::constants::{SARIF_PROPERTY_DATADOG_FINGERPRINT, SARIF_PROPERTY_SHA};
 use kernel::model::rule::RuleSeverity;
 use kernel::model::{
     common::PositionBuilder,
@@ -356,13 +357,15 @@ fn generate_results(
                 let partial_fingerprints: BTreeMap<String, String> =
                     match (sha_option, fingerprint_option) {
                         (Some(sha), Some(fp)) => BTreeMap::from([
-                            ("SHA".to_string(), sha),
-                            ("DATADOG_FINGERPRINT".to_string(), fp),
+                            (SARIF_PROPERTY_SHA.to_string(), sha),
+                            (SARIF_PROPERTY_DATADOG_FINGERPRINT.to_string(), fp),
                         ]),
                         (None, Some(fp)) => {
-                            BTreeMap::from([("DATADOG_FINGERPRINT".to_string(), fp)])
+                            BTreeMap::from([(SARIF_PROPERTY_DATADOG_FINGERPRINT.to_string(), fp)])
                         }
-                        (Some(sha), None) => BTreeMap::from([("SHA".to_string(), sha)]),
+                        (Some(sha), None) => {
+                            BTreeMap::from([(SARIF_PROPERTY_SHA.to_string(), sha)])
+                        }
                         _ => BTreeMap::new(),
                     };
 


### PR DESCRIPTION
## What problem are you trying to solve?

We want to add a unique fingerprint to each violation in the sarif file. 

## What is your solution?

This is reported in the `partialFingerprint` in the SARIF file. This hash contains the content of the file and some other meta information to attempt to make it unique.


## Testing and Performance

Ran the tool on a large repo and disable the generation of fingerprints. Run on 1630 files for Go and YAML. The objective is to see the performance impact.

To disable fingerprinting, we just added `let fingerprint_option = None;` in the `sarif_utils.rs`

Then, built each version with `cargo build -r`

### Without fingerprints

```
Found 1500 violation(s) in 1630 file(s) using 105 rule(s) within 12 sec(s)
./target/release/datadog-static-analyzer --directory  --format sarif --output  57.55s user 5.52s system 435% cpu 14.486 total
```

### With fingerprints

```
Found 1500 violation(s) in 1630 file(s) using 105 rule(s) within 12 sec(s)
./target/release/datadog-static-analyzer --directory  --format sarif --output  56.25s user 5.35s system 447% cpu 13.756 total
```