### PR TITLE
[STAL-2007] Handle branch from Gitlab pipelines

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -485,7 +485,7 @@ fn main() -> Result<()> {
 
     // check if we do a diff-aware scan
     let diff_aware_parameters: Option<DiffAwareData> = if diff_aware_requested {
-        match configuration.generate_diff_aware_request_data() {
+        match configuration.generate_diff_aware_request_data(configuration.use_debug) {
             Ok(params) => {
                 if configuration.use_debug {
                     println!("Diff-aware request with repository url {}, sha {}, branch {}, config hash {}", params.repository_url, params.sha, params.branch, params.config_hash);

--- a/crates/cli/src/constants.rs
+++ b/crates/cli/src/constants.rs
@@ -8,3 +8,6 @@ pub static SARIF_PROPERTY_DATADOG_FINGERPRINT: &str = "DATADOG_FINGERPRINT";
 pub static SARIF_PROPERTY_SHA: &str = "SHA";
 
 pub static DEFAULT_MAX_FILE_SIZE_KB: u64 = 200;
+// See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+pub static GITLAB_ENVIRONMENT_VARIABLE_COMMIT_BRANCH: &str = "CI_COMMIT_BRANCH";
+pub static GIT_HEAD: &str = "HEAD";

--- a/crates/cli/src/git_utils.rs
+++ b/crates/cli/src/git_utils.rs
@@ -1,0 +1,47 @@
+use crate::constants::{GITLAB_ENVIRONMENT_VARIABLE_COMMIT_BRANCH, GIT_HEAD};
+use git2::Repository;
+use std::env;
+
+/// Try to get the branch running. We first try to get the branch from the repository. When
+/// it fails, we attempt to get the branch from the CI provider when the analyzer
+/// runs in a CI provider.
+///
+/// Some CI providers (like Gitlab) runs their CI on a detached HEAD (see
+/// [this thread for example](https://forum.gitlab.com/t/why-i-cant-get-the-branch-name/72462).
+///
+/// When we do not find the branch, we attempt to find it from the CI provider using variables.
+pub fn get_branch(repository: &Repository, use_debug: bool) -> Option<String> {
+    // First, let's try to get it from the repository.
+    let head_try = repository.head();
+    if let Ok(head) = head_try {
+        let branch_from_shorthand = head.shorthand();
+
+        if let Some(branch) = branch_from_shorthand {
+            if branch == GIT_HEAD && use_debug {
+                eprintln!("branch is HEAD, not using it for diff-aware");
+            }
+
+            if branch != GIT_HEAD {
+                if use_debug {
+                    eprintln!("Getting branch {} from Git repo", branch)
+                }
+
+                return Some(branch.to_string());
+            }
+        }
+    }
+
+    // Let's try to get it from Gitlab.
+    let branch_from_gitlab_pipeline_try = env::var(GITLAB_ENVIRONMENT_VARIABLE_COMMIT_BRANCH);
+    if let Ok(branch_from_gitlab_pipeline) = branch_from_gitlab_pipeline_try {
+        if use_debug {
+            eprintln!(
+                "getting branch {} from Gitlab pipelines",
+                branch_from_gitlab_pipeline
+            );
+        }
+        return Some(branch_from_gitlab_pipeline);
+    }
+
+    None
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod constants;
 pub mod csv;
 pub mod datadog_utils;
 pub mod file_utils;
+mod git_utils;
 pub mod model;
 pub mod rule_utils;
 pub mod sarif;


### PR DESCRIPTION
## What problem are you trying to solve?

In Gitlab pipelines, there is no clean and easy way to get the current branch (see [thread](https://forum.gitlab.com/t/why-i-cant-get-the-branch-name/72462)). The branch cannot be fetched by existing mechanism, it is fetched through variables.

## What is your solution?

When we build the request to get diff-aware information, try to get the information in this order

1. Get it from the repo
2. Get it from the CI environment (here, GitLab)
3. Otherwise, fail
