### PR TITLE
[STAL-1557] add documentation for go

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/file_context/go.rs
+++ b/crates/static-analysis-kernel/src/analysis/file_context/go.rs
@@ -101,6 +101,17 @@ import (
         };
 
         assert_eq!((&(file_context_go).packages).len(), 3);
+        assert!(
+            (&(file_context_go)
+                .packages
+                .contains(&"math/rand".to_string()))
+        );
+        assert!((&(file_context_go).packages.contains(&"fmt".to_string())));
+        assert!(
+            (&(file_context_go)
+                .packages
+                .contains(&"crypto/rand".to_string()))
+        );
         assert_eq!((&(file_context_go).packages_aliased).len(), 5);
         assert_eq!(
             (file_context_go).packages_aliased.get("crand1").unwrap(),
@@ -113,6 +124,10 @@ import (
         assert_eq!(
             (file_context_go).packages_aliased.get("foo").unwrap(),
             "fmt"
+        );
+        assert_eq!(
+            (file_context_go).packages_aliased.get("rand").unwrap(),
+            "math/rand"
         );
     }
 }

--- a/doc/go.md
+++ b/doc/go.md
@@ -1,0 +1,42 @@
+## Go Support
+
+
+### Helpers
+
+#### Packages and Aliases
+
+Consider the following code:
+
+```go
+import (
+	"fmt"
+
+	fmt2 "fmt"
+)
+
+
+```
+
+The `query.context.packages` contains the list of packages being imported. In the code above, it will contain a single element: `"fmt"`
+
+The `query.context.packages_aliased` contains a map of the packages being imported with their aliases. If a package is not aliased, it will just contain it's value. For the code above, the map contains the following key/value:
+ - "fmt" -> "fmt"
+ - "fmt2" -> "fmt"
+
+
+Let's now consider another code
+
+```go
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+```
+
+- `query.context.packages` will contain the values `errors`, `fmt` and `net/http`
+- `query.context.packages_aliased` will contain the following values
+  - `errors` -> `errors`
+  - `fmt` -> `fmt`
+  - `http` -> `net/http`
+


### PR DESCRIPTION
## What problem are you trying to solve?

Adding documentation for package alias

## What is your solution?

Add a directory `doc` and a file per language to release language-specific information.
This PR started with a file `go.md`