### PR TITLE
[STAL-1522] add instructions to troubleshoot diff-aware

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -432,6 +432,9 @@ fn main() -> Result<()> {
             },
             Err(e) => {
                 eprintln!("diff aware not enabled (unable to generate diff-aware request data), proceeding with full scan.");
+                eprintln!("Make sure the user running the scan owns the repository (use git config --global --add safe.directory <repo-path> if needed)");
+                eprintln!("You can run the analyzer with --debug true to get more details about the error");
+                eprintln!("Proceeding with full scan");
 
                 if configuration.use_debug {
                     eprintln!("error when trying to enabled diff-aware scanning: {:?}", e);

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -176,7 +176,7 @@ pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
 ///
 /// If we can do a diff-aware scan, we will then receive the list of files
 /// to analyze and the base sha (e.g. the sha we used in the past to find
-/// the list of files). Those information will later be added in the
+/// the list of files). This information will later be added in the
 /// results.
 pub fn get_diff_aware_information(arguments: &DiffAwareRequestArguments) -> Result<DiffAwareData> {
     let site = get_datadog_site(false);

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -68,12 +68,16 @@ impl CliConfiguration {
     /// we need, we return an error.
     pub fn generate_diff_aware_request_data(&self) -> anyhow::Result<DiffAwareRequestArguments> {
         let config_hash = self.generate_diff_aware_digest();
+
         let repository = Repository::init(&self.source_directory)?;
-        let repository_url = repository
-            .find_remote("origin")?
-            .url()
-            .unwrap_or("")
-            .to_string();
+        let remote = repository.find_remote("origin")?;
+        let repository_url_option = remote.url();
+
+        if repository_url_option.is_none() {
+            return Err(anyhow!("cannot get the repository origin URL"));
+        }
+
+        let repository_url = repository_url_option.unwrap().to_string();
 
         // let's get the latest commit
         let head = repository.head()?;


### PR DESCRIPTION
## What problem are you trying to solve?

If a scan is a diff-aware scan, the user running the scan must be the same user as the one owning the repository. Otherwise, `libgit2` fails to get the repository information.

## What is your solution?

Give clear information if the diff-aware fails in the command and add more documentation.