### PR TITLE
Add a specific type for values that depend on the subtree

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -5,7 +5,7 @@ use crate::analysis::tree_sitter::{get_query_nodes, get_tree};
 use crate::arguments::ArgumentProvider;
 use crate::model::analysis::{AnalysisOptions, FileIgnoreBehavior, LinesToIgnore};
 use crate::model::common::Language;
-use crate::model::config_file::SplitPath;
+use crate::model::config_file::split_path;
 use crate::model::rule::{RuleInternal, RuleResult};
 use std::borrow::Borrow;
 use std::collections::HashMap;
@@ -133,7 +133,7 @@ where
 
     let parsing_time_ms = parsing_time.elapsed().as_millis();
 
-    let split_filename = SplitPath::from_string(filename);
+    let split_filename = split_path(filename);
 
     tree.map_or_else(
         || {
@@ -205,7 +205,6 @@ mod tests {
     use super::*;
     use crate::analysis::tree_sitter::get_query;
     use crate::model::common::Language;
-    use crate::model::config_file::SplitPath;
     use crate::model::rule::{RuleCategory, RuleSeverity};
 
     const QUERY_CODE: &str = r#"
@@ -858,18 +857,8 @@ function visit(node, filename, code) {
             ignore_generated_files: false,
         };
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument(
-            "rule1",
-            &SplitPath::from_string("myfile.py"),
-            "my-argument",
-            "101",
-        );
-        argument_provider.add_argument(
-            "rule1",
-            &SplitPath::from_string("myfile.py"),
-            "another-arg",
-            "101",
-        );
+        argument_provider.add_argument("rule1", &split_path("myfile.py"), "my-argument", "101");
+        argument_provider.add_argument("rule1", &split_path("myfile.py"), "another-arg", "101");
 
         let results = analyze(
             &Language::Python,

--- a/crates/static-analysis-kernel/src/arguments.rs
+++ b/crates/static-analysis-kernel/src/arguments.rs
@@ -1,15 +1,12 @@
-use crate::model::config_file::ConfigFile;
-use sequence_trie::SequenceTrie;
+use crate::model::config_file::{BySubtree, ConfigFile, SplitPath};
 use std::collections::HashMap;
 
 type Argument = (String, String);
 
-type ArgumentsByPrefix = SequenceTrie<String, Vec<Argument>>;
-
 #[derive(Clone)]
 // Used to extract rule arguments in the analyzer.
 pub struct ArgumentProvider {
-    by_rule: HashMap<String, ArgumentsByPrefix>,
+    by_rule: HashMap<String, BySubtree<Vec<Argument>>>,
 }
 
 impl ArgumentProvider {
@@ -25,8 +22,8 @@ impl ArgumentProvider {
             for (rule_shortname, rule_cfg) in &ruleset_cfg.rules {
                 for (arg_name, arg_values) in &rule_cfg.arguments {
                     let rule_name = format!("{}/{}", ruleset_name, rule_shortname);
-                    for (prefix, value) in &arg_values.by_subtree {
-                        provider.add_argument(&rule_name, prefix, arg_name, value);
+                    for (prefix, value) in arg_values {
+                        provider.add_argument(&rule_name, &prefix, arg_name, value);
                     }
                 }
             }
@@ -34,19 +31,11 @@ impl ArgumentProvider {
         provider
     }
 
-    pub fn add_argument(&mut self, rule_name: &str, path: &str, argument: &str, value: &str) {
-        let prefix: Vec<String> = path
-            .split('/')
-            .filter(|c| !c.is_empty())
-            .map(|c| c.to_string())
-            .collect();
-        let trie = self.by_rule.entry(rule_name.to_string()).or_default();
-        match trie.get_mut(prefix.iter()) {
+    pub fn add_argument(&mut self, rule_name: &str, path: &SplitPath, argument: &str, value: &str) {
+        let by_subtree = self.by_rule.entry(rule_name.to_string()).or_default();
+        match by_subtree.get_mut(path) {
             None => {
-                trie.insert(
-                    prefix.iter(),
-                    vec![(argument.to_string(), value.to_string())],
-                );
+                by_subtree.insert(path, vec![(argument.to_string(), value.to_string())]);
             }
             Some(v) => {
                 v.push((argument.to_string(), value.to_string()));
@@ -55,13 +44,10 @@ impl ArgumentProvider {
     }
 
     /// Returns the arguments that apply to the given file and the given rule.
-    pub fn get_arguments(&self, filename: &str, rulename: &str) -> HashMap<String, String> {
+    pub fn get_arguments(&self, filename: &SplitPath, rulename: &str) -> HashMap<String, String> {
         let mut out = HashMap::new();
         if let Some(by_prefix) = self.by_rule.get(rulename) {
-            for args in by_prefix
-                .prefix_iter(filename.split('/').filter(|c| !c.is_empty()))
-                .filter_map(|x| x.value())
-            {
+            for args in by_prefix.prefix_iter(filename) {
                 // Longer prefixes appear last, so they'll override arguments from shorter prefixes.
                 out.extend(args.clone());
             }
@@ -84,44 +70,62 @@ mod tests {
     #[test]
     fn test_argument_provider_returns_arg_for_default_prefix() {
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule", "/", "arg", "value");
+        argument_provider.add_argument("rule", &SplitPath::from_string("/"), "arg", "value");
 
         let expected = HashMap::from([("arg".to_string(), "value".to_string())]);
-        assert_eq!(argument_provider.get_arguments("a", "rule"), expected);
-        assert_eq!(argument_provider.get_arguments("b/c", "rule"), expected);
+        assert_eq!(
+            argument_provider.get_arguments(&SplitPath::from_string("a"), "rule"),
+            expected
+        );
+        assert_eq!(
+            argument_provider.get_arguments(&SplitPath::from_string("b/c"), "rule"),
+            expected
+        );
     }
 
     #[test]
     fn test_argument_provider_returns_arg_for_path_prefix() {
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule", "a/b/c", "arg", "value");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a/b/c"), "arg", "value");
 
         let expected = HashMap::from([("arg".to_string(), "value".to_string())]);
-        assert!(argument_provider.get_arguments("a", "rule").is_empty());
-        assert!(argument_provider.get_arguments("a/b", "rule").is_empty());
-        assert_eq!(argument_provider.get_arguments("a/b/c", "rule"), expected);
-        assert_eq!(argument_provider.get_arguments("a/b/c/d", "rule"), expected);
+        assert!(argument_provider
+            .get_arguments(&SplitPath::from_string("a"), "rule")
+            .is_empty());
+        assert!(argument_provider
+            .get_arguments(&SplitPath::from_string("a/b"), "rule")
+            .is_empty());
+        assert_eq!(
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c"), "rule"),
+            expected
+        );
+        assert_eq!(
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c/d"), "rule"),
+            expected
+        );
     }
 
     #[test]
     fn test_argument_provider_returns_arg_for_longest_path_prefix() {
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule", "a/b", "arg", "first");
-        argument_provider.add_argument("rule", "a/b/c", "arg", "second");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a/b"), "arg", "first");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a/b/c"), "arg", "second");
 
         let expected_first = HashMap::from([("arg".to_string(), "first".to_string())]);
         let expected_second = HashMap::from([("arg".to_string(), "second".to_string())]);
-        assert!(argument_provider.get_arguments("a", "rule").is_empty());
+        assert!(argument_provider
+            .get_arguments(&SplitPath::from_string("a"), "rule")
+            .is_empty());
         assert_eq!(
-            argument_provider.get_arguments("a/b", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b"), "rule"),
             expected_first
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b/c", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c"), "rule"),
             expected_second
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b/c/d", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c/d"), "rule"),
             expected_second
         );
     }
@@ -129,20 +133,25 @@ mod tests {
     #[test]
     fn test_argument_provider_returns_multiple_args_in_path() {
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule", "a", "arg1", "first_1");
-        argument_provider.add_argument("rule", "a", "arg2", "first_2");
-        argument_provider.add_argument("rule", "a/b", "arg3", "first_3");
-        argument_provider.add_argument("rule", "a/b/c", "arg1", "second_1");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a"), "arg1", "first_1");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a"), "arg2", "first_2");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a/b"), "arg3", "first_3");
+        argument_provider.add_argument(
+            "rule",
+            &SplitPath::from_string("a/b/c"),
+            "arg1",
+            "second_1",
+        );
 
         assert_eq!(
-            argument_provider.get_arguments("a", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "first_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string())
             ])
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "first_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string()),
@@ -150,7 +159,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b/c", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "second_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string()),
@@ -162,20 +171,25 @@ mod tests {
     #[test]
     fn test_argument_provider_is_independent_from_insertion_order() {
         let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule", "a/b/c", "arg1", "second_1");
-        argument_provider.add_argument("rule", "a", "arg2", "first_2");
-        argument_provider.add_argument("rule", "a/b", "arg3", "first_3");
-        argument_provider.add_argument("rule", "a", "arg1", "first_1");
+        argument_provider.add_argument(
+            "rule",
+            &SplitPath::from_string("a/b/c"),
+            "arg1",
+            "second_1",
+        );
+        argument_provider.add_argument("rule", &SplitPath::from_string("a"), "arg2", "first_2");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a/b"), "arg3", "first_3");
+        argument_provider.add_argument("rule", &SplitPath::from_string("a"), "arg1", "first_1");
 
         assert_eq!(
-            argument_provider.get_arguments("a", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "first_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string())
             ])
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "first_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string()),
@@ -183,7 +197,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            argument_provider.get_arguments("a/b/c", "rule"),
+            argument_provider.get_arguments(&SplitPath::from_string("a/b/c"), "rule"),
             HashMap::from([
                 ("arg1".to_string(), "second_1".to_string()),
                 ("arg2".to_string(), "first_2".to_string()),

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -1,7 +1,9 @@
 use globset::{GlobBuilder, GlobMatcher};
 use indexmap::IndexMap;
+use sequence_trie::SequenceTrie;
 use std::borrow::Borrow;
 use std::fmt;
+use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 
 use crate::model::rule::{RuleCategory, RuleSeverity};
@@ -23,10 +25,9 @@ pub struct PathConfig {
     pub ignore: Vec<PathPattern>,
 }
 
+// A structure that stores values that depend on the position in the repository tree.
 #[derive(Debug, PartialEq, Default, Clone)]
-pub struct ArgumentValues {
-    pub by_subtree: IndexMap<String, String>,
-}
+pub struct BySubtree<T>(SequenceTrie<String, T>);
 
 // Configuration for a single rule.
 #[derive(Debug, PartialEq, Default, Clone)]
@@ -34,7 +35,7 @@ pub struct RuleConfig {
     // Paths to include/exclude for this rule.
     pub paths: PathConfig,
     // Arguments to pass to this rule.
-    pub arguments: IndexMap<String, ArgumentValues>,
+    pub arguments: IndexMap<String, BySubtree<String>>,
     // Override this rule's severity.
     pub severity: Option<RuleSeverity>,
     // Override this rule's category.
@@ -121,5 +122,97 @@ impl PathConfig {
                 None => true,
                 Some(only) => only.iter().any(|pattern| pattern.matches(file_name)),
             }
+    }
+}
+
+// The key for operations on BySubtree.
+pub struct SplitPath(Vec<String>);
+
+impl SplitPath {
+    pub fn from_string(path: &str) -> Self {
+        SplitPath(
+            path.split('/')
+                .filter(|c| !c.is_empty())
+                .map(&str::to_string)
+                .collect(),
+        )
+    }
+}
+
+impl Display for SplitPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0.join("/").as_str())
+    }
+}
+
+impl<T> BySubtree<T> {
+    pub fn new() -> Self {
+        BySubtree(SequenceTrie::new())
+    }
+    pub fn get_mut(&mut self, path: &SplitPath) -> Option<&mut T> {
+        self.0.get_mut(path.0.iter())
+    }
+    pub fn insert(&mut self, path: &SplitPath, value: T) -> Option<T> {
+        self.0.insert(path.0.iter(), value)
+    }
+    pub fn prefix_iter<'s, 'k>(&'s self, path: &'k SplitPath) -> BySubtreePrefixIter<'s, 'k, T> {
+        BySubtreePrefixIter(self.0.prefix_iter(path.0.iter()))
+    }
+    pub fn iter(&self) -> BySubtreeIter<T> {
+        self.into_iter()
+    }
+}
+
+impl<V, const N: usize> From<[(String, V); N]> for BySubtree<V> {
+    fn from(value: [(String, V); N]) -> Self {
+        BySubtree::from_iter(value)
+    }
+}
+
+impl<V> FromIterator<(String, V)> for BySubtree<V> {
+    fn from_iter<T: IntoIterator<Item = (String, V)>>(iter: T) -> Self {
+        let mut out = BySubtree::new();
+        for (k, v) in iter {
+            out.insert(&SplitPath::from_string(k.as_str()), v);
+        }
+        out
+    }
+}
+
+impl<'a, T> IntoIterator for &'a BySubtree<T> {
+    type Item = (SplitPath, &'a T);
+    type IntoIter = BySubtreeIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BySubtreeIter(self.0.iter())
+    }
+}
+
+pub struct BySubtreeIter<'a, T>(sequence_trie::Iter<'a, String, T>);
+
+impl<'a, T> Iterator for BySubtreeIter<'a, T> {
+    type Item = (SplitPath, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0
+            .next()
+            .map(|(k, v)| (SplitPath(k.into_iter().cloned().collect()), v))
+    }
+}
+
+pub struct BySubtreePrefixIter<'s, 'k, T>(
+    sequence_trie::PrefixIter<'s, 'k, String, T, String, std::slice::Iter<'k, String>>,
+);
+
+impl<'s, 'k, T> Iterator for BySubtreePrefixIter<'s, 'k, T> {
+    type Item = &'s T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for item in self.0.by_ref() {
+            if let Some(value) = item.value() {
+                return Some(value);
+            }
+        }
+        None
     }
 }


### PR DESCRIPTION
## What this PR does
Creates a `BySubtree` type that stores values that depend on the specific location in the repository tree where a file is located.

This replaces the one-off `ArgumentValues` struct, and it will be used for per-subtree rule severity overrides.

The key for this type is a new `SplitPath` type that contains the split components of a pathname. This encourages the pattern where the `SplitPath` is created once for a file name and then used multiple times, instead of splitting it for every access to a `BySubtree` object. This will be more important as more uses of `BySubtree` are added.

## What problem are you trying to solve?
We want to add the ability to have per-subtree rule severity overrides, but before we do that, we need to refactor some of the code to generalize per-subtree overrides.

I've split the refactor into 6 PRs to make them manageable sizes. See https://github.com/DataDog/datadog-static-analyzer/tree/jacobotb/STAL-1832/severity-per-dir/99-final for the intended final state.

Future PRs will encapsulate per-rule configurations and add the per-subtree rule severity override.
