### PR TITLE
[STAL-1362] add ruby in default languages

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -474,6 +474,7 @@ fn main() -> Result<()> {
         );
     }
 
+    let mut number_of_rules_used = 0;
     // Finally run the analysis
     for language in &languages {
         let files_for_language = filter_files_for_language(&files_to_analyze, language);
@@ -500,6 +501,8 @@ fn main() -> Result<()> {
                     .context("cannot convert to rule internal")
             })
             .collect::<Result<Vec<_>>>()?;
+
+        number_of_rules_used += rules_for_language.len();
 
         println!(
             "Analyzing {} {:?} files using {} rules",
@@ -575,7 +578,7 @@ fn main() -> Result<()> {
         "Found {} violation(s) in {} file(s) using {} rule(s) within {} sec(s)",
         nb_violations,
         total_files_analyzed,
-        configuration.rules.len(),
+        number_of_rules_used,
         end_timestamp - start_timestamp
     );
 

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -26,6 +26,7 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "JAVASCRIPT",
     "KOTLIN",
     "PYTHON",
+    "RUBY",
     "TYPESCRIPT",
 ];
 


### PR DESCRIPTION
## What problem are you trying to solve?

Add ruby as a default language so it's being picked up when we launch the tool without any ruleset.

## What is your solution?

Add the language in the default languages

## What the reviewer should know?

We are also adding the accurate number of rules used. If rules for a language not used was loaded before, it was counting towards the total number of rules used. We now count the exact number of rules used during the scan.