### PR TITLE
update cc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,3 @@ serde_yaml = "0.9.21"
 sha2 = "0.10.7"
 tracing = "0.1.40"
 uuid = { version = "1.6.1", features = ["v4"] }
-
-# We're getting instability in macOS CI with cc 1.0.85, so pin to 1.0.83 until we can investigate further
-[patch.crates-io]
-cc = { git = "https://github.com/rust-lang/cc-rs", tag = "1.0.83" }

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "1.0.59"
 tree-sitter = "0.22.6"
 
 [build-dependencies]
-cc = "*"
+cc = "1.0.97"


### PR DESCRIPTION
## What problem are you trying to solve?

We have warnings when building the analyzer.

```
warning: Patch `cc v1.0.83 (https://github.com/rust-lang/cc-rs?tag=1.0.83#bfc3ba41)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
```

For context, we [hardcoded the version](https://github.com/DataDog/datadog-static-analyzer/pull/210) before in this PR because we had build issues.

## What is your solution?

Upgrade to the latest version.