### PR TITLE
[STAL-1686] Follow-up for handling rules marked as `is_testing`

### DIFF
--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -143,7 +143,6 @@ pub struct Rule {
     pub language: Language,
     pub rule_type: RuleType,
     pub entity_checked: Option<EntityChecked>,
-    pub is_testing: bool,
     #[serde(rename = "code")]
     pub code_base64: String,
     pub cwe: Option<String>,
@@ -154,6 +153,8 @@ pub struct Rule {
     #[serde(default)]
     pub arguments: Vec<Argument>,
     pub tests: Vec<RuleTest>,
+    #[serde(default)]
+    pub is_testing: bool,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize, Builder)]

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -27,6 +27,7 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
+    #[serde(default)]
     pub is_testing: bool,
 }
 

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -27,8 +27,6 @@ pub struct ServerRule {
     pub tree_sitter_query_base64: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
-    #[serde(default)]
-    pub is_testing: bool,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -112,7 +112,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             tree_sitter_query_base64: r.tree_sitter_query_base64.clone(),
             arguments: r.arguments.clone(),
             tests: vec![],
-            is_testing: r.is_testing,
+            is_testing: false,
         })
         .collect();
 
@@ -252,7 +252,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -286,7 +285,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -322,7 +320,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -358,7 +355,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -394,7 +390,6 @@ mod tests {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -422,7 +417,6 @@ mod tests {
             pattern: None,
             tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
             arguments: vec![],
-            is_testing: false,
         };
         let mut request = AnalysisRequest {
             filename: "path/to/myfile.py".to_string(),
@@ -594,7 +588,6 @@ rulesets:
                 pattern: None,
                 tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                 arguments: vec![],
-                is_testing: false,
             }],
         };
         let response = process_analysis_request(request.clone());
@@ -651,7 +644,6 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };
@@ -693,7 +685,6 @@ function visit(node, filename, code) {
                     pattern: None,
                     tree_sitter_query_base64: Some("KGZ1bmN0aW9uX2RlZmluaXRpb24KICAgIG5hbWU6IChpZGVudGlmaWVyKSBAbmFtZQogIHBhcmFtZXRlcnM6IChwYXJhbWV0ZXJzKSBAcGFyYW1zCik=".to_string()),
                     arguments: vec![],
-                    is_testing: false,
                 }
             ]
         };

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -204,7 +204,7 @@ def test_ruleset_cli(ruleset):
 
             # Invoke the tool, do not print anything
             cmd = f"{options.clibin} -r {test_rules_file} -i {ruledir} -o {test_results_file} -f json"
-            subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
             # check that the number of violations match the number of expected annotations
             with open(test_results_file) as results_file:

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -204,8 +204,12 @@ def test_ruleset_cli(ruleset):
 
             # Invoke the tool, do not print anything
             cmd = f"{options.clibin} -r {test_rules_file} -i {ruledir} -o {test_results_file} -f json"
-            subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
+            # TODO: There should be a cleaner way to be able to parse the output of the error
+            try:
+                subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+            
             # check that the number of violations match the number of expected annotations
             with open(test_results_file) as results_file:
                 results = results_file.read()

--- a/misc/test-production-rules.py
+++ b/misc/test-production-rules.py
@@ -151,7 +151,6 @@ def transform_rule(rule):
         'code': rule['code'],
         'variables': {},
         'checksum': rule['checksum'],
-        'is_testing': rule['is_testing']
     }
 
 def test_ruleset_cli(ruleset):


### PR DESCRIPTION
## What problem are you trying to solve?


When releasing version [0.3.3](https://github.com/DataDog/datadog-static-analyzer/pull/345) of the analyzer, we started having 422s. This was due to the front-end not sending `is_testing` if `is_testing` was unset. The IDE integration would have the same issue. This PR does the following to address this issue:

1. Adds a default value (false) if `is_testing` is empty in the Rule struct.
2. Remove the `is_testing` field from the ServerRule struct.
3. Updates the `test-production-rules.py` integration test to expose the error if it fails, rather than just `returned non-zero exit status 1.`
- However, there could possibly be a cleaner way of surfacing the error. The current output is 
```
Testing ruleset python-best-practices on the CLI
   Testing rule special-methods-arguments
Traceback (most recent call last):
  File "/home/runner/work/datadog-static-analyzer/datadog-static-analyzer/misc/test-production-rules.py", line 208, in test_ruleset_cli
    subprocess.run(shlex.split(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/runner/work/datadog-static-analyzer/datadog-static-analyzer/target/release/datadog-static-analyzer', '-r', '/tmp/tmp7tcyto2m/special-methods-arguments/next-with-error.py.datadog.rules', '-i', '/tmp/tmp7tcyto2m/special-methods-arguments', '-o', '/tmp/tmp7tcyto2m/special-methods-arguments/next-with-error.py.results', '-f', 'json']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/datadog-static-analyzer/datadog-static-analyzer/misc/test-production-rules.py", line 243, in <module>
    test_ruleset_cli(ruleset)
  File "/home/runner/work/datadog-static-analyzer/datadog-static-analyzer/misc/test-production-rules.py", line 210, in test_ruleset_cli
    raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
RuntimeError: command '['/home/runner/work/datadog-static-analyzer/datadog-static-analyzer/target/release/datadog-static-analyzer', '-r', '/tmp/tmp7tcyto2m/special-methods-arguments/next-with-error.py.datadog.rules', '-i', '/tmp/tmp7tcyto2m/special-methods-arguments', '-o', '/tmp/tmp7tcyto2m/special-methods-arguments/next-with-error.py.results', '-f', 'json']' return with error (code 1): b'Error: cannot read ruleset from file\n\nCaused by:\n    missing field `is_testing` at line 1 column 2486\n'
```

## What is your solution?

## Testing
Followed the procedure here: https://github.com/DataDog/datadog-static-analyzer/pull/339
