### PR TITLE
[STAL-2139] Ignore rules for the whole file

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -557,7 +557,15 @@ def foo(arg1):
     fn test_get_lines_to_ignore_python() {
         // no-dd-sa ruleset1/rule1 on line 3 so we ignore line 4 for ruleset1/rule1
         // no-dd-sa on line 7 so we ignore all rules on line 8
-        let code = "foo\n\n# no-dd-sa ruleset1/rule1\n\nbar\n\n# no-dd-sa\n";
+        let code = "\
+foo
+
+# no-dd-sa ruleset1/rule1
+
+bar
+
+# no-dd-sa
+";
 
         let lines_to_ignore = get_lines_to_ignore(code, &Language::Python);
 
@@ -591,8 +599,8 @@ def foo(arg1):
     #[test]
     fn test_get_lines_to_ignore_python_ignore_all_file() {
         let code = "\
-#no-dd-sa\n\n\
-def foo():\n\
+#no-dd-sa
+def foo():
   pass";
 
         let lines_to_ignore = get_lines_to_ignore(code, &Language::Python);
@@ -607,8 +615,8 @@ def foo():\n\
     #[test]
     fn test_get_lines_to_ignore_python_ignore_all_file_specific_rules() {
         let code1 = "\
-#no-dd-sa foo/bar\n\
-def foo():\n\
+#no-dd-sa foo/bar
+def foo():
   pass";
 
         let lines_to_ignore1 = get_lines_to_ignore(code1, &Language::Python);
@@ -620,8 +628,8 @@ def foo():\n\
         assert!(lines_to_ignore1.lines_to_ignore.is_empty());
 
         let code2 = "\
-#no-dd-sa foo/bar ruleset/rule\n\
-def foo():\n\
+#no-dd-sa foo/bar ruleset/rule
+def foo():
   pass";
 
         let lines_to_ignore2 = get_lines_to_ignore(code2, &Language::Python);

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -76,12 +76,10 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
                     } else {
                         lines_to_ignore_for_all_rules.push(line_number + 1);
                     }
+                } else if line_number == 1 {
+                    rules_to_ignore.extend(parts.clone());
                 } else {
-                    if line_number == 1 {
-                        rules_to_ignore.extend(parts.clone());
-                    } else {
-                        lines_to_ignore_per_rules.insert(line_number + 1, parts.clone());
-                    }
+                    lines_to_ignore_per_rules.insert(line_number + 1, parts.clone());
                 }
             }
         }

--- a/crates/static-analysis-kernel/src/model/analysis.rs
+++ b/crates/static-analysis-kernel/src/model/analysis.rs
@@ -41,20 +41,18 @@ impl LinesToIgnore {
                 return true;
             }
             FileIgnoreBehavior::SomeRules(rules) => {
-                if rules.contains(&rule_name.to_string()) {
+                if rules.iter().any(|c| c == rule_name) {
                     return true;
                 }
             }
         }
-
-        let rule_name_string = rule_name.to_string();
 
         if self.lines_to_ignore.contains(&line) {
             return true;
         }
 
         if let Some(rules) = self.lines_to_ignore_per_rule.get(&line) {
-            return rules.contains(&rule_name_string);
+            return rules.iter().any(|c| c == rule_name);
         }
 
         false

--- a/doc/ignore-rule.md
+++ b/doc/ignore-rule.md
@@ -1,0 +1,62 @@
+## Ignoring a rule
+
+
+> [!NOTE]
+> TL;DR: use the command `dd-no-sa` to ignore a rule
+
+
+### Ignoring all results in a file
+
+To ignore all rules in a file, put `no-dd-sa` in a comment
+on the **first line** of the file.
+
+In the following code snippet, all rules are ignored in the file.
+
+```python
+#no-dd-sa
+def foo():
+  print("foo: {}".format("bar"))
+```
+
+
+
+### Ignoring a list of rules in a file
+
+To ignore all rules in a file, put `no-dd-sa` followed
+by the list of rules to ignore in a comment
+on the **first line** of the file.
+
+In the following code snippets, the rules `python-best-practices/rule1`
+and `python-best-practices/rule2` will be ignored for the file, all
+other rules will apply.
+
+```python
+#no-dd-sa python-best-practices/rule1 python-best-practices/rule2
+def foo():
+  print("foo: {}".format("bar"))
+```
+
+
+### Ignoring a list of rules on a specific line
+
+To ignore rules on a specific line, put `no-dd-sa` followed
+by the list of rules to ignore in a comment on the **line above** 
+the one you want to ignore.
+
+```python
+def foo():
+  #no-dd-sa python-best-practices/rule1 python-best-practices/rule2
+  print("foo: {}".format("bar"))
+```
+
+
+### Ignoring all rules on a specific line
+
+To ignore all rules on a specific line, put `no-dd-sa` on the **line above**
+the one you want to ignore.
+
+```python
+def foo():
+  #no-dd-sa
+  print("foo: {}".format("bar"))
+```

--- a/schema/examples/invalid/disable-ignore-generated-files.yml
+++ b/schema/examples/invalid/disable-ignore-generated-files.yml
@@ -1,0 +1,14 @@
+schema-version: v1
+rulesets:
+  - python-best-practices
+  - go-best-practices:
+  - java-best-practices:
+    rules:
+      avoid-printstacktrace:
+        only:
+          - "foo/bar"
+ignore:
+  - path1/path2
+only:
+  - path2/path3
+ignore-generated-files: "wefwe"

--- a/schema/examples/valid/disable-ignore-generated-files.yml
+++ b/schema/examples/valid/disable-ignore-generated-files.yml
@@ -1,0 +1,14 @@
+schema-version: v1
+rulesets:
+  - python-best-practices
+  - go-best-practices:
+  - java-best-practices:
+    rules:
+      avoid-printstacktrace:
+        only:
+          - "foo/bar"
+ignore:
+  - path1/path2
+only:
+  - path2/path3
+ignore-generated-files: false


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to ignore rules for the complete file.

## What is your solution?

If a user wants to ignore rules for a complete file, they need to put a `no-dd-sa` directive at the top of the file.

This follows what eslint is doing (see [here](https://evanhahn.com/disable-eslint-for-a-file/) or [here](https://stackoverflow.com/questions/34764287/turning-off-eslint-rule-for-a-specific-file))

## What the reviewer should know

1. Documented all changes in a new markdown file with examples.
2. Adding some old schemas file I forgot to add in a previous PR about ignoring generated files.
