### PR TITLE
[STAL-1906] feat: add Dockerfile + ci workflow to publish to GHCR

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,53 @@
+name: Publish to GHCR
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04 AS base
+
+FROM base AS build
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+	CARGO_HOME=/usr/local/cargo   \
+	PATH=/usr/local/cargo/bin:$PATH
+
+RUN apt-get update && apt-get --no-install-recommends install -y \
+	build-essential ca-certificates curl git
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
+	&& rustup --version                          \
+	&& cargo --version                           \
+	&& rustc --version
+
+COPY . /app
+WORKDIR /app
+RUN cargo build --release --bin datadog-static-analyzer
+
+FROM base
+
+COPY --from=build /app/target/release/datadog-static-analyzer /usr/local/bin/datadog-static-analyzer
+
+RUN apt update && apt install -y curl git \
+	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& apt remove -y nodejs npm \
+	&& apt install -y nodejs \
+	&& apt clean && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @datadog/datadog-ci \
+	&& datadog-ci --version            \
+	&& datadog-static-analyzer --version
+
+ENTRYPOINT ["/usr/local/bin/datadog-static-analyzer"]
+CMD ["--help"]


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, it is not trivial for users to pull in the analyzer as a Docker image that they can run or build on top of, nor is it not publicly available on GHCR which is a convenient registry for users to pull in such images.

## What is your solution?

Add a Dockerfile + a ci workflow that publishes this image to GHCR every time we publish a release.

The workflow is pretty simple, and does the following
- Check out the repo
- Set up QEMU (for arm64 images) and Docker Buildx
- Logs into GHCR to authenticate publishing under this repo
- Extracts relevant metadata based on the event, for a push it will use the commit sha, but in the case of our release, it will use the tag (e.g. v0.20.0) *and* `latest`, which is just a convention used for Docker images
- Builds the image itself, note that because of arm emulation this takes around 80 minutes, which is not ideal, but since this only happens on a release, it is okay for now. Later down the line we can improve this with layering the steps appropriately to make use of caching
- Generates build provenance attestation, basically verifies who built the image/when for security/trust reasons, and to help consumers prevent supply chain attacks or other issues by verifying that this is a secure build

In addition, the dockerfile specifies bash as the entrypoint, and the analyzer as the command being run because `CMD` is overridable - users may want to run datadog-ci afterwards and process their results, hence the design choice here

## Alternatives considered

Stick to not having a Dockerfile/GHCR publishing workflow

## What the reviewer should know

This is only run on release, so it is not immediately verifiable that this works, however, I've tested this and published it in my own fork to verify that it does work, but I had it run on every push - see here for the GHCR image: https://ghcr.io/amaanq/datadog-static-analyzer and here for the attestation: https://github.com/amaanq/datadog-static-analyzer/attestations/946594
