### PR TITLE
[STAL-1921] More instructions when we fail to get the repository for diff-aware

### DIFF
--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -73,7 +73,15 @@ impl CliConfiguration {
     pub fn generate_diff_aware_request_data(&self) -> anyhow::Result<DiffAwareRequestArguments> {
         let config_hash = self.generate_diff_aware_digest();
 
-        let repository = Repository::init(&self.source_directory)?;
+        let repository_opt = Repository::init(&self.source_directory);
+
+        if repository_opt.is_err() {
+            eprintln!("Fail to get repository information");
+            eprintln!("If the user running the analyzer is different than the user running the analysis, use: git config --global --add safe.directory /path/to/repository");
+            eprintln!("In some systems you need to disable the worktreeConfig extension with: git config --unset extensions.worktreeConfig")
+        }
+
+        let repository = repository_opt?;
 
         let repository_url = repository
             .find_remote("origin")?


### PR DESCRIPTION
## What problem are you trying to solve?

We want to add more instructions when we fail to get informations about the repository being scanned for diff-aware. We found that when failing to get the repository, `libgit2` may fail to get the repository. We need to inform the user about potential issues.

See [this ticket in `datadog-static-analyzer-github-action`](https://github.com/DataDog/datadog-static-analyzer-github-action/pull/31) for more details.

## What is your solution?

Add more information about the cause with potential workarounds on the standard error.