### PR TITLE
Upgrade tree-sitter to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lto = true
 [workspace.dependencies]
 anyhow = "1"
 base64 = "0.21.2"
-itertools = "0.11.0"
+itertools = "0.12.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 derive_builder = "0.12"

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -17,8 +17,7 @@ sha2 = { workspace = true }
 deno_core = "0.196.0"
 lazy_static = "1.4.0"
 serde_v8 = "0.107.0"
-tree-sitter = "0.20.10"
-tree-sitter-swift = "=0.3.6"
+tree-sitter = "0.21.0"
 
 [build-dependencies]
 cc="*"

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -186,6 +186,15 @@ fn main() {
             files: vec!["scanner.cc".to_string()],
             cpp: true,
         },
+        TreeSitterProject {
+            name: "tree-sitter-swift".to_string(),
+            compilation_unit: "tree-sitter-swift".to_string(),
+            repository: "https://github.com/juli1/tree-sitter-swift.git".to_string(),
+            build_dir: "src".into(),
+            commit_hash: "e173c5fbe928dd95165c016e72c17fa2e97c5369".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:


### PR DESCRIPTION
## What problem are you trying to solve?

We are using an old version of tree-sitter. We should upgrade to the latest.

## What is your solution?

Upgrade tree-sitter.

## Alternatives considered

Do not upgrade

## What the reviewer should know

To upgrade Swift, we had to download the generated parser from their [GitHub action](https://github.com/alex-pinkus/tree-sitter-swift/actions/runs/7620932442) and publish them on a [repository](https://github.com/juli1/tree-sitter-swift). This is because the tree-sitter-swift maintainers [do not want](https://github.com/juli1/tree-sitter-swift) to publish the `parser.c` and `scanner.c`. We opened a [bug report](https://github.com/alex-pinkus/tree-sitter-swift/issues/362) to ask them to do so but in the meantime, we have a workaround.