### PR TITLE
fix(ra): fix rust-analyzer for vs code users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "rust-analyzer.cargo.allFeatures": false,
+  "rust-analyzer.showUnlinkedFileNotification": false
+}


### PR DESCRIPTION
## What problem are you trying to solve?

With the introduction of `vectorscan` the [rust-analyzer extension](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) which is the main LS extension for Rust in VS Code, stopped working. 

Even if users would follow the [build instructions](https://github.com/DataDog/datadog-static-analyzer/tree/main/crates/vectorscan-sys) provided in the repo, the analyzer would fail to compile, leading to it not working.

The main issue with this is that devs would have it more difficult to get build errors at development time.

## What is your solution?

The solution is to use a hidden flag: `rust-analyzer.cargo.allFeatures` and set it to false. This, in conjuction with having the proper tools `boost, cmake and ragel` installed, does the trick.


## What the reviewer should know

I also added this other flag: `rust-analyzer.showUnlinkedFileNotification` and set it to false, as from time to time the rust analyzer is throwing a false positive causing a warning to appear in the IDE, which is annoying.


IDE-2628