### PR TITLE
[STAL-1986] Fix macOS x86 GitHub Actions build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
           # Windows
           - target: x86_64-pc-windows-msvc
             os: windows-latest

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,7 +10,7 @@ jobs:
         config:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, gha_alias: 'Linux x64 - ' }
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, gha_alias: 'Linux aarch64 - ' }
-          - { os: macos-latest, target: x86_64-apple-darwin, gha_alias: 'macOS x64 - ' }
+          - { os: macos-13, target: x86_64-apple-darwin, gha_alias: 'macOS x64 - ' }
           - { os: macos-latest, target: aarch64-apple-darwin, gha_alias: 'macOS aarch64 - ' }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, gha_alias: 'Windows x64 - ' }
         cargo_cmd:


### PR DESCRIPTION
## What problem are you trying to solve?

Our build for for x86 macOS has started failing, because at some point `make` is passed `-mcpu=apple-m1`.

<img width="1096" alt="image" src="https://github.com/DataDog/datadog-static-analyzer/assets/774272/525f81e1-9064-44ad-8c98-5b26ea1b1835">

## What is your solution?

GitHub is currently moving `macos-14` (currently `macos-latest`) runners to aarch64.

Without actually digging for where this flag is getting set, I presume that some script assumes it is building for the native architecture, and so it detects aarch64 and sets the corresponding flag, despite us really wanting to compile x86.

As a workaround, this PR pins our x86 macOS runner to macos-13, which runs x86 natively.

You can see from this manually-run workflow that pinning to macos-13 solves this issue: https://github.com/DataDog/datadog-static-analyzer/actions/runs/8886167438/job/24399431838

<img width="1105" alt="image" src="https://github.com/DataDog/datadog-static-analyzer/assets/774272/5e18ded2-0345-4bac-9314-4cbed7a9b405">


(NOTE: the job overall failed because I ran this as an ad-hoc, incomplete release -- however, you can see that the build itself succeeded)


## Alternatives considered
* Finding and fixing the underlying build script introducing this flag

## What the reviewer should know
