### PR TITLE
[STAL-1701] add more performance statistics

### DIFF
--- a/crates/cli/src/csv.rs
+++ b/crates/cli/src/csv.rs
@@ -67,6 +67,8 @@ mod tests {
             execution_error: None,
             output: None,
             execution_time_ms: 10,
+            query_node_time_ms: 0,
+            parsing_time_ms: 0,
         }]);
         assert_eq!(res_with_result, "filename,rule,category,severity,message,start_line,start_col,end_line,end_col\nfilename,myrule,performance,error,message,10,12,12,10\n");
     }

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -496,6 +496,7 @@ mod tests {
             argument_provider: ArgumentProvider::new(),
             max_file_size_kb: 1,
             use_staging: false,
+            show_performance_statistics: false,
         };
         assert_eq!(0, filter_files_by_size(&files1, &cli_configuration).len());
 

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -27,6 +27,7 @@ pub struct CliConfiguration {
     pub argument_provider: ArgumentProvider,
     pub max_file_size_kb: u64,
     pub use_staging: bool,
+    pub show_performance_statistics: bool,
 }
 
 impl CliConfiguration {
@@ -143,6 +144,7 @@ mod tests {
             argument_provider: ArgumentProvider::new(),
             max_file_size_kb: 1,
             use_staging: false,
+            show_performance_statistics: false,
         };
         assert_eq!(
             cli_configuration.generate_diff_aware_digest(),

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -82,6 +82,8 @@ mod tests {
             execution_error: None,
             output: None,
             execution_time_ms: 0,
+            parsing_time_ms: 0,
+            query_node_time_ms: 0,
         };
 
         let rule_results = [rr];

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -711,6 +711,8 @@ mod tests {
             .output(None)
             .errors(vec![])
             .execution_time_ms(42)
+            .parsing_time_ms(0)
+            .query_node_time_ms(0)
             .execution_error(None)
             .build()
             .expect("building violation");
@@ -858,6 +860,8 @@ mod tests {
             .output(None)
             .errors(vec![])
             .execution_time_ms(42)
+            .parsing_time_ms(0)
+            .query_node_time_ms(0)
             .execution_error(None)
             .build()
             .expect("building violation");
@@ -937,6 +941,8 @@ mod tests {
             .errors(vec![])
             .execution_time_ms(42)
             .execution_error(None)
+            .parsing_time_ms(0)
+            .query_node_time_ms(0)
             .build()
             .expect("building violation");
 

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -7,7 +7,7 @@ use crate::model::common::Language;
 use crate::model::rule::{RuleInternal, RuleResult};
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::time::SystemTime;
+use std::time::Instant;
 
 fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
     let mut lines_to_ignore_for_all_rules = vec![];
@@ -99,19 +99,11 @@ where
 {
     let lines_to_ignore = get_lines_to_ignore(code, language);
 
-    let start_parsing_time_ms = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis();
+    let parsing_time = Instant::now();
 
     let tree = get_tree(code, language);
 
-    let end_parsing_time_ms = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis();
-
-    let parsing_time_ms = end_parsing_time_ms - start_parsing_time_ms;
+    let parsing_time_ms = parsing_time.elapsed().as_millis();
 
     tree.map_or_else(
         || {
@@ -130,10 +122,7 @@ where
                         eprintln!("Apply rule {} file {}", rule.name, filename);
                     }
 
-                    let start_get_query_node_ms = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis();
+                    let query_node_time = Instant::now();
 
                     let nodes = get_query_nodes(
                         &tree,
@@ -143,11 +132,7 @@ where
                         &argument_provider.get_arguments(filename, &rule.name),
                     );
 
-                    let end_get_query_node_ms = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis();
-                    let query_node_time_ms = end_get_query_node_ms - start_get_query_node_ms;
+                    let query_node_time_ms = query_node_time.elapsed().as_millis();
 
                     if nodes.is_empty() {
                         RuleResult {

--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -6,7 +6,7 @@ use crate::model::violation::Violation;
 use deno_core::{v8, FastString, JsRuntime, JsRuntimeForSnapshot, RuntimeOptions, Snapshot};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use crate::analysis::file_context::common::FileContext;
 use lazy_static::lazy_static;
@@ -45,10 +45,9 @@ pub fn execute_rule(
     let rule_name_copy_thr = rule.name.clone();
     let filename_copy_thr = filename.clone();
     let use_debug = analysis_options.use_debug;
-    let start = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis();
+
+    let execution_start = Instant::now();
+
     // These mutexes and condition variables are used to wait on the execution
     // and have a proper timeout.
     let condvar_main = Arc::new((Mutex::new(()), Condvar::new()));
@@ -119,7 +118,7 @@ pub fn execute_rule(
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_millis();
-        let execution_time_ms = end - start;
+        let execution_time_ms = execution_start.elapsed().as_millis();
 
         // drop the thread. Note that it does not terminate the thread, it just put
         // it out of scope.

--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -143,6 +143,8 @@ pub fn execute_rule(
                         execution_error: None,
                         output: None,
                         execution_time_ms,
+                        parsing_time_ms: 0,    // filled later in the execute step
+                        query_node_time_ms: 0, // filled later in the execute step
                     }
                 } else if let Some(res) = rx_result.try_recv().unwrap_or(None) {
                     RuleResult {
@@ -153,6 +155,8 @@ pub fn execute_rule(
                         execution_error: res.execution_error,
                         execution_time_ms,
                         output: res.output,
+                        parsing_time_ms: 0,    // filled later in the execute step
+                        query_node_time_ms: 0, // filled later in the execute step
                     }
                 } else {
                     RuleResult {
@@ -163,6 +167,8 @@ pub fn execute_rule(
                         execution_error: None,
                         output: None,
                         execution_time_ms,
+                        parsing_time_ms: 0,    // filled later in the execute step
+                        query_node_time_ms: 0, // filled later in the execute step
                     }
                 }
             }
@@ -174,6 +180,8 @@ pub fn execute_rule(
                 execution_error: None,
                 output: None,
                 execution_time_ms,
+                parsing_time_ms: 0,    // filled later in the execute step
+                query_node_time_ms: 0, // filled later in the execute step
             },
         }
     })
@@ -238,6 +246,8 @@ res
             execution_error: Some(ERROR_RULE_CODE_TOO_BIG.to_string()),
             output: None,
             execution_time_ms: 0,
+            parsing_time_ms: 0,    // filled later in the execute step
+            query_node_time_ms: 0, // filled later in the execute step
         };
     }
 
@@ -286,6 +296,8 @@ res
                                 execution_error: None,
                                 output: console_lines,
                                 execution_time_ms: 0,
+                                parsing_time_ms: 0, // filled later in the execute step
+                                query_node_time_ms: 0, // filled later in the execute step
                             }
                         }
                         Err(e) => RuleResult {
@@ -296,6 +308,8 @@ res
                             execution_error: Some(format!("error when getting violations: ${e}")),
                             output: None,
                             execution_time_ms: 0,
+                            parsing_time_ms: 0, // filled later in the execute step
+                            query_node_time_ms: 0, // filled later in the execute step
                         },
                     }
                 }
@@ -307,6 +321,8 @@ res
                     execution_error: Some(format!("error: {err}")),
                     output: None,
                     execution_time_ms: 0,
+                    parsing_time_ms: 0,    // filled later in the execute step
+                    query_node_time_ms: 0, // filled later in the execute step
                 },
             }
         }
@@ -331,6 +347,8 @@ res
                 execution_error: Some(error_message),
                 output: None,
                 execution_time_ms: 0,
+                parsing_time_ms: 0,    // filled later in the execute step
+                query_node_time_ms: 0, // filled later in the execute step
             }
         }
     }

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -285,6 +285,8 @@ pub struct RuleResult {
     pub execution_error: Option<String>,
     pub output: Option<String>,
     pub execution_time_ms: u128,
+    pub parsing_time_ms: u128,
+    pub query_node_time_ms: u128,
 }
 
 impl RuleResultBuilder {
@@ -424,6 +426,8 @@ mod tests {
                 .execution_error(None)
                 .output(None)
                 .execution_time_ms(0)
+                .parsing_time_ms(0)
+                .query_node_time_ms(0)
                 .clone()
         }
 


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to diagnose potential bottlenecks.

## What is your solution?

We are now collecting more traces and data

 - time to parse the tree-sitter query
 - time to query the nodes in an AST
 - time to parse the source code

When the `-x` flag is set `--performance-statistics`, we show the query node time and the execution time for each node.
We also show the time to convert a rule to an internal rule. We also show the files that are the slowest to parse.

This would then help us to investigate performance bottlenecks.