### PR TITLE
Fix leftover legacy field `ignore-paths` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ rulesets:
   - python-code-style
   - python-best-practices
   - python-inclusive
-ignore-paths:
+ignore:
   - tests
 ```
 


### PR DESCRIPTION
## What problem are you trying to solve?
An `ignore-paths` that was forgotten in the README.md.

## What is your solution?
Change it to `ignore`.

## Alternatives considered
Not changing it to `ignore`.

## What the reviewer should know
I decided to change it to `ignore`.