### PR TITLE
[STAL-1851] Add normalized entropy Checker

### DIFF
--- a/crates/secrets/src/check.rs
+++ b/crates/secrets/src/check.rs
@@ -2,11 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+use crate::check::entropy::NormalizedEntropy;
 use crate::check::simple::{AnyOf, Contains, Equals};
 use crate::rule_file::check::RawCheck;
 use crate::rule_file::StringsOrInts;
 use secrets_core::Checker;
 
+pub(crate) mod entropy;
 pub(crate) mod simple;
 
 #[derive(Debug, Clone)]
@@ -14,6 +16,7 @@ pub(crate) enum Check {
     Equals(Equals),
     AnyOf(AnyOf),
     Contains(Contains),
+    Entropy(NormalizedEntropy),
 }
 
 impl Checker for Check {
@@ -22,6 +25,7 @@ impl Checker for Check {
             Check::Equals(ch) => ch.check(input),
             Check::AnyOf(ch) => ch.check(input),
             Check::Contains(ch) => ch.check(input),
+            Check::Entropy(ch) => ch.check(input),
         }
     }
 }
@@ -38,6 +42,9 @@ impl Check {
                 kind.into()
             }
             RawCheck::Contains(raw) => Contains::new(&raw.substring).into(),
+            RawCheck::NormalizedEntropy(raw) => {
+                NormalizedEntropy::new(raw.over_threshold, raw.base).into()
+            }
         }
     }
 }

--- a/crates/secrets/src/check/entropy.rs
+++ b/crates/secrets/src/check/entropy.rs
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::check::Check;
+use secrets_core::Checker;
+
+/// A [`Checker`] that interprets the input as a [`String`] and measures its Shannon entropy,
+/// normalizing it to a given base.
+///
+/// Reference: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NormalizedEntropy {
+    /// A number between 0 and 1. When the normalized entropy is over this number, the check will return true.
+    threshold: f32,
+    /// The base to use to normalize the calculated entropy.
+    base: u8,
+}
+
+impl NormalizedEntropy {
+    /// Creates a new [`NormalizedEntropy`]. If no `base` is provided, 95 (the number of printable characters
+    /// will be used).
+    pub fn new(threshold: f32, base: Option<u8>) -> Self {
+        let base = base.unwrap_or(95);
+        Self { threshold, base }
+    }
+
+    fn normalized_entropy(&self, data: impl IntoIterator<Item = char>) -> f32 {
+        let entropy = shannon_entropy(data);
+        (entropy / (self.base as f32).log2()).clamp(0.0, 1.0)
+    }
+}
+
+impl Checker for NormalizedEntropy {
+    fn check(&self, input: &[u8]) -> bool {
+        let normalized = self.normalized_entropy(String::from_utf8_lossy(input).chars());
+        normalized >= self.threshold
+    }
+}
+
+impl From<NormalizedEntropy> for Check {
+    fn from(value: NormalizedEntropy) -> Self {
+        Self::Entropy(value)
+    }
+}
+
+fn shannon_entropy(data: impl IntoIterator<Item = char>) -> f32 {
+    let mut data_len = 0_usize;
+    let mut entropy = 0.0;
+    let mut counts = [0_usize; 256];
+
+    for ch in data.into_iter() {
+        counts[ch as usize] += 1;
+        data_len += 1;
+    }
+
+    for count in counts.into_iter().filter(|&count| count > 0) {
+        let p = (count as f32) / (data_len as f32);
+        entropy -= p * p.log2()
+    }
+    entropy
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::check::entropy::NormalizedEntropy;
+
+    #[test]
+    fn entropy_zero() {
+        let norm_entropy = NormalizedEntropy::new(0.5, Some(16));
+        let str = "aaaaaaaa";
+        assert_eq!(norm_entropy.normalized_entropy(str.chars()), 0.0);
+    }
+
+    #[test]
+    fn entropy_default_base() {
+        let str = "5f375a86";
+        let norm_entropy = NormalizedEntropy::new(0.2, None);
+        assert_eq!(norm_entropy.normalized_entropy(str.chars()), 0.41857845);
+        let norm_entropy = NormalizedEntropy::new(0.2, Some(16));
+        assert_eq!(norm_entropy.normalized_entropy(str.chars()), 0.6875);
+    }
+
+    #[test]
+    fn entropy_clamped() {
+        let str = "5f375a86";
+        let norm_entropy = NormalizedEntropy::new(0.2, Some(1));
+        assert_eq!(norm_entropy.normalized_entropy(str.chars()), 1.0);
+    }
+}

--- a/crates/secrets/src/rule_file/check.rs
+++ b/crates/secrets/src/rule_file/check.rs
@@ -10,6 +10,7 @@ raw_item! {
         Equals(RawEquals),
         AnyOf(RawAnyOf),
         Contains(RawContains),
+        NormalizedEntropy(RawNormalizedEntropy),
     }
 
     /// The configuration for check `equals`
@@ -35,6 +36,16 @@ raw_item! {
         /// The substring to search for
         pub substring: String,
     }
+
+    /// The configuration for check `normalized-entropy`
+    pub struct RawNormalizedEntropy {
+        /// The variable to measure the entropy of.
+        pub input: TemplateVar,
+        /// The threshold at which this check will return true.
+        pub over_threshold: f32,
+        /// The number of possible characters, used to normalize the entropy calculation.
+        pub base: Option<u8>,
+    }
 }
 
 impl RawCheck {
@@ -44,6 +55,7 @@ impl RawCheck {
             RawCheck::Equals(raw) => raw.input.name(),
             RawCheck::AnyOf(raw) => raw.input.name(),
             RawCheck::Contains(raw) => raw.input.name(),
+            RawCheck::NormalizedEntropy(raw) => raw.input.name(),
         }
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
Make rule authoring more powerful by allowing assertions against the (normalized) entropy of a candidate.

## What is your solution?
Add a `Checker` for normalized entropy. This calculates the Shannon entropy of a string and then normalizes it to a float between 0 and 1 by dividing by the total number of possible characters. For example, a hex pattern should use a base of 16, whereas a base64-encoded string should use...64.

```yml
matcher:
  hyperscan:
    id: api-key
    pattern: \b[a-zA-Z0-9+\/]{18}\b
    checks:
      - normalized-entropy:
          input: ${{ candidate }}
          over-threshold: 0.6
          base: 64
```

```
let key = "72k1xXWG59wUsYv7h2";
//         ^^^^^^^^^^^^^^^^^^
//           Match (0.65795)
```
```
let key = "Prestidigitatively";
//         ^^^^^^^^^^^^^^^^^^
//         No Match (0.55837)
```

## Alternatives considered

## What the reviewer should know