### PR TITLE
Avoid making copies of the configuration file for the path restrictions

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -248,7 +248,7 @@ fn main() -> Result<()> {
 
     // if there is a configuration file, we load the rules from it. But it means
     // we cannot have the rule parameter given.
-    if let Some(conf) = configuration_file {
+    if let Some(conf) = &configuration_file {
         use_configuration_file = true;
         ignore_gitignore = conf.ignore_gitignore.unwrap_or(false);
         if rules_file.is_some() {
@@ -262,8 +262,8 @@ fn main() -> Result<()> {
         path_restrictions = PathRestrictions::from_ruleset_configs(&conf.rulesets);
 
         // copy the only and ignore paths from the configuration file
-        path_config.ignore.extend(conf.paths.ignore);
-        path_config.only = conf.paths.only;
+        path_config.ignore.extend(conf.paths.ignore.to_owned());
+        path_config.only = conf.paths.only.to_owned();
 
         // Get the max file size from the configuration or default to the default constant.
         max_file_size_kb = conf.max_file_size_kb.unwrap_or(DEFAULT_MAX_FILE_SIZE_KB)

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 
 /// represents the CLI configuration
 #[derive(Clone)]
-pub struct CliConfiguration {
+pub struct CliConfiguration<'a> {
     pub use_debug: bool,
     pub use_configuration_file: bool,
     pub ignore_gitignore: bool,
@@ -22,12 +22,12 @@ pub struct CliConfiguration {
     pub output_file: String,
     pub num_cpus: usize, // of cpus to use for parallelism
     pub rules: Vec<Rule>,
-    pub path_restrictions: PathRestrictions,
+    pub path_restrictions: PathRestrictions<'a>,
     pub max_file_size_kb: u64,
     pub use_staging: bool,
 }
 
-impl CliConfiguration {
+impl<'a> CliConfiguration<'a> {
     /// Generate a digest to include in SARIF files to indicate what configuration and rules were used
     /// to run the analysis. To compute the digest, we take the attributes that are important to
     /// run and replicate the analysis such as the ignored paths and rules.


### PR DESCRIPTION
Instead, keep a reference to the values in the configuration file.

## What problem are you trying to solve?

## What is your solution?

## Alternatives considered

## What the reviewer should know
