### PR TITLE
fix(serialization): correctly serialize arguments

### DIFF
--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -3,7 +3,6 @@ use indexmap::IndexMap;
 use serde;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -36,7 +35,7 @@ pub struct PathConfig {
 
 #[derive(Serialize, Debug, PartialEq, Default)]
 pub struct ArgumentValues {
-    pub by_subtree: HashMap<String, String>,
+    pub by_subtree: IndexMap<String, String>,
 }
 
 // Configuration for a single rule.
@@ -47,10 +46,10 @@ pub struct RuleConfig {
     pub paths: PathConfig,
     #[serde(
         default,
-        skip_serializing_if = "HashMap::is_empty",
+        skip_serializing_if = "IndexMap::is_empty",
         serialize_with = "serialize_arguments"
     )]
-    pub arguments: HashMap<String, ArgumentValues>,
+    pub arguments: IndexMap<String, ArgumentValues>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub severity: Option<RuleSeverity>,
     #[serde(

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -8,8 +8,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::config_file::{
-    deserialize_category, deserialize_ruleconfigs, deserialize_rulesetconfigs,
-    deserialize_schema_version, get_default_schema_version, serialize_rulesetconfigs,
+    deserialize_category, deserialize_rule_configs, deserialize_ruleset_configs,
+    deserialize_schema_version, get_default_schema_version, serialize_arguments,
+    serialize_ruleset_configs,
 };
 use crate::model::rule::{RuleCategory, RuleSeverity};
 
@@ -44,7 +45,11 @@ pub struct RuleConfig {
     // Paths to include/exclude for this rule.
     #[serde(flatten)]
     pub paths: PathConfig,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        serialize_with = "serialize_arguments"
+    )]
     pub arguments: HashMap<String, ArgumentValues>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub severity: Option<RuleSeverity>,
@@ -65,7 +70,7 @@ pub struct RulesetConfig {
     // Rule-specific configurations.
     #[serde(
         default,
-        deserialize_with = "deserialize_ruleconfigs",
+        deserialize_with = "deserialize_rule_configs",
         skip_serializing_if = "IndexMap::is_empty"
     )]
     pub rules: IndexMap<String, RuleConfig>,
@@ -78,7 +83,7 @@ pub struct ConfigFile {
     #[serde(rename = "schema-version")]
     pub schema_version: String,
     // Configurations for the rulesets.
-    #[serde(serialize_with = "serialize_rulesetconfigs")]
+    #[serde(serialize_with = "serialize_ruleset_configs")]
     pub rulesets: IndexMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.
     #[serde(flatten)]
@@ -102,7 +107,7 @@ struct RawConfigFile {
     )]
     schema_version: String,
     // Configurations for the rulesets.
-    #[serde(deserialize_with = "deserialize_rulesetconfigs")]
+    #[serde(deserialize_with = "deserialize_ruleset_configs")]
     rulesets: IndexMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.
     #[serde(flatten)]


### PR DESCRIPTION
## What problem are you trying to solve?

Serialization of the `ArgumentValues` struct is not properly done. This causes issues for the IDEs when using serialization for ignoring rules.

So, this:

```yaml
- typescript-code-style:
  rules:
    max-params:
      arguments:
        max-params: 3
```

becomed:

```yaml
- typescript-code-style:
  rules:
    max-params:
      ignore:
      - '**'
      arguments:
        max-params:
          by_subtree:
            '': '3'
```

## What is your solution?

Added a custom serialization method and some tests covering it.

## Alternatives considered

## What the reviewer should know

Feel free to modify or expand this implementation. I was wondering why we need the `ArgumentValues` at all given that we chose to ignore the `by_subtree` property. If there's no point, maybe we could use a HashMap or a a tuple struct. Although, I guess we would still want to have a custom serializer/deserializer to avoid having this case:
```yaml
arguments:
  max-params:
    '': '3'
```

So... I guess it's ok.

IDE-2650