### PR TITLE
Release 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.3.4": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.4/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
         "0.3.3": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
Includes the C# grammar updates - so we can get this out to customers who need the fixes