### PR TITLE
Override a rule's severity and category when specified in the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ The map in the `rules` field uses the rule's name as its key, and the values are
 
 - `ignore` (optional) a list of path prefixes and glob patterns to ignore _for this rule_. This rule will not be evaluated for any files that match any of the entries in the `ignore` list.
 - `only`: (optional) a list of path prefixes and glob patterns to analyze _for this rule_. If `only` is specified, this rule will only be evaluated for files that match one of the entries.
+- `severity`: (optional) if provided, override the severity of violations produced by this rule. The valid severities are `ERROR`, `WARNING`, `NOTICE`, and `NONE`.
+- `category`: (optional) if provided, override this rule's category. The valid categories are `BEST_PRACTICES`, `CODE_STYLE`, `ERROR_PRONE`, `PERFORMANCE`, and `SECURITY`.
 - `arguments`: (optional) a map of values for the rule's arguments.
 
 The map in the `arguments` field uses an argument's name as its key, and the values are either strings or maps:
@@ -176,6 +178,10 @@ rulesets:
     rules:
       # Special configuration for the `python-best-practices/no-generic-exception` rule.
       no-generic-exception:
+        # Treat violations of this rule as errors (normally "notice").
+        severity: ERROR
+        # Classify violations of this rule under the "code style" category.
+        category: CODE_STYLE
         # Only apply this rule to files under the `src/new-code` subtree.
         only:
           - src/new-code
@@ -224,6 +230,8 @@ rulesets:
       - imported/**/new/**
     rules:
       max-function-lines:
+        severity: WARNING
+        category: PERFORMANCE
         ignore:
           - src/new-code
           - src/new/*.gen.py

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -462,7 +462,7 @@ impl<'de> Deserialize<'de> for ArgumentValues {
     }
 }
 
-/// Deserializer for a `RuleConfig` map which rejects duplicate rules.
+/// Deserializer for a `RuleCategory` which rejects the 'unknown' option.
 pub fn deserialize_category<'de, D>(deserializer: D) -> Result<Option<RuleCategory>, D::Error>
 where
     D: Deserializer<'de>,

--- a/crates/static-analysis-kernel/src/lib.rs
+++ b/crates/static-analysis-kernel/src/lib.rs
@@ -3,4 +3,5 @@ pub mod config_file;
 pub mod constants;
 pub mod model;
 pub mod path_restrictions;
+pub mod rule_overrides;
 pub mod utils;

--- a/crates/static-analysis-kernel/src/rule_overrides.rs
+++ b/crates/static-analysis-kernel/src/rule_overrides.rs
@@ -1,0 +1,52 @@
+use crate::model::config_file::ConfigFile;
+use crate::model::rule::{RuleCategory, RuleSeverity};
+use std::collections::HashMap;
+
+/// User-provided overrides for rule definitions.
+#[derive(Default)]
+pub struct RuleOverrides {
+    severities: HashMap<String, RuleSeverity>,
+    categories: HashMap<String, RuleCategory>,
+}
+
+impl RuleOverrides {
+    // Reads the overrides from the configuration file.
+    pub fn from_config_file(cfg: &ConfigFile) -> Self {
+        let severities: HashMap<String, RuleSeverity> = cfg
+            .rulesets
+            .iter()
+            .flat_map(|(rs_name, cfg)| {
+                cfg.rules.iter().filter_map(move |(rule_name, rule)| {
+                    rule.severity
+                        .as_ref()
+                        .map(|sev| (format!("{}/{}", rs_name, rule_name), *sev))
+                })
+            })
+            .collect();
+        let categories: HashMap<String, RuleCategory> = cfg
+            .rulesets
+            .iter()
+            .flat_map(|(rs_name, cfg)| {
+                cfg.rules.iter().filter_map(move |(rule_name, rule)| {
+                    rule.category
+                        .as_ref()
+                        .map(|cat| (format!("{}/{}", rs_name, rule_name), *cat))
+                })
+            })
+            .collect();
+        RuleOverrides {
+            severities,
+            categories,
+        }
+    }
+
+    // Returns the overridden severity for the given rule name, or the original severity if no override exists.
+    pub fn severity(&self, rule_name: &str, original: RuleSeverity) -> RuleSeverity {
+        *self.severities.get(rule_name).unwrap_or(&original)
+    }
+
+    // Returns the overridden category for the given rule name, or the original category if no override exists.
+    pub fn category(&self, rule_name: &str, original: RuleCategory) -> RuleCategory {
+        *self.categories.get(rule_name).unwrap_or(&original)
+    }
+}


### PR DESCRIPTION
## What problem are you trying to solve?
Sometimes users want to change the severity or category of a violation.

## What is your solution?
Users can specify per-rule severities and categories and we use those when specified.

## Alternatives considered

## What the reviewer should know
