### PR TITLE
[STAL-2057] Hardcode include testing rules in CLI

### DIFF
--- a/crates/bins/src/bin/datadog-export-rulesets.rs
+++ b/crates/bins/src/bin/datadog-export-rulesets.rs
@@ -22,7 +22,6 @@ fn main() {
     opts.optflag("h", "help", "print this help");
     opts.optflag("v", "version", "shows the version");
     opts.optflag("s", "staging", "use staging");
-    opts.optflag("t", "include-testing-rules", "include testing rules");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -54,7 +53,6 @@ fn main() {
     }
 
     let use_staging = matches.opt_present("s");
-    let include_testing_rules = matches.opt_present("t");
     let rulesets_names = matches.opt_strs("r");
     let file_to_write = matches.opt_str("o").expect("output file");
 
@@ -62,7 +60,7 @@ fn main() {
     let rulesets: Vec<RuleSet> = rulesets_names
         .iter()
         .map(|ruleset_name| {
-            get_ruleset(ruleset_name, use_staging, include_testing_rules)
+            get_ruleset(ruleset_name, use_staging)
                 .expect("error when reading ruleset")
         })
         .collect();

--- a/crates/bins/src/bin/datadog-export-rulesets.rs
+++ b/crates/bins/src/bin/datadog-export-rulesets.rs
@@ -60,8 +60,7 @@ fn main() {
     let rulesets: Vec<RuleSet> = rulesets_names
         .iter()
         .map(|ruleset_name| {
-            get_ruleset(ruleset_name, use_staging)
-                .expect("error when reading ruleset")
+            get_ruleset(ruleset_name, use_staging).expect("error when reading ruleset")
         })
         .collect();
 

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -80,10 +80,9 @@ fn main() {
 
     let use_staging = matches.opt_present("s");
     let rulesets = matches.opt_strs("r");
-    let include_testing_rules = matches.opt_present("t");
     let mut num_failures = 0;
     for ruleset in rulesets {
-        match get_ruleset(ruleset.as_str(), use_staging, include_testing_rules) {
+        match get_ruleset(ruleset.as_str(), use_staging) {
             Ok(r) => {
                 println!("Testing ruleset {}", r.name);
                 for rule in r.rules.clone() {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -385,8 +385,8 @@ fn main() -> Result<()> {
                 " - Datadog documentation: https://docs.datadoghq.com/code_analysis/static_analysis"
             );
             println!(" - Static analyzer repository on GitHub: https://github.com/DataDog/datadog-static-analyzer");
-            let rulesets_from_api = get_all_default_rulesets(use_staging)
-                .expect("cannot get default rules");
+            let rulesets_from_api =
+                get_all_default_rulesets(use_staging).expect("cannot get default rules");
 
             rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));
         } else {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -263,7 +263,6 @@ fn main() -> Result<()> {
 
     let should_verify_checksum = !matches.opt_present("b");
     let use_staging = matches.opt_present("s");
-    let include_testing_rules = matches.opt_present("t");
     let add_git_info = matches.opt_present("g");
     let enable_performance_statistics = matches.opt_present("x");
     let print_violations = matches.opt_present("print-violations");
@@ -360,7 +359,7 @@ fn main() -> Result<()> {
         let overrides = RuleOverrides::from_config_file(&conf);
 
         let rulesets = conf.rulesets.keys().cloned().collect_vec();
-        let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging, include_testing_rules)
+        let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging)
             .context("error when reading rules from API")?;
         rules.extend(rules_from_api.into_iter().map(|rule| Rule {
             severity: overrides.severity(&rule.name, rule.severity),
@@ -386,7 +385,7 @@ fn main() -> Result<()> {
                 " - Datadog documentation: https://docs.datadoghq.com/code_analysis/static_analysis"
             );
             println!(" - Static analyzer repository on GitHub: https://github.com/DataDog/datadog-static-analyzer");
-            let rulesets_from_api = get_all_default_rulesets(use_staging, include_testing_rules)
+            let rulesets_from_api = get_all_default_rulesets(use_staging)
                 .expect("cannot get default rules");
 
             rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -31,10 +31,7 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
 ];
 
 // Get all the rules from different rulesets from Datadog
-pub fn get_rules_from_rulesets(
-    rulesets_name: &[String],
-    use_staging: bool,
-) -> Result<Vec<Rule>> {
+pub fn get_rules_from_rulesets(rulesets_name: &[String], use_staging: bool) -> Result<Vec<Rule>> {
     let mut rules: Vec<Rule> = Vec::new();
     for ruleset_name in rulesets_name {
         rules.extend(get_ruleset(ruleset_name, use_staging)?.rules);
@@ -73,10 +70,7 @@ fn get_datadog_site(use_staging: bool) -> String {
 // get rules from one ruleset at datadog
 // it connects to the API using the DD_SITE, DD_APP_KEY and DD_API_KEY and retrieve
 // the rulesets. We then extract all the rulesets
-pub fn get_ruleset(
-    ruleset_name: &str,
-    use_staging: bool,
-) -> Result<RuleSet> {
+pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
     let site = get_datadog_site(use_staging);
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
@@ -156,9 +150,7 @@ pub fn get_default_rulesets_name_for_language(
 
 /// Get all the default rulesets available at DataDog. Take all the language
 /// from `DEFAULT_RULESETS_LANGAGES` and get their rulesets
-pub fn get_all_default_rulesets(
-    use_staging: bool,
-) -> Result<Vec<RuleSet>> {
+pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
     let mut result: Vec<RuleSet> = vec![];
 
     for language in DEFAULT_RULESETS_LANGUAGES {
@@ -166,10 +158,7 @@ pub fn get_all_default_rulesets(
             get_default_rulesets_name_for_language(language.to_string(), use_staging)?;
 
         for ruleset_name in ruleset_names {
-            result.push(get_ruleset(
-                ruleset_name.as_str(),
-                use_staging,
-            )?);
+            result.push(get_ruleset(ruleset_name.as_str(), use_staging)?);
         }
     }
     Ok(result)

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -34,11 +34,10 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
 pub fn get_rules_from_rulesets(
     rulesets_name: &[String],
     use_staging: bool,
-    include_testing_rules: bool,
 ) -> Result<Vec<Rule>> {
     let mut rules: Vec<Rule> = Vec::new();
     for ruleset_name in rulesets_name {
-        rules.extend(get_ruleset(ruleset_name, use_staging, include_testing_rules)?.rules);
+        rules.extend(get_ruleset(ruleset_name, use_staging)?.rules);
     }
     Ok(rules)
 }
@@ -77,15 +76,14 @@ fn get_datadog_site(use_staging: bool) -> String {
 pub fn get_ruleset(
     ruleset_name: &str,
     use_staging: bool,
-    include_testing_rules: bool,
 ) -> Result<RuleSet> {
     let site = get_datadog_site(use_staging);
     let app_key = get_datadog_variable_value("APP_KEY");
     let api_key = get_datadog_variable_value("API_KEY");
 
     let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules={}",
-        site, ruleset_name, include_testing_rules
+        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules=true",
+        site, ruleset_name
     );
 
     let request_builder = reqwest::blocking::Client::new()
@@ -160,7 +158,6 @@ pub fn get_default_rulesets_name_for_language(
 /// from `DEFAULT_RULESETS_LANGAGES` and get their rulesets
 pub fn get_all_default_rulesets(
     use_staging: bool,
-    include_testing_rules: bool,
 ) -> Result<Vec<RuleSet>> {
     let mut result: Vec<RuleSet> = vec![];
 
@@ -172,7 +169,6 @@ pub fn get_all_default_rulesets(
             result.push(get_ruleset(
                 ruleset_name.as_str(),
                 use_staging,
-                include_testing_rules,
             )?);
         }
     }


### PR DESCRIPTION
## What problem are you trying to solve?
When using the Analyzer via the CLI, all rules, including testing rules, should be included. 

## What is your solution?
By hard-coding that all rules, including testing rules, should be pulled from the API, we remove the complexity associated with parameterizing whether or not testing rules should be included. The con of including testing rules by default is virtually only that additional results are in the resulting SARIF file. When the SARIF file gets sent to Datadog, violations from testing rules are hidden in the UI by default (but is easily accessed via a toggle). The pro of including testing rules by default is that it reduces the number of places a user needs to specify that testing rules should be included.

## Alternatives considered
1. Making the query param `exclude_testing_rules` instead of `include_testing_rules`. The con of this is that we'd need to change the semantics of this feature in many places. 
2. Update [Github Action](https://github.com/DataDog/datadog-static-analyzer-github-action) to specify that testing rules should be included, and update usage of the GHA and the CLI in many places. This choice would also result in a more manual work, and also no guarantee that all downstream consumers would pick up this change.

## What the reviewer should know
