### PR TITLE
[STAL-1493] Cache results of HTTP requests

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -41,3 +41,4 @@ uuid,https://crates.io/crates/uuid,MIT,Copyright 2018 The Uuid Developers
 valico,https://github.com/s-panferov/valico,MIT,Copyright (c) 2014 Stanislav Panferov
 vectorscan,https://github.com/VectorCamp/vectorscan,BSD-3-Clause,Copyright (c) 2020 VectorCamp PC
 walkdir,https://github.com/BurntSushi/walkdir,MIT,Copyright (c) 2015 Andrew Gallant
+xxhash-rust,https://github.com/DoumanAsh/xxhash-rust,BSL-1.0,Copyright (c) 2003-Present The original authors

--- a/crates/secrets-core/Cargo.toml
+++ b/crates/secrets-core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 default = ["validator-http"]
-validator-http = ["governor", "ureq", "url"]
+validator-http = ["governor", "ureq", "url", "xxhash-rust"]
 
 [dependencies]
 bstr = "1.9.1"
@@ -16,6 +16,7 @@ thiserror = "1.0.57"
 ureq = { version = "2.9.6", default-features = false, features = ["tls"], optional = true }
 url = { version = "2.5.0", optional = true }
 vectorscan = { path = "../vectorscan" }
+xxhash-rust = {  version = "0.8.10", features = ["xxh3"], optional = true }
 
 [dev-dependencies]
 httpmock = { version = "0.7.0", default-features = false }


### PR DESCRIPTION
## What problem are you trying to solve?
The HTTP validator makes duplicate requests, even if we already know if a given text is a valid or invalid secret.

## What is your solution?
* Cache the results of HTTP validation when possible. This cache is shared amongst all threads.
* The essential properties of each request are hashed and used as a 128 bit key. By using a hash as a key instead of plaintext, we avoid storing potential secrets in memory longer than necessary.
* Multiple threads could be racing on the same request, so at every return point, the cached value is used (or freshly stored). When a thread times out due to its retry limit, no result is cached.

## Alternatives considered


## What the reviewer should know
* `xxhash-rust` was chosen for low lines of code, no dependencies, and the ability to generate a 128-bit hash. A hash larger than 64 bits is desirable because we never store the actual secret in memory (and thus can't compare equality in case of a hash collision)