### PR TITLE
[STAL-1575] Fingerprint improvements

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -313,7 +313,7 @@ pub fn get_fingerprint_for_violation(
                     .filter(|ch| !ch.is_whitespace())
                     .collect::<String>();
                 let hash_content = format!(
-                    "{}-{}-{}-{}-{}",
+                    "{}|{}|{}|{}|{}",
                     rule_name,
                     filename,
                     filename.len(),
@@ -396,7 +396,7 @@ mod tests {
         assert!(!fingerprint.is_none());
         assert_eq!(
             fingerprint.unwrap(),
-            "4c5987c7fe4b561923265bf911650d25d255a3cbc0e9894f553ccc704f691c9f".to_string()
+            "882d2eca8a353641ecfc71d4befb5dcb115a05b543dce6b7fa8a55cce62982db".to_string()
         );
 
         let fingerprint_unknown_file = get_fingerprint_for_violation(
@@ -414,6 +414,8 @@ mod tests {
     #[test]
     fn get_fingerprint_different_by_rule() {
         let d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = "resources/test/gitignore/test1";
+
         let violation = Violation {
             start: Position { line: 10, col: 1 },
             end: Position { line: 12, col: 1 },
@@ -423,27 +425,28 @@ mod tests {
             fixes: vec![],
         };
         let directory_string = d.into_os_string().into_string().unwrap();
+
         let fingerprint1 = get_fingerprint_for_violation(
-            "my_rule".to_string(),
+            "rule1".to_string(),
             &violation,
             Path::new(directory_string.as_str()),
-            Path::new("resources/test/gitignore/test1"),
+            Path::new(path),
             false,
         )
         .unwrap();
         let fingerprint2 = get_fingerprint_for_violation(
-            "my_rule".to_string(),
+            "rule1".to_string(),
             &violation,
             Path::new(directory_string.as_str()),
-            Path::new("resources/test/gitignore/test1"),
+            Path::new(path),
             false,
         )
         .unwrap();
         let fingerprint3 = get_fingerprint_for_violation(
-            "my_rule2".to_string(),
+            "rule2".to_string(),
             &violation,
             Path::new(directory_string.as_str()),
-            Path::new("resources/test/gitignore/test1"),
+            Path::new(path),
             false,
         )
         .unwrap();

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -458,6 +458,7 @@ fn generate_results(
                 };
 
                 let fingerprint_option = get_fingerprint_for_violation(
+                    rule_result.rule_name().to_string(),
                     violation,
                     Path::new(options.repository_directory.as_str()),
                     Path::new(rule_result.file_path()),

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -100,7 +100,7 @@ fn main() {
             name: "tree-sitter-java".to_string(),
             compilation_unit: "tree-sitter-java".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-java.git".to_string(),
-            commit_hash: "2b57cd9541f9fd3a89207d054ce8fbe72657c444".to_string(),
+            commit_hash: "5e62fbb519b608dfd856000fdc66536304c414de".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,


### PR DESCRIPTION
## What problem are you trying to solve?

The fingerprint relies only on the content of the file and line. If two violations from two different rules put a warning on the same line, they have the same fingerprint.

## What is your solution?

Add the rule name in the fingerprint so that if we have two rules on the same line, they will have another fingerprint.