### PR TITLE
[STAL-1645] fix: use maintained and up-to-date yaml grammar

### DIFF
--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -153,20 +153,11 @@ fn main() {
         TreeSitterProject {
             name: "tree-sitter-yaml".to_string(),
             compilation_unit: "tree-sitter-yaml-parser".to_string(),
-            repository: "https://github.com/ikatyang/tree-sitter-yaml.git".to_string(),
+            repository: "https://github.com/tree-sitter-grammars/tree-sitter-yaml.git".to_string(),
             build_dir: "src".into(),
-            commit_hash: "0e36bed171768908f331ff7dff9d956bae016efb".to_string(),
-            files: vec!["parser.c".to_string()],
+            commit_hash: "ee093118211be521742b9866a8ed8ce6d87c7a94".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
-        },
-        TreeSitterProject {
-            name: "tree-sitter-yaml".to_string(),
-            compilation_unit: "tree-sitter-yaml-scanner".to_string(),
-            repository: "https://github.com/ikatyang/tree-sitter-yaml.git".to_string(),
-            build_dir: "src".into(),
-            commit_hash: "0e36bed171768908f331ff7dff9d956bae016efb".to_string(),
-            files: vec!["scanner.cc".to_string()],
-            cpp: true,
         },
         TreeSitterProject {
             name: "tree-sitter-ruby".to_string(),


### PR DESCRIPTION
## What problem are you trying to solve?

The YAML parser currently cannot be loaded in the browser as a WASM module, due to it being unmaintained and using C++, which tree-sitter has now deprecated upstream

## What is your solution?

Use a maintained fork that has rewritten the scanner in C and has fixed some other bugs

## Alternatives considered

N/A

## What the reviewer should know

This only updates a dependency