### PR TITLE
Display a nicer error message for configuration file errors

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -261,7 +261,16 @@ fn main() -> Result<()> {
     }
 
     let configuration_file: Option<ConfigFile> =
-        read_config_file(directory_to_analyze.as_str()).unwrap();
+        match read_config_file(directory_to_analyze.as_str()) {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                eprintln!(
+                    "Error reading configuration file from {}:\n  {}",
+                    directory_to_analyze, err
+                );
+                exit(1)
+            }
+        };
     let mut rules: Vec<Rule> = Vec::new();
     let mut path_restrictions = PathRestrictions::default();
     let mut argument_provider = ArgumentProvider::new();


### PR DESCRIPTION
## What problem are you trying to solve?
Configuration error messages look exactly like "something went horribly wrong" error messages.

## What is your solution?
Display a slightly friendlier message.

## Alternatives considered
In the future we may try to have messages that explain what went wrong in simpler words.

## What the reviewer should know
