### PR TITLE
show rule that fails to convert

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -122,7 +122,7 @@ fn convert_rules_to_rules_internal(
 
             let res = r
                 .to_rule_internal()
-                .context("cannot convert to rule internal");
+                .context(format!("cannot convert {} to rule internal", r.name));
 
             if configuration.show_performance_statistics {
                 println!(


### PR DESCRIPTION
## What problem are you trying to solve?

When a rule fails to convert to a rule internal, we do not know what is the rule.

## What is your solution?

Show the rule that fails.

**Before**

```
Error: cannot convert to rule internal

Caused by:
    Query error at 9:18. Invalid node type string_literal_content
```

**After**

```
Error: cannot convert csharp-best-practices/strings-with-one-char to rule internal

Caused by:
    Query error at 9:18. Invalid node type string_literal_content
```
