### PR TITLE
Fix build

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -98,7 +98,7 @@ pub fn execute_rule(
                 );
             }
 
-            let _ = mutex.lock();
+            let _unused = mutex.lock();
             // notify the main thread we are done with the execution
             cvar.notify_one();
         });


### PR DESCRIPTION
## What problem are you trying to solve?

The build [fails](https://github.com/DataDog/datadog-static-analyzer/actions/runs/8387920499/job/22971079786) because a new version of the rust compiler (`1.77.0`) was published and brings more warning

## What is your solution?

Fix the build
