### PR TITLE
Fix Stella console

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -564,6 +564,13 @@ function visit(node, filename, code) {
 }
         "#;
 
+        let rule_code_number = r#"
+function visit(node, filename, code) {
+    foo = 42;
+    console.log(foo);
+}
+        "#;
+
         let c = r#"
 def foo(arg1):
     pass
@@ -648,6 +655,21 @@ def foo(arg1):
 
         assert!(rule_execution.execution_error.is_none());
         assert_eq!(rule_execution.output.unwrap(), "null\nundefined");
+
+        // execute with a number
+        rule.code = rule_code_number.to_string();
+        let rule_execution = execute_rule(
+            &rule,
+            nodes.clone(),
+            "foo.py".to_string(),
+            AnalysisOptions {
+                use_debug: true,
+                log_output: true,
+            },
+        );
+
+        assert!(rule_execution.execution_error.is_none());
+        assert_eq!(rule_execution.output.unwrap(), "42");
     }
 
     // change the type of the edit, which should trigger a serialization issue

--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -536,6 +536,7 @@ def foo(arg1):
         let rule_code = r#"
 function visit(node, filename, code) {
     console.log("bla");
+    console.log(node.captures["name"].astType);
 }
         "#;
 
@@ -576,7 +577,7 @@ def foo(arg1):
         );
         assert_eq!("myrule", rule_execution.rule_name);
         assert!(rule_execution.execution_error.is_none());
-        assert_eq!("bla", rule_execution.output.unwrap())
+        assert_eq!("bla\nidentifier", rule_execution.output.unwrap())
     }
 
     // change the type of the edit, which should trigger a serialization issue

--- a/crates/static-analysis-kernel/src/analysis/js/stella.js
+++ b/crates/static-analysis-kernel/src/analysis/js/stella.js
@@ -22,6 +22,11 @@ function StellaError(startLine, startCol, endLine, endCol, message, severity, ca
 function StellaConsole(startLine, startCol, endLine, endCol, message, severity, category) {
   this.lines = [];
   this.log = function (message) {
+    if (Array.isArray(message) || typeof message === "object") {
+      this.lines.push(JSON.stringify(message));
+      return;
+    }
+
     this.lines.push("" + message);
   }
 }

--- a/crates/static-analysis-kernel/src/analysis/js/stella.js
+++ b/crates/static-analysis-kernel/src/analysis/js/stella.js
@@ -22,7 +22,7 @@ function StellaError(startLine, startCol, endLine, endCol, message, severity, ca
 function StellaConsole(startLine, startCol, endLine, endCol, message, severity, category) {
   this.lines = [];
   this.log = function (message) {
-    this.lines.push(message);
+    this.lines.push("" + message);
   }
 }
 


### PR DESCRIPTION
## What problem are you trying to solve?

When in a rule, we do `console.log(var)`, it logs nothing, which is a bad user experience. We should log a string.

## What is your solution?

Force the `console.log` to log a string by prefixing the entry in the logs with `""`.

## Alternatives considered

Adding another dependency by using the `deno` console. I prefer not to introduce another dependency for now, this should do the work, especially since output is for debug only.