### PR TITLE
Use a member function of PathConfig to check if the path config allows a file.

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -10,7 +10,6 @@ use walkdir::WalkDir;
 use kernel::model::common::Language;
 use kernel::model::config_file::PathConfig;
 use kernel::model::violation::Violation;
-use kernel::path_restrictions::is_allowed_by_path_config;
 
 use crate::model::cli_configuration::CliConfiguration;
 use crate::model::datadog_api::DiffAwareData;
@@ -138,8 +137,7 @@ pub fn get_files(
                 .ok_or_else(|| anyhow::Error::msg("should get the path"))?;
 
             // check if the path is allowed by the configuration.
-            should_include =
-                should_include && is_allowed_by_path_config(path_config, relative_path_str);
+            should_include = should_include && path_config.allows_file(relative_path_str);
 
             // do not include the git directory.
             if entry.starts_with(git_directory.as_str()) {

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -191,3 +191,13 @@ impl PartialEq for PathPattern {
         self.prefix.eq(&other.prefix)
     }
 }
+
+impl PathConfig {
+    pub fn allows_file(&self, file_name: &str) -> bool {
+        !self.ignore.iter().any(|pattern| pattern.matches(file_name))
+            && match &self.only {
+                None => true,
+                Some(only) => only.iter().any(|pattern| pattern.matches(file_name)),
+            }
+    }
+}

--- a/crates/static-analysis-kernel/src/path_restrictions.rs
+++ b/crates/static-analysis-kernel/src/path_restrictions.rs
@@ -43,10 +43,10 @@ impl PathRestrictions {
         match self.rulesets.get(ruleset) {
             None => true,
             Some(restrictions) => {
-                is_allowed_by_path_config(&restrictions.paths, file_path)
+                restrictions.paths.allows_file(file_path)
                     && match restrictions.rules.get(short_name) {
                         None => true,
-                        Some(paths) => is_allowed_by_path_config(paths, file_path),
+                        Some(paths) => paths.allows_file(file_path),
                     }
             }
         }
@@ -57,20 +57,6 @@ fn split_rule_name(name: &str) -> (&str, &str) {
     match name.split_once('/') {
         None => ("", name),
         Some((ruleset, short_name)) => (ruleset, short_name),
-    }
-}
-
-pub fn is_allowed_by_path_config(paths: &PathConfig, file_name: &str) -> bool {
-    if paths
-        .ignore
-        .iter()
-        .any(|pattern| pattern.matches(file_name))
-    {
-        return false;
-    }
-    match &paths.only {
-        None => true,
-        Some(only) => only.iter().any(|pattern| pattern.matches(file_name)),
     }
 }
 

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -9,7 +9,7 @@ use kernel::analysis::analyze::analyze;
 use kernel::config_file::{parse_config_file, ArgumentProvider};
 use kernel::model::analysis::AnalysisOptions;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
-use kernel::path_restrictions::{is_allowed_by_path_config, PathRestrictions};
+use kernel::path_restrictions::PathRestrictions;
 use kernel::rule_overrides::RuleOverrides;
 use kernel::utils::decode_base64_string;
 
@@ -42,7 +42,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
     // If the file is excluded by the global configuration, stop early.
     let file_is_excluded_by_cfg = configuration
         .as_ref()
-        .map(|cfg_file| !is_allowed_by_path_config(&cfg_file.paths, &request.filename))
+        .map(|cfg_file| !cfg_file.paths.allows_file(&request.filename))
         .unwrap_or_default();
     if file_is_excluded_by_cfg {
         tracing::debug!("Skipped excluded file: {}", request.filename);


### PR DESCRIPTION
## What this PR does
This PR makes `is_allowed_by_path_config` a member function of `PathConfig`, which removes external dependencies on `path_restrictions.rs`.

## What problem are you trying to solve?
We want to add the ability to have per-subtree rule severity overrides, but before we do that, we need to refactor some of the code to generalize per-subtree overrides.

I've split the refactor into 6 PRs to make them manageable sizes. See https://github.com/DataDog/datadog-static-analyzer/tree/jacobotb/STAL-1832/severity-per-dir/99-final for the intended final state.

Future PRs will move the `ArgumentProvider` to a separate file, separate the configuration file YAML parsing from its internal representation, add a `BySubtree` type, encapsulate per-rule configurations, and finally add the per-subtree rule severity override.
