### PR TITLE
[STAL-1457] add better handling of git SHA finding

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,13 @@
+## Generating the SARIF output file is slow
+ 
+This can occur is you are using the option `-g` and generate a SARIF file. The `-g` option
+attempts to get the last commit for a file/line. In some case, git can be very slow and the
+generation of the file can take a long time.
+
+If you try to generate a SARIF file with the `-g` and have a slow file generation, consider
+trying without the `-g` flag.
+
+
+## I do not see an answer to my question
+
+Please ask your question in the [discussions section](https://github.com/DataDog/datadog-static-analyzer/discussions).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ datadog-static-analyzer is the static analyzer engine for Datadog [static analys
 datadog-static-analyzer --directory /path/to/directory --output report.csv --format csv
 ```
 
+If you encounter an issue, read the [Frequently Asked Questions](FAQ.md) first, it may contain
+the solution to your problem.
+
 ### Advanced Usage
 
 You can choose the rules to use to scan your repository by creating a `static-analysis.datadog.yml` file.
@@ -130,7 +133,7 @@ The static analyzer can be configured using a `static-analysis.datadog.yml` file
 at the root directory of the repository. This is a YAML file with the following entries:
 
  - `rulesets`: the rulesets to use (see [Datadog Documentation](https://docs.datadoghq.com/continuous_integration/static_analysis/rules) for a full list)
- - `ignore-paths`: list of paths (glob) to ignore
+ - `ignore`: list of paths (glob) to ignore
  - `ignore-gitignore`: a boolean to indicate if files in `.gitignore` should be ignored (default: `false`)
  - `max-file-size-kb`: all files above this size are ignored (default: 200KB)
 
@@ -142,7 +145,7 @@ rulesets:
   - python-code-style
   - python-best-practices
   - python-inclusive
-ignore-paths:
+ignore:
   - tests
 ignore-gitignore: false
 max-file-size-kb: 100

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,7 @@ serde-sarif = { workspace = true }
 sha2 = { workspace = true }
 uuid = { workspace = true }
 # other
-git2 = "0.18.0"
+git2 = "0.18.2"
 glob-match = "0.2.1"
 percent-encoding = "2.3.1"
 prettytable-rs = "0.10.0"

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -225,7 +225,9 @@ fn get_level_from_severity(severity: RuleSeverity) -> String {
     .to_string()
 }
 
-// Get the sha for the line if we have the repository.
+/// Get the latest commit id/sha for a file/line. This is done to know the latest SHA for a line with
+/// a violation. Note that this function performs a `git blame` and can take significant time.
+/// Take the file/line of the SHA to get and return the SHA if found.
 fn get_sha_for_line(
     filename: &str,
     line: usize,

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -251,7 +251,9 @@ fn get_sha_for_line(
                 }
                 return Some(commit_id);
             } else {
-                eprintln!("hunk not found");
+                if generation_options.debug {
+                    eprintln!("hunk not found");
+                }
                 return None;
             }
         }


### PR DESCRIPTION
## What problem are you trying to solve?

Internal users mentioned that the [SARIF generation](https://dd.slack.com/archives/C066HQ6K8BX/p1709221692867909) can be very long.

## What is your solution?

It is not a solution of the problem, rather a code cleanup and documenting the issue.

1. Cleaning the code and removing code that does potential unsafe `unwrap`
2. Printing mode debug information that could help diagnose the issue
3. Adding a FAQ section to inform users

We still need to see potential solution for this problem