### PR TITLE
[STAL-1496] add option to fail if there is any violation

### DIFF
--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -61,6 +61,20 @@ pub enum RuleSeverity {
     None,
 }
 
+impl TryFrom<&str> for RuleSeverity {
+    type Error = &'static str;
+
+    fn try_from(s: &str) -> Result<Self, &'static str> {
+        match s.to_lowercase().as_str() {
+            "error" => Ok(RuleSeverity::Error),
+            "warning" => Ok(RuleSeverity::Warning),
+            "notice" => Ok(RuleSeverity::Notice),
+            "none" => Ok(RuleSeverity::None),
+            _ => Err("unknown severity"),
+        }
+    }
+}
+
 impl fmt::Display for RuleSeverity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -50,7 +50,7 @@ if [ "$RES" -lt "18" ]; then
 fi
 
 # Test that --fail-on-any-violation returns a non-zero return code
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
 
 if [ $? -eq 0 ]; then
   echo "static analyzer reports 0 when it should not"

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -27,7 +27,6 @@ if [ "$RES" -lt "18" ]; then
 fi
 
 # Test with the static-analysis.datadog.yml file
-
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
@@ -47,6 +46,14 @@ echo "Found $RES errors on second run"
 
 if [ "$RES" -lt "18" ]; then
   echo "not enough errors found"
+  exit 1
+fi
+
+# Test that --fail-on-any-violation returns a non-zero return code
+./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation
+
+if [ $? -eq 0 ]; then
+  echo "static analyzer reports 0 when it should not"
   exit 1
 fi
 


### PR DESCRIPTION
## What problem are you trying to solve?

The problem is reported by @yoannmoinet: we want to have an option to exit a non-zero code if there is at least one violation. 

## What is your solution?

We offer the option for different severity.

- `--fail-on-any-violation=<list-of-severities>` fail if there is at least one violation with a severity from the list of `<list-of-severities>`


## Testing

Added unit tests for the counting as well as an integration tests.

See below for manual testing.


Incorrect severity

```
datadog-static-analyzer --directory /Users/julien.delange/git/rosie-tests --output /tmp/plop.plop --fail-on-any-violation=none,warning.notice,error        14:02:18
thread 'main' panicked at crates/bins/src/bin/datadog-static-analyzer.rs:208:48:
cannot map severity: "unknown severity"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Option with correct severities

```
$ datadog-static-analyzer --directory /Users/julien.delange/git/rosie-tests --output /tmp/plop.plop --fail-on-any-violation=none,warning,notice,error        
...
Found 8 violation(s) in 8 file(s) using 126 rule(s) within 0 sec(s)
$ echo $? 
1
```

Removing the option

```
datadog-static-analyzer --directory /Users/julien.delange/git/rosie-tests --output /tmp/plop.plop  
Configuration
...
Found 8 violation(s) in 8 file(s) using 126 rule(s) within 1 sec(s)
$ echo $?
0
```