### PR TITLE
feat(kernel): add support for ConfigFile serialization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Debug executable 'datadog-static-analyzer-server'",
+      "name": "Debug 'datadog-static-analyzer-server'",
       "cargo": {
         "args": [
           "build",
@@ -21,6 +21,25 @@
       },
       "args": ["-p", "9090", "-e"],
       "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Tests in Kernel",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--lib",
+          "--package=static-analysis-kernel"
+        ],
+        "filter": {
+          "name": "static-analysis-kernel",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}/crates/static-analysis-kernel"
     }
   ]
 }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,6 +9,7 @@ deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno auth
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 globset,https://crates.io/crates/globset,MIT,Copyright (c) 2015 Andrew Gallant
 governor,https://github.com/boinkor-net/governor,MIT,Copyright (c) 2023 Andreas Fuchs
+indexmap,https://github.com/indexmap-rs/indexmap,MIT and Apache-2.0,Copyright (c) 2016-2017 bluss
 indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers
 lazy_static,https://crates.io/crates/lazy_static,MIT,Copyright 2016 lazy-static.rs Developers

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -21,7 +21,7 @@ sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 serde_v8 = "0.107.0"
 tree-sitter = "0.21.0"
-indexmap = "2.2"
+indexmap = { version = "2.2", features = ["serde"] }
 
 [build-dependencies]
 cc = "*"

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -21,6 +21,7 @@ sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 serde_v8 = "0.107.0"
 tree-sitter = "0.21.0"
+indexmap = "2.2"
 
 [build-dependencies]
-cc="*"
+cc = "*"

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -1025,28 +1025,6 @@ rulesets:
     }
 
     #[test]
-    fn test_rulesetconfigs_map() {
-        let mut map = IndexMap::new();
-        map.insert("rule-security", "value2");
-        map.insert("rules", "value3");
-        map.insert("only", "value1");
-
-        let s = serde_yaml::to_string(&map).unwrap();
-        assert_eq!(s, "rule-security: value2\nrules: value3\nonly: value1\n");
-    }
-
-    #[test]
-    fn test_rulesetconfigs_map2() {
-        let mut map = std::collections::BTreeMap::new();
-        map.insert("rule-security", "value2");
-        map.insert("rules", "value3");
-        map.insert("only", "value1");
-
-        let s = serde_yaml::to_string(&map).unwrap();
-        assert_ne!(s, "rule-security: value2\nrules: value3\nonly: value1\n");
-    }
-
-    #[test]
     fn test_serialize_rulesetconfigs_multiple() {
         let mut rulesets = IndexMap::new();
         rulesets.insert("java-1".to_string(), RulesetConfig::default());

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use sequence_trie::SequenceTrie;
 use serde::de::{Error, MapAccess, SeqAccess, Unexpected, Visitor};
-use serde::ser::SerializeMap;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -186,14 +186,9 @@ pub fn serialize_rulesetconfigs<S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_seq(Some(rulesets.len()))?;
 
-    // we want to always serialize the rulesets in the same order
-    let mut keys = rulesets.keys().collect::<Vec<_>>();
-    keys.sort();
-
-    for key in keys {
-        let value = rulesets.get(key).unwrap();
+    for (key, value) in rulesets {
         if !value.rules.is_empty() || value.paths.only.is_some() || !value.paths.ignore.is_empty() {
-            // we must ensure that this is the first being serialized, so we'll use a IndexMap crate
+            // we must ensure that this is the first being serialized, so we'll use an IndexMap
             let mut map = IndexMap::new();
             map.insert(key.as_str(), CompatMapValue::Null);
             // manually adding elements

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -11,6 +11,10 @@ use crate::config_file::{
     get_default_schema_version,
 };
 
+fn is_default<T: Default + PartialEq>(val: &T) -> bool {
+    *val == T::default()
+}
+
 // A pattern for an 'only' or 'ignore' field. The 'glob' field contains a precompiled glob pattern,
 // while the 'prefix' field contains a path prefix.
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
@@ -24,9 +28,10 @@ pub struct PathPattern {
 #[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
 pub struct PathConfig {
     // Analyze only these directories and patterns.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub only: Option<Vec<PathPattern>>,
     // Do not analyze any of these directories and patterns.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub ignore: Vec<PathPattern>,
 }
 
@@ -52,7 +57,11 @@ pub struct RulesetConfig {
     #[serde(flatten)]
     pub paths: PathConfig,
     // Rule-specific configurations.
-    #[serde(default, deserialize_with = "deserialize_ruleconfigs")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_ruleconfigs",
+        skip_serializing_if = "is_default"
+    )]
     pub rules: HashMap<String, RuleConfig>,
 }
 
@@ -68,10 +77,10 @@ pub struct ConfigFile {
     #[serde(flatten)]
     pub paths: PathConfig,
     // Ignore all the paths in the .gitignore file.
-    #[serde(rename = "ignore-gitignore")]
+    #[serde(rename = "ignore-gitignore", skip_serializing_if = "Option::is_none")]
     pub ignore_gitignore: Option<bool>,
     // Analyze only files up to this size.
-    #[serde(rename = "max-file-size-kb")]
+    #[serde(rename = "max-file-size-kb", skip_serializing_if = "Option::is_none")]
     pub max_file_size_kb: Option<u64>,
 }
 

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config_file::{
     deserialize_ruleconfigs, deserialize_rulesetconfigs, deserialize_schema_version,
-    get_default_schema_version,
+    get_default_schema_version, serialize_rulesetconfigs,
 };
 
 fn is_default<T: Default + PartialEq>(val: &T) -> bool {
@@ -46,7 +46,7 @@ pub struct RuleConfig {
     // Paths to include/exclude for this rule.
     #[serde(flatten)]
     pub paths: PathConfig,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub arguments: HashMap<String, ArgumentValues>,
 }
 
@@ -72,6 +72,7 @@ pub struct ConfigFile {
     #[serde(rename = "schema-version")]
     pub schema_version: String,
     // Configurations for the rulesets.
+    #[serde(serialize_with = "serialize_rulesetconfigs")]
     pub rulesets: HashMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.
     #[serde(flatten)]

--- a/crates/static-analysis-kernel/src/path_restrictions.rs
+++ b/crates/static-analysis-kernel/src/path_restrictions.rs
@@ -1,3 +1,5 @@
+use indexmap::IndexMap;
+
 use crate::model::config_file::{PathConfig, RulesetConfig};
 use std::collections::HashMap;
 
@@ -18,7 +20,7 @@ struct RestrictionsForRuleset {
 
 impl PathRestrictions {
     /// Builds a `PathRestrictions` from a map of ruleset configurations.
-    pub fn from_ruleset_configs(rulesets: &HashMap<String, RulesetConfig>) -> PathRestrictions {
+    pub fn from_ruleset_configs(rulesets: &IndexMap<String, RulesetConfig>) -> PathRestrictions {
         let mut out = PathRestrictions::default();
         for (name, ruleset_config) in rulesets {
             let mut restriction = RestrictionsForRuleset {
@@ -76,12 +78,12 @@ pub fn is_allowed_by_path_config(paths: &PathConfig, file_name: &str) -> bool {
 mod tests {
     use crate::model::config_file::{PathConfig, RuleConfig, RulesetConfig};
     use crate::path_restrictions::PathRestrictions;
-    use std::collections::HashMap;
 
     // By default, everything is included.
     #[test]
     fn empty_restrictions() {
-        let config = HashMap::from([("defined-ruleset".to_string(), RulesetConfig::default())]);
+        let config =
+            indexmap::IndexMap::from([("defined-ruleset".to_string(), RulesetConfig::default())]);
         let restrictions = PathRestrictions::from_ruleset_configs(&config);
         assert!(&restrictions.rule_applies("defined-ruleset/any-rule", "src/main.go"));
         assert!(restrictions.rule_applies("other-ruleset/any-rule", "src/main.go"));
@@ -90,7 +92,7 @@ mod tests {
     // Can include and exclude rulesets.
     #[test]
     fn ruleset_restrictions() {
-        let config = HashMap::from([
+        let config = indexmap::IndexMap::from([
             (
                 "ignores-test".to_string(),
                 RulesetConfig {
@@ -98,7 +100,7 @@ mod tests {
                         ignore: vec!["test/**".to_string().into()],
                         only: None,
                     },
-                    rules: HashMap::new(),
+                    rules: indexmap::IndexMap::new(),
                 },
             ),
             (
@@ -108,7 +110,7 @@ mod tests {
                         ignore: vec![],
                         only: Some(vec!["*/code/**".to_string().into()]),
                     },
-                    rules: HashMap::new(),
+                    rules: indexmap::IndexMap::new(),
                 },
             ),
             (
@@ -118,7 +120,7 @@ mod tests {
                         ignore: vec!["*/code/**".to_string().into()],
                         only: Some(vec!["test/**".to_string().into()]),
                     },
-                    rules: HashMap::new(),
+                    rules: indexmap::IndexMap::new(),
                 },
             ),
         ]);
@@ -140,11 +142,11 @@ mod tests {
     // Can include and exclude individual rules.
     #[test]
     fn rule_restrictions() {
-        let config = HashMap::from([(
+        let config = indexmap::IndexMap::from([(
             "a-ruleset".to_string(),
             RulesetConfig {
                 paths: PathConfig::default(),
-                rules: HashMap::from([
+                rules: indexmap::IndexMap::from([
                     (
                         "ignores-test".to_string(),
                         RuleConfig {
@@ -198,14 +200,14 @@ mod tests {
     // Can combine inclusion and exclusions for rules and rulesets.
     #[test]
     fn ruleset_and_rule_restrictions() {
-        let config = HashMap::from([(
+        let config = indexmap::IndexMap::from([(
             "only-test".to_string(),
             RulesetConfig {
                 paths: PathConfig {
                     only: Some(vec!["test/**".to_string().into()]),
                     ignore: vec![],
                 },
-                rules: HashMap::from([(
+                rules: indexmap::IndexMap::from([(
                     "ignores-code".to_string(),
                     RuleConfig {
                         paths: PathConfig {
@@ -235,7 +237,7 @@ mod tests {
     // Can do prefix and glob pattern matching.
     #[test]
     fn prefix_and_glob_matching() {
-        let config = HashMap::from([
+        let config = indexmap::IndexMap::from([
             (
                 "only-test-starstar-foo-glob".to_string(),
                 RulesetConfig {


### PR DESCRIPTION
## What problem are you trying to solve?

I was trying to serialize a ConfigFile instance and expected to get a valid YAML file. Unfortunately, the serialization for the rulesets was not implemented resulting in an invalid YAML according to the schema of our configuration file.

## What is your solution?

This PR adds support for proper serialization, ignoring both `Option::None` and some default values. This helps to avoid having values showing `null`, `{}` or `[]`

## Alternatives considered

## What the reviewer should know

Added a few tests for the new functionality and a vscode debug configuration to help debugging the tests, if needed.

Also, I added a new crate called [indexmap](https://crates.io/crates/indexmap), which was needed to keep the insertion order of the keys in the maps. This is critical for serialization purposes as the `rulesets` array has a weird convention where the first key must be the ruleset name with a null value.
