### PR TITLE
Split configuration data object and parsing code

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -1,5 +1,6 @@
 use super::error::ConfigFileError;
 use indexmap::IndexMap;
+use kernel::config_file::config_file_to_yaml;
 use kernel::{
     config_file::parse_config_file,
     model::config_file::{ConfigFile, PathConfig, PathPattern, RuleConfig, RulesetConfig},
@@ -235,7 +236,7 @@ impl StaticAnalysisConfigFile {
 
     /// Serializes the `StaticAnalysisConfigFile` into a YAML string.
     pub fn to_string(&self) -> Result<String, ConfigFileError> {
-        let str = serde_yaml::to_string(&**self)?;
+        let str = config_file_to_yaml(self)?;
         // fix null maps
         let fixed = str.replace(": null", ":");
         Ok(fixed)

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -334,8 +334,7 @@ rulesets:
                 None,
             )
             .unwrap();
-            let expected = 
-                r"
+            let expected = r"
 schema-version: v1
 rulesets:
 - ruleset1

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -9,8 +9,6 @@ use kernel::{
 use std::{borrow::Cow, fmt::Debug, ops::Deref};
 use tracing::instrument;
 
-pub const LATEST_SUPPORTED_CONFIG_VERSION: &str = "v1";
-
 pub struct StaticAnalysisConfigFile(ConfigFile);
 
 impl From<ConfigFile> for StaticAnalysisConfigFile {
@@ -172,11 +170,7 @@ impl StaticAnalysisConfigFile {
                 e
             })
         } else {
-            let mut inner = ConfigFile::default();
-            if inner.schema_version.is_empty() {
-                inner.schema_version = LATEST_SUPPORTED_CONFIG_VERSION.to_string();
-            }
-            Ok(Self(inner))
+            Ok(Self(ConfigFile::default()))
         }?;
 
         config.add_rulesets(rulesets);
@@ -340,15 +334,14 @@ rulesets:
                 None,
             )
             .unwrap();
-            let expected = format!(
+            let expected = 
                 r"
-schema-version: {LATEST_SUPPORTED_CONFIG_VERSION}
+schema-version: v1
 rulesets:
 - ruleset1
 - ruleset2
 - a-ruleset3
-"
-            );
+";
             assert_eq!(config.trim(), expected.trim());
         }
 

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -16,6 +16,10 @@ pub fn parse_config_file(config_contents: &str) -> Result<ConfigFile> {
     Ok(serde_yaml::from_str(config_contents)?)
 }
 
+pub fn config_file_to_yaml(cfg: &ConfigFile) -> Result<String> {
+    Ok(serde_yaml::to_string(cfg)?)
+}
+
 const SCHEMA_VERSION: &str = "v1";
 
 pub fn deserialize_schema_version<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -734,7 +738,7 @@ max-file-size-kb: 512
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         assert_eq!(
             serialized.trim(),
             r#"schema-version: v1
@@ -753,7 +757,7 @@ rulesets: []"#
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         assert_eq!(
             serialized.trim(),
             r#"schema-version: v1
@@ -803,7 +807,7 @@ rulesets:
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         let serialized = serialized.trim();
         let expected = r#"
 schema-version: v1
@@ -863,7 +867,7 @@ rulesets:
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         let serialized = serialized.trim();
         let expected = r#"
 schema-version: v1
@@ -914,7 +918,7 @@ rulesets:
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         let serialized = serialized.trim();
         let expected = r"
 schema-version: v1
@@ -963,7 +967,7 @@ rulesets:
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
+        let serialized = config_file_to_yaml(&config).unwrap();
         let serialized = serialized.trim();
         let expected = r"
 schema-version: v1

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -66,7 +66,7 @@ impl From<YamlConfigFile> for ConfigFile {
 impl From<ConfigFile> for YamlConfigFile {
     fn from(value: ConfigFile) -> Self {
         YamlConfigFile {
-            schema_version: YamlSchemaVersion {},
+            schema_version: YamlSchemaVersion::V1,
             rulesets: value.rulesets.into(),
             paths: value.paths.into(),
             ignore_paths: None,
@@ -77,37 +77,13 @@ impl From<ConfigFile> for YamlConfigFile {
     }
 }
 
-// YAML-serializable marker for the schema version.
-// It only deserializes successfully if it matches the expected value.
-#[derive(Default)]
-struct YamlSchemaVersion {}
-
-const SCHEMA_VERSION: &str = "v1";
-
-impl<'de> Deserialize<'de> for YamlSchemaVersion {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let v = String::deserialize(deserializer)?;
-        if v != SCHEMA_VERSION {
-            Err(Error::invalid_value(
-                Unexpected::Str(&v),
-                &format!("\"{}\"", SCHEMA_VERSION).as_str(),
-            ))
-        } else {
-            Ok(YamlSchemaVersion {})
-        }
-    }
-}
-
-impl Serialize for YamlSchemaVersion {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        SCHEMA_VERSION.serialize(serializer)
-    }
+// YAML-serializable schema version.
+// It only contains the expected value for this parser.
+#[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+enum YamlSchemaVersion {
+    #[default]
+    V1,
 }
 
 // YAML-serializable ruleset list.

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -424,9 +424,9 @@ impl<'de> Deserialize<'de> for YamlRuleCategory {
 // A map from string to value that disallows repeated keys when deserializing.
 #[derive(Serialize, Default, PartialEq)]
 #[serde(transparent)]
-struct UniqueKeyMap<T>(IndexMap<String, T>);
+struct UniqueKeyMap<V>(IndexMap<String, V>);
 
-impl<T> UniqueKeyMap<T> {
+impl<V> UniqueKeyMap<V> {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -46,7 +46,6 @@ struct YamlConfigFile {
 impl From<YamlConfigFile> for ConfigFile {
     fn from(value: YamlConfigFile) -> Self {
         ConfigFile {
-            schema_version: SCHEMA_VERSION.to_string(),
             rulesets: value.rulesets.into(),
             paths: {
                 let mut paths: PathConfig = value.paths.into();
@@ -584,7 +583,6 @@ rulesets:
   - go-best-practices
     "#;
         let expected = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::from([
                 ("python-security".to_string(), RulesetConfig::default()),
                 ("go-best-practices".to_string(), RulesetConfig::default()),
@@ -635,7 +633,6 @@ rulesets:
     "#;
 
         let expected = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::from([
                 ("c-best-practices".to_string(), RulesetConfig::default()),
                 ("rust-best-practices".to_string(), RulesetConfig::default()),
@@ -724,7 +721,6 @@ rulesets:
           - "py/insecure/**"
     "#;
         let expected = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::from([(
                 "python-security".to_string(),
                 RulesetConfig {
@@ -820,7 +816,6 @@ rulesets:
         "#;
 
         let expected = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::from([(
                 "python-security".to_string(),
                 RulesetConfig {
@@ -911,7 +906,6 @@ max-file-size-kb: 512
     "#;
 
         let expected = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::from([("python-security".to_string(), RulesetConfig::default())]),
             paths: PathConfig {
                 only: Some(vec!["py/**/foo/*.py".to_string().into()]),
@@ -943,7 +937,6 @@ max-file-size-kb: 512
     #[test]
     fn test_serialize_ruleset_configs_empty() {
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets: IndexMap::new(),
             ..Default::default()
         };
@@ -962,7 +955,6 @@ rulesets: []"#
         rulesets.insert("java-1".to_string(), RulesetConfig::default());
 
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets,
             ..Default::default()
         };
@@ -1012,7 +1004,6 @@ rulesets:
         );
 
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets,
             ..Default::default()
         };
@@ -1072,7 +1063,6 @@ rulesets:
         );
 
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets,
             ..Default::default()
         };
@@ -1123,7 +1113,6 @@ rulesets:
         );
 
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets,
             ..Default::default()
         };
@@ -1172,7 +1161,6 @@ rulesets:
         );
 
         let config = ConfigFile {
-            schema_version: "v1".to_string(),
             rulesets,
             ..Default::default()
         };

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -1,34 +1,25 @@
 use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
-use serde;
-use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use crate::config_file::{
-    deserialize_category, deserialize_rule_configs, deserialize_ruleset_configs,
-    deserialize_schema_version, get_default_schema_version, serialize_ruleset_configs,
-};
 use crate::model::rule::{RuleCategory, RuleSeverity};
 
 // A pattern for an 'only' or 'ignore' field. The 'glob' field contains a precompiled glob pattern,
 // while the 'prefix' field contains a path prefix.
-#[derive(Deserialize, Serialize, Debug, Default, Clone)]
-#[serde(from = "String", into = "String")]
+#[derive(Debug, Default, Clone)]
 pub struct PathPattern {
     pub glob: Option<GlobMatcher>,
     pub prefix: PathBuf,
 }
 
 // Lists of directories and glob patterns to include/exclude from the analysis.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct PathConfig {
     // Analyze only these directories and patterns.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub only: Option<Vec<PathPattern>>,
     // Do not analyze any of these directories and patterns.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore: Vec<PathPattern>,
 }
 
@@ -38,109 +29,41 @@ pub struct ArgumentValues {
 }
 
 // Configuration for a single rule.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct RuleConfig {
     // Paths to include/exclude for this rule.
-    #[serde(flatten)]
     pub paths: PathConfig,
-    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    // Arguments to pass to this rule.
     pub arguments: IndexMap<String, ArgumentValues>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Override this rule's severity.
     pub severity: Option<RuleSeverity>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_category",
-        default
-    )]
+    // Override this rule's category.
     pub category: Option<RuleCategory>,
 }
 
 // Configuration for a ruleset.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct RulesetConfig {
     // Paths to include/exclude for all rules in this ruleset.
-    #[serde(flatten)]
     pub paths: PathConfig,
     // Rule-specific configurations.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_rule_configs",
-        skip_serializing_if = "IndexMap::is_empty"
-    )]
     pub rules: IndexMap<String, RuleConfig>,
 }
 
 // The parsed configuration file without any legacy fields.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Default)]
-#[serde(from = "RawConfigFile")]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct ConfigFile {
-    #[serde(rename = "schema-version")]
     pub schema_version: String,
     // Configurations for the rulesets.
-    #[serde(serialize_with = "serialize_ruleset_configs")]
     pub rulesets: IndexMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.
-    #[serde(flatten)]
     pub paths: PathConfig,
     // Ignore all the paths in the .gitignore file.
-    #[serde(rename = "ignore-gitignore", skip_serializing_if = "Option::is_none")]
     pub ignore_gitignore: Option<bool>,
     // Analyze only files up to this size.
-    #[serde(rename = "max-file-size-kb", skip_serializing_if = "Option::is_none")]
     pub max_file_size_kb: Option<u64>,
-    #[serde(
-        rename = "ignore-generated-files",
-        skip_serializing_if = "Option::is_none"
-    )]
+    // Do not analyze generated files.
     pub ignore_generated_files: Option<bool>,
-}
-
-// The raw configuration file format with legacy fields and other quirks.
-#[derive(Deserialize)]
-struct RawConfigFile {
-    // Version this configuration file complies with.
-    #[serde(
-        rename = "schema-version",
-        default = "get_default_schema_version",
-        deserialize_with = "deserialize_schema_version"
-    )]
-    schema_version: String,
-    // Configurations for the rulesets.
-    #[serde(deserialize_with = "deserialize_ruleset_configs")]
-    rulesets: IndexMap<String, RulesetConfig>,
-    // Paths to include/exclude from analysis.
-    #[serde(flatten)]
-    paths: PathConfig,
-    // For backwards compatibility. Its content will be added to paths.ignore.
-    #[serde(rename = "ignore-paths")]
-    ignore_paths: Option<Vec<PathPattern>>,
-    // Ignore all the paths in the .gitignore file.
-    #[serde(rename = "ignore-gitignore")]
-    ignore_gitignore: Option<bool>,
-    // Analyze only files up to this size.
-    #[serde(rename = "max-file-size-kb")]
-    max_file_size_kb: Option<u64>,
-    #[serde(rename = "ignore-generated-files")]
-    ignore_generated_files: Option<bool>,
-}
-
-impl From<RawConfigFile> for ConfigFile {
-    fn from(value: RawConfigFile) -> Self {
-        ConfigFile {
-            schema_version: value.schema_version,
-            rulesets: value.rulesets,
-            paths: {
-                let mut paths = value.paths;
-                if let Some(ignore) = value.ignore_paths {
-                    paths.ignore.extend(ignore);
-                }
-                paths
-            },
-            ignore_gitignore: value.ignore_gitignore,
-            max_file_size_kb: value.max_file_size_kb,
-            ignore_generated_files: value.ignore_generated_files,
-        }
-    }
 }
 
 impl fmt::Display for ConfigFile {

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -53,7 +53,6 @@ pub struct RulesetConfig {
 // The parsed configuration file without any legacy fields.
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct ConfigFile {
-    pub schema_version: String,
     // Configurations for the rulesets.
     pub rulesets: IndexMap<String, RulesetConfig>,
     // Paths to include/exclude from analysis.


### PR DESCRIPTION
## What this PR does
Removes all the YAML parsing functionality from `ConfigFile` and moves it to the `src/config_file.rs` file. This PR also adds a `config_file_to_yaml` function, to be used instead of a direct call to `serde_yaml::to_str`. The existing unit tests pass without changes to their inputs or outputs.

These changes separate the YAML representation of the configuration from its binary representation, which lets us have each one in a convenient form for its intended use.

For example, in the YAML, the rulesets are defined in a list, while in the `ConfigFile` they are a map. With the original representation, the parsing code was quite awkward. Now it just parses as a list, and we convert it to a map when we generate the `ConfigFile` object.

This will make it easier to create and use a special data type that holds per-subtree values of any type. Right now we have it for argument values, but it's a one-off; we will need it for `RuleSeverities` too.

## What problem are you trying to solve?
We want to add the ability to have per-subtree rule severity overrides, but before we do that, we need to refactor some of the code to generalize per-subtree overrides.

I've split the refactor into 6 PRs to make them manageable sizes. See https://github.com/DataDog/datadog-static-analyzer/tree/jacobotb/STAL-1832/severity-per-dir/99-final for the intended final state.

Future PRs will add a `BySubtree` type, encapsulate per-rule configurations, and finally add the per-subtree rule severity override.
