### PR TITLE
[STAL-1172] Serialize Rust structs directly to v8 objects

### DIFF
--- a/crates/static-analysis-kernel/src/model/analysis.rs
+++ b/crates/static-analysis-kernel/src/model/analysis.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 
 pub const ERROR_RULE_TIMEOUT: &str = "rule-timeout";
 pub const ERROR_RULE_EXECUTION: &str = "error-execution";
-pub const ERROR_RULE_CODE_TOO_BIG: &str = "error-code-too-big";
 pub const ERROR_INVALID_QUERY: &str = "error-invalid-query";
 
 // Used internally to pass options to the analysis


### PR DESCRIPTION
PR 3/3

When we pass data between Rust and v8, we currently serialize it into JSON, pass it in as a string, and let the v8 runtime parse the objects and re-construct them into v8 objects.

This leads to large spikes in memory usage, as well as a lot of CPU cycles serializing and deserializing.

## What is your solution?
Serialize Rust structs directly into v8 objects, and expose those as globals in the JavaScript context. This leads to significant speedups in real-world workloads.

It additionally enables features that were previously infeasible, as we now have the ability to quickly and cheaply drop into JavaScript.

### Before (81s)
Note how over 37% of the time is spent serializing and executing the rule (of which 20% is parsing the JSON string we are sending in)
![before](https://github.com/DataDog/datadog-static-analyzer/assets/774272/0afa4c3c-f411-437d-8d37-c30349027055)


### After (58s: 1.4x speedup)
Now, only 17% of the time is spent serializing data and executing the rule.
![after](https://github.com/DataDog/datadog-static-analyzer/assets/774272/4fad399d-7032-4771-bde7-6f2f329bc009)


## Alternatives considered

## What the reviewer should know
* A small optimization was made to the JavaScript: we check if the `fileContext` is non-empty before spreading the object. While it's possible v8 might be smart enough to optimize this, if it doesn't, we'll needlessly reallocate a potentially large amount of data.
* The script execution behavior has no regressions (if anything, it improves it by reporting more errors because of the new use of Try/Catch)
* The "v8 string max length" check is no longer relevant anymore. Before, it was possible to go over this limit when serializing a large number of nodes with a large number of children into a string. Now, the rule's JavaScript text would need to be over this limit (~1GB), which is practically impossible. 