### PR TITLE
[STAL-1172] Use Result for `execute_rule_inner`

### DIFF
--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 serde_v8 = "0.107.0"
+thiserror = "1.0.59"
 tree-sitter = "0.21.0"
 
 [build-dependencies]


### PR DESCRIPTION
## What problem are you trying to solve?
PR 1/3

We're going to refactor `execute_rule_internal` for performance reasons, and cleaning up error handling will simplify things.

## What is your solution?
This paves the way for flatter control-flow as we refactor this section.

Conceptually, this PR transforms the `execute_rule_internal` function into a pure function (e.g. no logging), and offloads that duty to the `execute_rule` function.

By using `Result` as the return value, we can ergonomically match and handle errors per-type.

To reduce code churn, I kept the same internal API for `execute_rule`, using a small translation layer.

## Alternatives considered

## What the reviewer should know
* This PR is really about the idea of (eventually) flatter control flow and making `execute_rule_internal` pure--most of this will be rewritten as we refactor further.