### PR TITLE
Allow the GitLab pipeline to override the `DataDog/images` branch used

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,10 @@ trigger_internal_image:
     - main
   trigger:
     project: DataDog/images
-    branch: master
+    branch: ${DD_IMAGES_BRANCH}
     strategy: depend
   variables:
+    DD_IMAGES_BRANCH: master
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: images
     IMAGE_VERSION: current
     IMAGE_NAME: datadog-static-analyzer


### PR DESCRIPTION
## What problem are you trying to solve?
We're currently unable to test builds of our internal staging build's Docker image without merging those changes into the `DataDog/images` main branch. We should be able to do this from a non-main branch.

## What is your solution?
Add `DD_IMAGES_BRANCH` variable, which maintains the same default as before, but can be overridden by a pipeline trigger.

## Alternatives considered

## What the reviewer should know
