### PR TITLE
Add a schema-version field to the configuration file JSON Schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All the rules can be found on the [Datadog documentation](https://docs.datadoghq
 Example of YAML file
 
 ```yaml
+schema-version: v1
 rulesets:
   - python-code-style
   - python-best-practices
@@ -141,6 +142,7 @@ at the root directory of the repository. This is a YAML file with the following 
 Example of configuration:
 
 ```yaml
+schema-version: v1
 rulesets:
   - python-code-style
   - python-best-practices

--- a/schema/examples/invalid/invalid-version.yml
+++ b/schema/examples/invalid/invalid-version.yml
@@ -1,0 +1,5 @@
+schema-version: v0
+rulesets:
+  - python-best-practices
+  - java-best-practices
+  - python-security

--- a/schema/examples/valid/arguments.yml
+++ b/schema/examples/valid/arguments.yml
@@ -1,3 +1,4 @@
+schema-version: v1
 rulesets:
   - lorem_ipsum:
     ignore:

--- a/schema/examples/valid/complex1.yml
+++ b/schema/examples/valid/complex1.yml
@@ -1,3 +1,4 @@
+schema-version: v1
 rulesets:
   - python-best-practices
   - go-best-practices:

--- a/schema/examples/valid/complex2.yml
+++ b/schema/examples/valid/complex2.yml
@@ -1,3 +1,4 @@
+schema-version: v1
 rulesets:
   - python-best-practices
   - java-best-practices:

--- a/schema/examples/valid/extensions.yml
+++ b/schema/examples/valid/extensions.yml
@@ -1,5 +1,6 @@
 # Additional fields not handled by the schema are accepted.
 # (Additional field names do NOT have to start with x-. This is done for tests only.)
+schema-version: v1
 rulesets:
   - java-best-practices:
     x-ruleset-field: abc

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "schema-version": {
+      "type": "string",
+      "default": "v1",
+      "enum": ["v1"]
+    },
     "rulesets": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## What problem are you trying to solve?
Future versions of the configuration file format may not be backwards compatible, so we need a reliable way to tell that a configuration file is from the future.

## What is your solution?
A `schema-version` field. This field can only take the value `"v1"`, and it is optional for backwards compatibility with existing configurations: if absent, `"v1"` is assumed.

In future versions of the JSON schema, this field will be mandatory.

## Alternatives considered

## What the reviewer should know
