### PR TITLE
Fix check for ignore-gitignore.

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -319,7 +319,7 @@ fn main() -> Result<()> {
         .extend(ignore_paths_from_options.iter().map(|p| p.clone().into()));
 
     // ignore all directories that are in gitignore
-    if !ignore_gitignore {
+    if ignore_gitignore {
         let paths_from_gitignore = read_files_from_gitignore(directory_to_analyze.as_str())
             .expect("error when reading gitignore file");
         path_config


### PR DESCRIPTION
The check was reversed: `ignore-gitignore` being true means that all the paths from `.gitignore` are added to the `ignore` list. With the current check, the logic was reversed.

## What problem are you trying to solve?

## What is your solution?

## Alternatives considered

## What the reviewer should know
