### PR TITLE
Add the ability to call other endpoints with JWT tokens.

### DIFF
--- a/crates/cli/src/constants.rs
+++ b/crates/cli/src/constants.rs
@@ -2,6 +2,7 @@ pub static DATADOG_CONFIG_FILE_WITHOUT_PREFIX: &str = "static-analysis.datadog";
 
 pub static DATADOG_HEADER_APP_KEY: &str = "dd-application-key";
 pub static DATADOG_HEADER_API_KEY: &str = "dd-api-key";
+pub static DATADOG_HEADER_JWT_TOKEN: &str = "dd-auth-jwt";
 pub static HEADER_CONTENT_TYPE: &str = "Content-Type";
 pub static HEADER_CONTENT_TYPE_APPLICATION_JSON: &str = "application/json";
 pub static SARIF_PROPERTY_DATADOG_FINGERPRINT: &str = "DATADOG_FINGERPRINT";

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -1,12 +1,13 @@
 use std::env;
 
 use crate::constants::{
-    DATADOG_HEADER_API_KEY, DATADOG_HEADER_APP_KEY, HEADER_CONTENT_TYPE,
+    DATADOG_HEADER_API_KEY, DATADOG_HEADER_APP_KEY, DATADOG_HEADER_JWT_TOKEN, HEADER_CONTENT_TYPE,
     HEADER_CONTENT_TYPE_APPLICATION_JSON,
 };
 use anyhow::{anyhow, Result};
 use kernel::model::rule::Rule;
 use kernel::model::ruleset::RuleSet;
+use reqwest::blocking::RequestBuilder;
 use uuid::Uuid;
 
 use crate::model::datadog_api::{
@@ -15,8 +16,8 @@ use crate::model::datadog_api::{
     DiffAwareResponse,
 };
 
-const STAGING_DATADOG_SITE: &str = "datad0g.com";
-const DEFAULT_DATADOG_SITE: &str = "datadoghq.com";
+const STAGING_DATADOG_HOSTNAME: &str = "api.datad0g.com";
+const DEFAULT_DATADOG_HOSTNAME: &str = "api.datadoghq.com";
 
 const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "CSHARP",
@@ -42,7 +43,7 @@ pub fn get_rules_from_rulesets(rulesets_name: &[String], use_staging: bool) -> R
 // Get environment variables for Datadog. First try to get the variables
 // prefixed with DD_ and then, try DATADOG_.
 // If nothing works, just returns an error.
-pub fn get_datadog_variable_value(variable: &str) -> anyhow::Result<String> {
+pub fn get_datadog_variable_value(variable: &str) -> Result<String> {
     let prefixes = vec!["DD", "DATADOG"];
     for prefix in prefixes {
         let name = format!("{}_{}", prefix, variable);
@@ -57,13 +58,56 @@ pub fn get_datadog_variable_value(variable: &str) -> anyhow::Result<String> {
     Err(anyhow!("cannot find variable DD_{}", variable))
 }
 
-// if we put the first argument to true staging, override the value and use staging.
-// otherwise, use the DD_SITE variable or the default site
-fn get_datadog_site(use_staging: bool) -> String {
-    if use_staging {
-        STAGING_DATADOG_SITE.to_string()
+// If a DD_HOSTNAME envvar has been specified, use it; otherwise, use the staging hostname
+// if use_staging is true; otherwise, use the DD_SITE envvar with 'api.' prepended;
+// otherwise, use the default hostname.
+fn get_datadog_hostname(use_staging: bool) -> String {
+    if let Ok(hostname) = get_datadog_variable_value("HOSTNAME") {
+        hostname
+    } else if use_staging {
+        STAGING_DATADOG_HOSTNAME.to_string()
+    } else if let Ok(site) = get_datadog_variable_value("SITE") {
+        format!("api.{}", site).to_string()
     } else {
-        get_datadog_variable_value("SITE").unwrap_or(DEFAULT_DATADOG_SITE.to_string())
+        DEFAULT_DATADOG_HOSTNAME.to_string()
+    }
+}
+
+#[derive(PartialEq)]
+enum UseKeys {
+    // Do not add APP/API keys or a JWT token to the request.
+    DoNotUse,
+    // Add APP/API keys or JWT token to the request, if available.
+    NotRequired,
+    // Add APP/API keys or JWT token to the request, and fail if not available.
+    Required,
+}
+
+// Returns a RequestBuilder for the given API path.
+fn make_request(path: &str, use_staging: bool, use_keys: UseKeys) -> Result<RequestBuilder> {
+    let request_builder = reqwest::blocking::Client::new()
+        .get(format!(
+            "https://{}/api/v2/static-analysis/{}",
+            get_datadog_hostname(use_staging),
+            path
+        ))
+        .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON);
+
+    if use_keys == UseKeys::DoNotUse {
+        return Ok(request_builder);
+    }
+
+    let api_key = get_datadog_variable_value("API_KEY");
+    let app_key = get_datadog_variable_value("APP_KEY");
+    match (api_key, app_key) {
+        (Ok(apik), Ok(appk)) => Ok(request_builder
+            .header(DATADOG_HEADER_API_KEY, apik)
+            .header(DATADOG_HEADER_APP_KEY, appk)),
+        (apir, appr) => match get_datadog_variable_value("JWT_TOKEN") {
+            Ok(jwtt) => Ok(request_builder.header(DATADOG_HEADER_JWT_TOKEN, jwtt)),
+            Err(_) if use_keys != UseKeys::Required => Ok(request_builder),
+            Err(jwte) => Err(apir.err().or(appr.err()).unwrap_or(jwte)),
+        },
     }
 }
 
@@ -71,28 +115,11 @@ fn get_datadog_site(use_staging: bool) -> String {
 // it connects to the API using the DD_SITE, DD_APP_KEY and DD_API_KEY and retrieve
 // the rulesets. We then extract all the rulesets
 pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
-    let site = get_datadog_site(use_staging);
-    let app_key = get_datadog_variable_value("APP_KEY");
-    let api_key = get_datadog_variable_value("API_KEY");
-
-    let url = format!(
-        "https://api.{}/api/v2/static-analysis/rulesets/{}?include_tests=false&include_testing_rules=true",
-        site, ruleset_name
+    let path = format!(
+        "rulesets/{}?include_tests=false&include_testing_rules=true",
+        ruleset_name
     );
-
-    let request_builder = reqwest::blocking::Client::new()
-        .get(url)
-        .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON);
-
-    // only add datadog credentials if both app-key and api-keys are defined.
-    let request_builder_with_auth = match (app_key, api_key) {
-        (Ok(appk), Ok(apik)) => request_builder
-            .header(DATADOG_HEADER_API_KEY, apik)
-            .header(DATADOG_HEADER_APP_KEY, appk),
-        _ => request_builder,
-    };
-
-    let server_response = request_builder_with_auth
+    let server_response = make_request(&path, use_staging, UseKeys::NotRequired)?
         .send()
         .expect("error when querying the datadog server");
 
@@ -119,16 +146,12 @@ pub fn get_default_rulesets_name_for_language(
     language: String,
     use_staging: bool,
 ) -> Result<Vec<String>> {
-    let site = get_datadog_site(use_staging);
-
-    let url = format!(
-        "https://api.{}/api/v2/static-analysis/default-rulesets/{}",
-        site, language
-    );
-
-    let request_builder = reqwest::blocking::Client::new()
-        .get(url)
-        .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON);
+    let request_builder = make_request(
+        &format!("default-rulesets/{}", language),
+        use_staging,
+        UseKeys::DoNotUse,
+    )?
+    .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON);
 
     let server_response = request_builder.send()?;
 
@@ -179,15 +202,6 @@ pub fn get_all_default_rulesets(use_staging: bool) -> Result<Vec<RuleSet>> {
 /// the list of files). This information will later be added in the
 /// results.
 pub fn get_diff_aware_information(arguments: &DiffAwareRequestArguments) -> Result<DiffAwareData> {
-    let site = get_datadog_site(false);
-    let app_key = get_datadog_variable_value("APP_KEY")?;
-    let api_key = get_datadog_variable_value("API_KEY")?;
-
-    let url = format!(
-        "https://api.{}/api/v2/static-analysis/analysis/diff-aware",
-        site
-    );
-
     let request_uuid = Uuid::new_v4().to_string();
 
     let request_payload = DiffAwareRequest {
@@ -204,14 +218,8 @@ pub fn get_diff_aware_information(arguments: &DiffAwareRequestArguments) -> Resu
         },
     };
 
-    let request_builder = reqwest::blocking::Client::new()
-        .post(url)
+    let server_response = make_request("analysis/diff-aware", false, UseKeys::Required)?
         .json(&request_payload)
-        .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON)
-        .header(DATADOG_HEADER_API_KEY, api_key)
-        .header(DATADOG_HEADER_APP_KEY, app_key);
-
-    let server_response = request_builder
         .send()
         .expect("error when querying the datadog server");
 
@@ -240,8 +248,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_datadog_site() {
-        assert_eq!(get_datadog_site(true), STAGING_DATADOG_SITE);
-        assert_eq!(get_datadog_site(false), DEFAULT_DATADOG_SITE);
+    fn test_get_datadog_hostname() {
+        assert_eq!(get_datadog_hostname(true), STAGING_DATADOG_HOSTNAME);
+        assert_eq!(get_datadog_hostname(false), DEFAULT_DATADOG_HOSTNAME);
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
We will need to have the static analyzer call our internal API endpoints with JWT tokens for auth. This lets the program that runs the static analyzer provide the hostname and JWT token.

## What is your solution?
A `DD_HOSTNAME` envvar and a `DD_JWT_TOKEN` envvar. Those are read when requests are built and used if present.

`DD_HOSTNAME` has priority over `use_staging` and `DD_SITE`; `DD_JWT_TOKEN` is used if `DD_API_KEY` and `DD_APP_KEY` are not available.

## Alternatives considered

## What the reviewer should know
