### PR TITLE
[STAL-1529] Enable secret validation for integration testing

### DIFF
--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -750,7 +750,6 @@ mod tests {
             ValidationStatus::Unvalidated,
             Position { line: 1, col: 24 },
             Position { line: 1, col: 64 },
-            "detected-secret-that-is-stored-as-a-hash",
         );
 
         let sarif_report = generate_sarif_report(
@@ -770,7 +769,7 @@ mod tests {
         let sarif_report_to_string = serde_json::to_value(sarif_report).unwrap();
         assert_json_eq!(
             sarif_report_to_string,
-            serde_json::json!({"runs":[{"results":[{"fixes":[],"level":"note","locations":[{"physicalLocation":{"artifactLocation":{"uri":"folder/file.txt"},"region":{"endColumn":64,"endLine":1,"startColumn":24,"startLine":1}}}],"message":{"text":"Unvalidated potential secret"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:SECURITY","DATADOG_VALIDATION_STATUS:UNVALIDATED"]},"ruleId":"datadog-app-key","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:5d7273dec32b80788b4d3eac46c866f0","DATADOG_EXECUTION_TIME_SECS:42","DATADOG_DIFF_AWARE_ENABLED:false"]},"rules":[{"fullDescription":{"text":"Long description about detecting a Datadog secret..."},"id":"datadog-app-key","properties":{"tags":["DATADOG_RULE_TYPE:SECRET"]},"shortDescription":{"text":"Short description"}}]}}}],"version":"2.1.0"}),
+            serde_json::json!({"runs":[{"results":[{"fixes":[],"level":"note","locations":[{"physicalLocation":{"artifactLocation":{"uri":"folder/file.txt"},"region":{"endColumn":64,"endLine":1,"startColumn":24,"startLine":1}}}],"message":{"text":"A potential secret where validation was not attempted"},"partialFingerprints":{},"properties":{"tags":["DATADOG_CATEGORY:SECURITY","DATADOG_VALIDATION_STATUS:UNVALIDATED"]},"ruleId":"datadog-app-key","ruleIndex":0}],"tool":{"driver":{"informationUri":"https://www.datadoghq.com","name":"datadog-static-analyzer","properties":{"tags":["DATADOG_DIFF_AWARE_CONFIG_DIGEST:5d7273dec32b80788b4d3eac46c866f0","DATADOG_EXECUTION_TIME_SECS:42","DATADOG_DIFF_AWARE_ENABLED:false"]},"rules":[{"fullDescription":{"text":"Long description about detecting a Datadog secret..."},"id":"datadog-app-key","properties":{"tags":["DATADOG_RULE_TYPE:SECRET"]},"shortDescription":{"text":"Short description"}}]}}}],"version":"2.1.0"}),
         );
 
         // validate the schema

--- a/misc/integration-test-secrets.sh
+++ b/misc/integration-test-secrets.sh
@@ -23,12 +23,12 @@ if [ "${FIRST_SCAN}" != "null" ]; then echo "secret scan results should be empty
 
 rm "${TEMP_DIR}/results.json" &&
   perl -pi -e 's/(quick)/$1 DD_API_KEY=/' $TEMP_FILE &&
-  perl -pi -e 's/(over)/$1 a0ef3594e77b5346791b02bdb1b2ea20c9057d61/' $TEMP_FILE
+  perl -pi -e 's/(over)/$1 e77b5346791b02bdb1b2ea20c9057d61/' $TEMP_FILE
 
 ./target/release/datadog-static-analyzer --test-secrets --directory "${TEMP_DIR}" -o "${TEMP_DIR}/results.json" -f sarif &>/dev/null
 
 RULE_ID=$(jq '.runs[0].results[0].ruleId' "${TEMP_DIR}/results.json")
-if [ "${RULE_ID}" != "\"datadog-app-key\"" ]; then echo "expected violation for secret detection rule"; exit 1; fi
+if [ "${RULE_ID}" != "\"datadog-api-key\"" ]; then echo "expected violation for secret detection rule"; exit 1; fi
 
 echo "All tests passed"
 


### PR DESCRIPTION
## What problem are you trying to solve?
Enable secrets validation in the temporary integration test

## What is your solution?
* Introduce CLI flag `--validate-secrets`, which, when used, will:
1. Scan all files, doing nothing until all scans are complete.
2. Once complete, for each candidate, kick off a thread to run the triggering rule's validation logic.
3. Once all validation threads are done (or a timeout is hit), collect the results, and then move on to static analysis.

## Alternatives considered

## What the reviewer should know
* This uses a hardcoded rule that performs validation of Datadog API tokens on `datad0g.com`
* There is currently a limit of 100 validations to avoid exhausting the OS threadpool (currently, all threads are fired off at once). This will be solved in the production implementation.