### PR TITLE
[STAL-1686] Add is_testing to rules

### DIFF
--- a/crates/bins/src/bin/datadog-export-rulesets.rs
+++ b/crates/bins/src/bin/datadog-export-rulesets.rs
@@ -62,7 +62,8 @@ fn main() {
     let rulesets: Vec<RuleSet> = rulesets_names
         .iter()
         .map(|ruleset_name| {
-            get_ruleset(ruleset_name, use_staging, include_testing_rules).expect("error when reading ruleset")
+            get_ruleset(ruleset_name, use_staging, include_testing_rules)
+                .expect("error when reading ruleset")
         })
         .collect();
 

--- a/crates/bins/src/bin/datadog-export-rulesets.rs
+++ b/crates/bins/src/bin/datadog-export-rulesets.rs
@@ -22,6 +22,7 @@ fn main() {
     opts.optflag("h", "help", "print this help");
     opts.optflag("v", "version", "shows the version");
     opts.optflag("s", "staging", "use staging");
+    opts.optflag("t", "include-testing-rules", "include testing rules");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -53,6 +54,7 @@ fn main() {
     }
 
     let use_staging = matches.opt_present("s");
+    let include_testing_rules = matches.opt_present("t");
     let rulesets_names = matches.opt_strs("r");
     let file_to_write = matches.opt_str("o").expect("output file");
 
@@ -60,7 +62,7 @@ fn main() {
     let rulesets: Vec<RuleSet> = rulesets_names
         .iter()
         .map(|ruleset_name| {
-            get_ruleset(ruleset_name, use_staging).expect("error when reading ruleset")
+            get_ruleset(ruleset_name, use_staging, include_testing_rules).expect("error when reading ruleset")
         })
         .collect();
 

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -64,6 +64,7 @@ fn main() {
     opts.optmulti("r", "ruleset", "rules to test", "python-security");
     opts.optflag("h", "help", "print this help");
     opts.optflag("s", "staging", "use staging");
+    opts.optflag("t", "include-testing-rules", "include testing rules");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -79,9 +80,10 @@ fn main() {
 
     let use_staging = matches.opt_present("s");
     let rulesets = matches.opt_strs("r");
+    let include_testing_rules = matches.opt_present("t");
     let mut num_failures = 0;
     for ruleset in rulesets {
-        match get_ruleset(ruleset.as_str(), use_staging) {
+        match get_ruleset(ruleset.as_str(), use_staging, include_testing_rules) {
             Ok(r) => {
                 println!("Testing ruleset {}", r.name);
                 for rule in r.rules.clone() {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -386,8 +386,8 @@ fn main() -> Result<()> {
                 " - Datadog documentation: https://docs.datadoghq.com/code_analysis/static_analysis"
             );
             println!(" - Static analyzer repository on GitHub: https://github.com/DataDog/datadog-static-analyzer");
-            let rulesets_from_api =
-                get_all_default_rulesets(use_staging, include_testing_rules).expect("cannot get default rules");
+            let rulesets_from_api = get_all_default_rulesets(use_staging, include_testing_rules)
+                .expect("cannot get default rules");
 
             rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));
         } else {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -218,6 +218,7 @@ fn main() -> Result<()> {
         "enable performance statistics",
     );
     opts.optflag("s", "staging", "use staging");
+    opts.optflag("t", "include-testing-rules", "include testing rules");
     opts.optflag(
         "g",
         "add-git-info",
@@ -262,6 +263,7 @@ fn main() -> Result<()> {
 
     let should_verify_checksum = !matches.opt_present("b");
     let use_staging = matches.opt_present("s");
+    let include_testing_rules = matches.opt_present("t");
     let add_git_info = matches.opt_present("g");
     let enable_performance_statistics = matches.opt_present("x");
     let print_violations = matches.opt_present("print-violations");
@@ -358,7 +360,7 @@ fn main() -> Result<()> {
         let overrides = RuleOverrides::from_config_file(&conf);
 
         let rulesets = conf.rulesets.keys().cloned().collect_vec();
-        let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging)
+        let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging, include_testing_rules)
             .context("error when reading rules from API")?;
         rules.extend(rules_from_api.into_iter().map(|rule| Rule {
             severity: overrides.severity(&rule.name, rule.severity),
@@ -385,7 +387,7 @@ fn main() -> Result<()> {
             );
             println!(" - Static analyzer repository on GitHub: https://github.com/DataDog/datadog-static-analyzer");
             let rulesets_from_api =
-                get_all_default_rulesets(use_staging).expect("cannot get default rules");
+                get_all_default_rulesets(use_staging, include_testing_rules).expect("cannot get default rules");
 
             rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));
         } else {

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -83,14 +83,9 @@ pub fn get_ruleset(
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
 
-    let include_testing_rules_query_param_val = match include_testing_rules {
-        true => "true",
-        false => "false",
-    };
-
     let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={:?}",
-        site, ruleset_name, include_testing_rules_query_param_val
+        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={}",
+        site, ruleset_name, include_testing_rules
     );
 
     let request_builder = reqwest::blocking::Client::new()

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -31,7 +31,11 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
 ];
 
 // Get all the rules from different rulesets from Datadog
-pub fn get_rules_from_rulesets(rulesets_name: &[String], use_staging: bool, include_testing_rules:bool) -> Result<Vec<Rule>> {
+pub fn get_rules_from_rulesets(
+    rulesets_name: &[String],
+    use_staging: bool,
+    include_testing_rules: bool,
+) -> Result<Vec<Rule>> {
     let mut rules: Vec<Rule> = Vec::new();
     for ruleset_name in rulesets_name {
         rules.extend(get_ruleset(ruleset_name, use_staging, include_testing_rules)?.rules);
@@ -70,15 +74,19 @@ fn get_datadog_site(use_staging: bool) -> String {
 // get rules from one ruleset at datadog
 // it connects to the API using the DD_SITE, DD_APP_KEY and DD_API_KEY and retrieve
 // the rulesets. We then extract all the rulesets
-pub fn get_ruleset(ruleset_name: &str, use_staging: bool, include_testing_rules:bool) -> Result<RuleSet> {
+pub fn get_ruleset(
+    ruleset_name: &str,
+    use_staging: bool,
+    include_testing_rules: bool,
+) -> Result<RuleSet> {
     let site = get_datadog_site(use_staging);
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
 
     let include_testing_rules_query_param_val = match include_testing_rules {
         true => "true",
-        false => "false"
-      };
+        false => "false",
+    };
 
     let url = format!(
         "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={:?}",
@@ -155,7 +163,10 @@ pub fn get_default_rulesets_name_for_language(
 
 /// Get all the default rulesets available at DataDog. Take all the language
 /// from `DEFAULT_RULESETS_LANGAGES` and get their rulesets
-pub fn get_all_default_rulesets(use_staging: bool, include_testing_rules:bool) -> Result<Vec<RuleSet>> {
+pub fn get_all_default_rulesets(
+    use_staging: bool,
+    include_testing_rules: bool,
+) -> Result<Vec<RuleSet>> {
     let mut result: Vec<RuleSet> = vec![];
 
     for language in DEFAULT_RULESETS_LANGUAGES {
@@ -163,7 +174,11 @@ pub fn get_all_default_rulesets(use_staging: bool, include_testing_rules:bool) -
             get_default_rulesets_name_for_language(language.to_string(), use_staging)?;
 
         for ruleset_name in ruleset_names {
-            result.push(get_ruleset(ruleset_name.as_str(), use_staging, include_testing_rules)?);
+            result.push(get_ruleset(
+                ruleset_name.as_str(),
+                use_staging,
+                include_testing_rules,
+            )?);
         }
     }
     Ok(result)

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -31,10 +31,10 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
 ];
 
 // Get all the rules from different rulesets from Datadog
-pub fn get_rules_from_rulesets(rulesets_name: &[String], use_staging: bool) -> Result<Vec<Rule>> {
+pub fn get_rules_from_rulesets(rulesets_name: &[String], use_staging: bool, include_testing_rules:bool) -> Result<Vec<Rule>> {
     let mut rules: Vec<Rule> = Vec::new();
     for ruleset_name in rulesets_name {
-        rules.extend(get_ruleset(ruleset_name, use_staging)?.rules);
+        rules.extend(get_ruleset(ruleset_name, use_staging, include_testing_rules)?.rules);
     }
     Ok(rules)
 }
@@ -70,14 +70,21 @@ fn get_datadog_site(use_staging: bool) -> String {
 // get rules from one ruleset at datadog
 // it connects to the API using the DD_SITE, DD_APP_KEY and DD_API_KEY and retrieve
 // the rulesets. We then extract all the rulesets
-pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
+pub fn get_ruleset(ruleset_name: &str, use_staging: bool, include_testing_rules:bool) -> Result<RuleSet> {
     let site = get_datadog_site(use_staging);
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
 
+    let include_testing_rules_query_param_val;
+    if include_testing_rules { 
+        include_testing_rules_query_param_val = "true";
+     } else { 
+        include_testing_rules_query_param_val = "false";
+      }
+
     let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false",
-        site, ruleset_name
+        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={}",
+        site, ruleset_name, include_testing_rules_query_param_val
     );
 
     let request_builder = reqwest::blocking::Client::new()
@@ -150,7 +157,7 @@ pub fn get_default_rulesets_name_for_language(
 
 /// Get all the default rulesets available at DataDog. Take all the language
 /// from `DEFAULT_RULESETS_LANGAGES` and get their rulesets
-pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
+pub fn get_all_default_rulesets(use_staging: bool, include_testing_rules:bool) -> Result<Vec<RuleSet>> {
     let mut result: Vec<RuleSet> = vec![];
 
     for language in DEFAULT_RULESETS_LANGUAGES {
@@ -158,7 +165,7 @@ pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
             get_default_rulesets_name_for_language(language.to_string(), use_staging)?;
 
         for ruleset_name in ruleset_names {
-            result.push(get_ruleset(ruleset_name.as_str(), use_staging)?);
+            result.push(get_ruleset(ruleset_name.as_str(), use_staging, include_testing_rules)?);
         }
     }
     Ok(result)

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -75,15 +75,13 @@ pub fn get_ruleset(ruleset_name: &str, use_staging: bool, include_testing_rules:
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
 
-    let include_testing_rules_query_param_val;
-    if include_testing_rules { 
-        include_testing_rules_query_param_val = "true";
-     } else { 
-        include_testing_rules_query_param_val = "false";
-      }
+    let include_testing_rules_query_param_val = match include_testing_rules {
+        true => "true",
+        false => "false"
+      };
 
     let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={}",
+        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={:?}",
         site, ruleset_name, include_testing_rules_query_param_val
     );
 

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -150,7 +150,6 @@ mod tests {
                 tree_sitter_query_base64: None,
                 arguments: vec![],
                 tests: vec![],
-                is_testing: false,
             }],
             path_restrictions: PathRestrictions::default(),
             argument_provider: ArgumentProvider::new(),

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -150,7 +150,7 @@ mod tests {
                 tree_sitter_query_base64: None,
                 arguments: vec![],
                 tests: vec![],
-                is_testing: false,
+                is_testing: Some(false),
             }],
             path_restrictions: PathRestrictions::default(),
             argument_provider: ArgumentProvider::new(),

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -150,7 +150,7 @@ mod tests {
                 tree_sitter_query_base64: None,
                 arguments: vec![],
                 tests: vec![],
-                is_testing: Some(false),
+                is_testing: false,
             }],
             path_restrictions: PathRestrictions::default(),
             argument_provider: ArgumentProvider::new(),

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -150,6 +150,7 @@ mod tests {
                 tree_sitter_query_base64: None,
                 arguments: vec![],
                 tests: vec![],
+                is_testing: false,
             }],
             path_restrictions: PathRestrictions::default(),
             argument_provider: ArgumentProvider::new(),

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -121,7 +121,7 @@ pub struct ApiResponseRule {
     pub severity: RuleSeverity,
     pub category: RuleCategory,
     pub tests: Vec<ApiResponseRuleTest>,
-    pub is_testing: bool,
+    pub is_testing: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -121,7 +121,7 @@ pub struct ApiResponseRule {
     pub severity: RuleSeverity,
     pub category: RuleCategory,
     pub tests: Vec<ApiResponseRuleTest>,
-    pub is_testing: Option<bool>,
+    pub is_testing: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -121,6 +121,7 @@ pub struct ApiResponseRule {
     pub severity: RuleSeverity,
     pub category: RuleCategory,
     pub tests: Vec<ApiResponseRuleTest>,
+    pub is_testing: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -180,6 +181,7 @@ impl ApiResponseRuleset {
                             annotation_count: t.annotation_count,
                         })
                         .collect(),
+                    is_testing: rule_from_api.is_testing,
                 })
                 .collect(),
             None => Vec::new(),

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -252,7 +252,8 @@ mod tests {
                                     "annotation_count": 0
                                 }
                             ],
-                            "is_published": false
+                            "is_published": false,
+                            "is_testing": false
                         }
                     ]
                 }

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -126,7 +126,8 @@ mod tests {
                 "checksum": "d2b54f17b9ecdd41d88671fb32276899b322de91fb46ed8e0bac65ad47bb0a0a",
                 "pattern": null,
                 "tree_sitter_query": "KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgbmFtZTogKGlkZW50aWZpZXIpIEBmdW5jdGlvbm5hbWUKICAgcGFyYW1ldGVyczogKHBhcmFtZXRlcnMpIEBwYXJhbWV0ZXJzCik=",
-                "tests": []
+                "tests": [],
+                "is_testing": false
             }
         ]
     }

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -83,10 +83,10 @@ impl SarifRule {
         format!("DATADOG_RULE_TYPE:{}", kind)
     }
 
-    fn is_testing(&self) -> Option<bool> {
+    fn is_testing(&self) -> bool {
         match self {
             SarifRule::StaticAnalysis(r) => r.is_testing,
-            SarifRule::Secret(_) => None,
+            SarifRule::Secret(_) => false,
         }
     }
 }
@@ -218,7 +218,7 @@ impl IntoSarif for &Rule {
         if let Some(cwe) = self.cwe.as_ref() {
             tags.push(format!("CWE:{}", cwe));
         }
-        if let Some(is_testing) = self.is_testing {
+        if self.is_testing{
             tags.push("DATADOG_TESTING:true".to_string());  
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();
@@ -490,10 +490,8 @@ fn generate_results(
                 }
 
                 // If the rule is a test, add a tag
-                if let Some(is_testing) = rule.is_testing() {
-                    if is_testing {
-                        tags.push("DATADOG_TESTING:true".to_string());
-                    }
+                if rule.is_testing() {
+                    tags.push("DATADOG_TESTING:true".to_string());
                 }
             }
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -219,7 +219,7 @@ impl IntoSarif for &Rule {
             tags.push(format!("CWE:{}", cwe));
         }
         if let Some(_is_testing) = self.is_testing {
-            tags.push("DATADOG_TESTING:true".to_string());  
+            tags.push("DATADOG_TESTING:true".to_string());
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();
         builder.properties(props);

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -83,10 +83,10 @@ impl SarifRule {
         format!("DATADOG_RULE_TYPE:{}", kind)
     }
 
-    fn is_testing(&self) -> bool {
+    fn is_testing(&self) -> Option<bool> {
         match self {
             SarifRule::StaticAnalysis(r) => r.is_testing,
-            SarifRule::Secret(_) => false,
+            SarifRule::Secret(_) => None,
         }
     }
 }
@@ -218,7 +218,7 @@ impl IntoSarif for &Rule {
         if let Some(cwe) = self.cwe.as_ref() {
             tags.push(format!("CWE:{}", cwe));
         }
-        if self.is_testing{
+        if let Some(is_testing) = self.is_testing {
             tags.push("DATADOG_TESTING:true".to_string());  
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();
@@ -490,8 +490,10 @@ fn generate_results(
                 }
 
                 // If the rule is a test, add a tag
-                if rule.is_testing() {
-                    tags.push("DATADOG_TESTING:true".to_string());
+                if let Some(is_testing) = rule.is_testing() {
+                    if is_testing {
+                        tags.push("DATADOG_TESTING:true".to_string());
+                    }
                 }
             }
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -218,7 +218,7 @@ impl IntoSarif for &Rule {
         if let Some(cwe) = self.cwe.as_ref() {
             tags.push(format!("CWE:{}", cwe));
         }
-        if let Some(is_testing) = self.is_testing {
+        if let Some(_is_testing) = self.is_testing {
             tags.push("DATADOG_TESTING:true".to_string());  
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -218,8 +218,8 @@ impl IntoSarif for &Rule {
         if let Some(cwe) = self.cwe.as_ref() {
             tags.push(format!("CWE:{}", cwe));
         }
-        if self.is_testing{
-            tags.push("DATADOG_TESTING:true".to_string());  
+        if self.is_testing {
+            tags.push("DATADOG_TESTING:true".to_string());
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();
         builder.properties(props);

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -698,6 +698,7 @@ mod tests {
             .cwe(Some("1234".to_string()))
             .arguments(vec![])
             .tests(vec![])
+            .is_testing(None)
             .build()
             .unwrap();
 
@@ -847,6 +848,7 @@ mod tests {
             .cwe(Some("1234".to_string()))
             .arguments(vec![])
             .tests(vec![])
+            .is_testing(None)
             .build()
             .unwrap();
 
@@ -927,6 +929,7 @@ mod tests {
             .arguments(vec![])
             .cwe(None)
             .tests(vec![])
+            .is_testing(None)
             .build()
             .unwrap();
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -696,7 +696,7 @@ mod tests {
             .cwe(Some("1234".to_string()))
             .arguments(vec![])
             .tests(vec![])
-            .is_testing(None)
+            .is_testing(false)
             .build()
             .unwrap();
 
@@ -846,7 +846,7 @@ mod tests {
             .cwe(Some("1234".to_string()))
             .arguments(vec![])
             .tests(vec![])
-            .is_testing(None)
+            .is_testing(false)
             .build()
             .unwrap();
 
@@ -927,7 +927,7 @@ mod tests {
             .arguments(vec![])
             .cwe(None)
             .tests(vec![])
-            .is_testing(None)
+            .is_testing(false)
             .build()
             .unwrap();
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -83,10 +83,10 @@ impl SarifRule {
         format!("DATADOG_RULE_TYPE:{}", kind)
     }
 
-    fn is_testing(&self) -> Option<bool> {
+    fn is_testing(&self) -> bool {
         match self {
             SarifRule::StaticAnalysis(r) => r.is_testing,
-            SarifRule::Secret(_) => None,
+            SarifRule::Secret(_) => false,
         }
     }
 }
@@ -218,8 +218,8 @@ impl IntoSarif for &Rule {
         if let Some(cwe) = self.cwe.as_ref() {
             tags.push(format!("CWE:{}", cwe));
         }
-        if let Some(_is_testing) = self.is_testing {
-            tags.push("DATADOG_TESTING:true".to_string());
+        if self.is_testing{
+            tags.push("DATADOG_TESTING:true".to_string());  
         }
         let props = PropertyBagBuilder::default().tags(tags).build().unwrap();
         builder.properties(props);
@@ -490,10 +490,8 @@ fn generate_results(
                 }
 
                 // If the rule is a test, add a tag
-                if let Some(is_testing) = rule.is_testing() {
-                    if is_testing {
-                        tags.push("DATADOG_TESTING:true".to_string());
-                    }
+                if rule.is_testing() {
+                    tags.push("DATADOG_TESTING:true".to_string());
                 }
             }
 

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -324,7 +324,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         let rule_valid_checksum = Rule {
             name: "myrule".to_string(),
@@ -343,7 +343,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         assert!(!rule_invalid_checksum.verify_checksum());
         assert!(rule_valid_checksum.verify_checksum());
@@ -367,7 +367,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -391,7 +391,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -415,7 +415,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_some());

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -324,7 +324,6 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
         };
         let rule_valid_checksum = Rule {
             name: "myrule".to_string(),
@@ -343,7 +342,6 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
         };
         assert!(!rule_invalid_checksum.verify_checksum());
         assert!(rule_valid_checksum.verify_checksum());
@@ -367,7 +365,6 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -391,7 +388,6 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -415,7 +411,6 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_some());

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -143,7 +143,7 @@ pub struct Rule {
     pub language: Language,
     pub rule_type: RuleType,
     pub entity_checked: Option<EntityChecked>,
-    pub is_testing: Option<bool>,
+    pub is_testing: bool,
     #[serde(rename = "code")]
     pub code_base64: String,
     pub cwe: Option<String>,

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -324,7 +324,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         let rule_valid_checksum = Rule {
             name: "myrule".to_string(),
@@ -343,7 +343,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         assert!(!rule_invalid_checksum.verify_checksum());
         assert!(rule_valid_checksum.verify_checksum());
@@ -367,7 +367,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -391,7 +391,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -415,7 +415,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_some());

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -324,6 +324,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
+            is_testing: false,
         };
         let rule_valid_checksum = Rule {
             name: "myrule".to_string(),
@@ -342,6 +343,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
+            is_testing: false,
         };
         assert!(!rule_invalid_checksum.verify_checksum());
         assert!(rule_valid_checksum.verify_checksum());
@@ -365,6 +367,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -388,6 +391,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_none());
@@ -411,6 +415,7 @@ mod tests {
             tree_sitter_query_base64: None,
             arguments: vec![],
             tests: vec![],
+            is_testing: false,
         };
         let fixed_ruled = rule.fix_cwe();
         assert!(fixed_ruled.cwe.is_some());

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -143,6 +143,7 @@ pub struct Rule {
     pub language: Language,
     pub rule_type: RuleType,
     pub entity_checked: Option<EntityChecked>,
+    pub is_testing: Option<bool>,
     #[serde(rename = "code")]
     pub code_base64: String,
     pub cwe: Option<String>,

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -143,7 +143,7 @@ pub struct Rule {
     pub language: Language,
     pub rule_type: RuleType,
     pub entity_checked: Option<EntityChecked>,
-    pub is_testing: bool,
+    pub is_testing: Option<bool>,
     #[serde(rename = "code")]
     pub code_base64: String,
     pub cwe: Option<String>,

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -27,7 +27,7 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
-    pub is_testing: Option<bool>,
+    pub is_testing: bool,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,6 +15,7 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
+    pub is_testing: bool,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]
@@ -27,7 +28,6 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
-    pub is_testing: bool,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,7 +15,7 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
-    pub is_testing: bool,
+    pub is_testing: Option<bool>,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,6 +15,7 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
+    pub is_testing: Option<bool>,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,7 +15,6 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
-    pub is_testing: bool,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]
@@ -28,6 +27,7 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
+    pub is_testing: bool,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,7 +15,6 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
-    pub is_testing: Option<bool>,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]
@@ -28,6 +27,7 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
+    pub is_testing: Option<bool>,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -15,7 +15,7 @@ pub struct ServerRule {
     pub category: Option<RuleCategory>,
     pub severity: Option<RuleSeverity>,
     pub language: Language,
-    pub is_testing: Option<bool>,
+    pub is_testing: bool,
     #[serde(rename = "type")]
     pub rule_type: RuleType,
     #[serde(rename = "entity_checked")]

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -252,6 +252,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -285,6 +286,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -320,6 +322,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -355,6 +358,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -390,6 +394,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -417,6 +422,7 @@ mod tests {
             pattern: None,
             tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
             arguments: vec![],
+            is_testing: false,
         };
         let mut request = AnalysisRequest {
             filename: "path/to/myfile.py".to_string(),
@@ -588,6 +594,7 @@ rulesets:
                 pattern: None,
                 tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                 arguments: vec![],
+                is_testing: false,
             }],
         };
         let response = process_analysis_request(request.clone());
@@ -644,6 +651,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };
@@ -685,6 +693,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
+                    is_testing: false,
                 }
             ]
         };

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -252,7 +252,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -286,7 +286,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -322,7 +322,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -358,7 +358,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -394,7 +394,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -422,7 +422,7 @@ mod tests {
             pattern: None,
             tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
             arguments: vec![],
-            is_testing: false,
+            is_testing: Some(false),
         };
         let mut request = AnalysisRequest {
             filename: "path/to/myfile.py".to_string(),
@@ -594,7 +594,7 @@ rulesets:
                 pattern: None,
                 tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                 arguments: vec![],
-                is_testing: false,
+                is_testing: Some(false),
             }],
         };
         let response = process_analysis_request(request.clone());
@@ -651,7 +651,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };
@@ -693,7 +693,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
+                    is_testing: Some(false),
                 }
             ]
         };

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -112,6 +112,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             tree_sitter_query_base64: r.tree_sitter_query_base64.clone(),
             arguments: r.arguments.clone(),
             tests: vec![],
+            is_testing: r.is_testing,
         })
         .collect();
 

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -252,7 +252,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -286,7 +285,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -322,7 +320,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -358,7 +355,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -394,7 +390,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -422,7 +417,6 @@ mod tests {
             pattern: None,
             tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
             arguments: vec![],
-            is_testing: false,
         };
         let mut request = AnalysisRequest {
             filename: "path/to/myfile.py".to_string(),
@@ -594,7 +588,6 @@ rulesets:
                 pattern: None,
                 tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                 arguments: vec![],
-                is_testing: false,
             }],
         };
         let response = process_analysis_request(request.clone());
@@ -651,7 +644,6 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -693,7 +685,6 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -252,7 +252,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -286,7 +286,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -322,7 +322,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -358,7 +358,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -394,7 +394,7 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -422,7 +422,7 @@ mod tests {
             pattern: None,
             tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
             arguments: vec![],
-            is_testing: Some(false),
+            is_testing: false,
         };
         let mut request = AnalysisRequest {
             filename: "path/to/myfile.py".to_string(),
@@ -594,7 +594,7 @@ rulesets:
                 pattern: None,
                 tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                 arguments: vec![],
-                is_testing: Some(false),
+                is_testing: false,
             }],
         };
         let response = process_analysis_request(request.clone());
@@ -651,7 +651,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };
@@ -693,7 +693,7 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: Some(false),
+                    is_testing: false,
                 }
             ]
         };

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -144,7 +144,8 @@ def transform_rule(rule):
         "tree_sitter_query": rule['tree_sitter_query'],
         'code': rule['code'],
         'variables': {},
-        'checksum': rule['checksum']
+        'checksum': rule['checksum'],
+        'is_testing': rule['is_testing']
     }
 
 def test_ruleset_cli(ruleset):


### PR DESCRIPTION
## What problem are you trying to solve?
We would like to create a system in which we can test rules before adding them to the pool of production-ready rules.

## What is your solution?
As part of an effort to build a system in which rules can be tested but not be disruptive, we're adding an `is_testing` boolean flag on rules. This tag can be used for filtering, tagging, etc.

This PR adds handling to the analyzer for the `is_testing` boolean flag on rules retrieved from the Rules API. 

# Testing
Create a ruleset that has both a testing rule and a non-testing rule. Populate with rules that are known to have violations in the datadog-static-analyzer-test-repo.

Make the config use the test ruleset:
```
 ~/g/s/g/D/datadog-static-analyzer: cat ../datadog-static-analyzer-test-repo/static-analysis.datadog.yml          
rulesets:
  - celia-testing
```

Run a scan without including the test rule
```
cargo run --bin datadog-static-analyzer -- --directory ../datadog-static-analyzer-test-repo --format sarif --output test.sarif --staging
```

See lack of a `DATADOG_TESTING:true` tag in the SARIF output:
```
 "properties": {
            "tags": [
              "DATADOG_CATEGORY:BEST_PRACTICES"
            ]
          },
```

Run a scan including the test rule
```
cargo run --bin datadog-static-analyzer -- --directory ../datadog-static-analyzer-test-repo --format sarif --output test.sarif --staging --include-testing-rules
```

See at least one more rule in the rule count, and see in the output sarif something like this (focusing on the tags): 
```
{
          "fixes": [],
          "level": "error",
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "java/path-traversal-file-read.java"
                },
                "region": {
                  "endColumn": 56,
                  "endLine": 7,
                  "startColumn": 51,
                  "startLine": 7
                }
              }
            }
          ],
          "message": {
            "text": "Path traversal using an un-sanitized value"
          },
          "partialFingerprints": {
            "DATADOG_FINGERPRINT": "97b8fe5189cabfa9223611d586882bb7bfe422493b1b2bc65c81f59732cb4fa4"
          },
          "properties": {
            "tags": [
              "DATADOG_CATEGORY:BEST_PRACTICES",
              "DATADOG_TESTING:true"
            ]
          },
          "ruleId": "celia-testing/celia-testing",
          "ruleIndex": 0
        }
```
