### PR TITLE
Bundle the per-rule configurations/overrides

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -5,8 +5,8 @@ use kernel::model::rule::Rule;
 
 use anyhow::{Error, Result};
 use getopts::Options;
-use kernel::arguments::ArgumentProvider;
 use kernel::model::rule_test::RuleTest;
+use kernel::rule_config::RuleConfig;
 use kernel::utils::decode_base64_string;
 use std::env;
 use std::process::exit;
@@ -32,7 +32,7 @@ fn test_rule(rule: &Rule, test: &RuleTest) -> Result<String> {
         &rules,
         &Arc::from(test.filename.clone()),
         &code,
-        &ArgumentProvider::new(),
+        &RuleConfig::default(),
         &analysis_options,
     );
 

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -369,8 +369,8 @@ fn main() -> Result<()> {
         let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging, use_debug)
             .context("error when reading rules from API")?;
         rules.extend(rules_from_api.into_iter().map(|rule| Rule {
-            severity: overrides.severity(&rule.name, rule.severity),
-            category: overrides.category(&rule.name, rule.category),
+            severity: overrides.severity(&rule.name).unwrap_or(rule.severity),
+            category: overrides.category(&rule.name).unwrap_or(rule.category),
             ..rule
         }));
         path_restrictions = PathRestrictions::from_ruleset_configs(&conf.rulesets);

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -31,10 +31,8 @@ use cli::violations_table;
 use common::model::diff_aware::DiffAware;
 use getopts::Options;
 use indicatif::ProgressBar;
-use kernel::arguments::ArgumentProvider;
 use kernel::model::config_file::{ConfigFile, PathConfig};
-use kernel::path_restrictions::PathRestrictions;
-use kernel::rule_overrides::RuleOverrides;
+use kernel::rule_config::RuleConfigProvider;
 use rayon::prelude::*;
 use secrets::model::secret_result::SecretResult;
 use secrets::scanner::{build_sds_scanner, find_secrets};
@@ -349,9 +347,11 @@ fn main() -> Result<()> {
                 exit(1)
             }
         };
+    let rule_config_provider = configuration_file
+        .as_ref()
+        .map(RuleConfigProvider::from_config)
+        .unwrap_or_default();
     let mut rules: Vec<Rule> = Vec::new();
-    let mut path_restrictions = PathRestrictions::default();
-    let mut argument_provider = ArgumentProvider::new();
 
     // if there is a configuration file, we load the rules from it. But it means
     // we cannot have the rule parameter given.
@@ -363,18 +363,10 @@ fn main() -> Result<()> {
             exit(1);
         }
 
-        let overrides = RuleOverrides::from_config_file(&conf);
-
         let rulesets = conf.rulesets.keys().cloned().collect_vec();
         let rules_from_api = get_rules_from_rulesets(&rulesets, use_staging, use_debug)
             .context("error when reading rules from API")?;
-        rules.extend(rules_from_api.into_iter().map(|rule| Rule {
-            severity: overrides.severity(&rule.name).unwrap_or(rule.severity),
-            category: overrides.category(&rule.name).unwrap_or(rule.category),
-            ..rule
-        }));
-        path_restrictions = PathRestrictions::from_ruleset_configs(&conf.rulesets);
-        argument_provider = ArgumentProvider::from(&conf);
+        rules.extend(rules_from_api);
 
         // copy the only and ignore paths from the configuration file
         path_config.ignore.extend(conf.paths.ignore);
@@ -459,8 +451,7 @@ fn main() -> Result<()> {
         output_format,
         num_cpus,
         rules,
-        path_restrictions,
-        argument_provider,
+        rule_config_provider,
         output_file,
         max_file_size_kb,
         use_staging,
@@ -646,24 +637,17 @@ fn main() -> Result<()> {
                         .to_str()
                         .expect("path contains non-Unicode characters");
                     let relative_path: Arc<str> = Arc::from(relative_path);
-                    let mut selected_rules = rules_for_language
-                        .iter()
-                        .filter(|r| {
-                            configuration
-                                .path_restrictions
-                                .rule_applies(&r.name, relative_path.as_ref())
-                        })
-                        .peekable();
-                    let res = if selected_rules.peek().is_none() {
-                        vec![]
-                    } else if let Ok(file_content) = fs::read_to_string(&path) {
+                    let rule_config = configuration
+                        .rule_config_provider
+                        .config_for_file(relative_path.as_ref());
+                    let res = if let Ok(file_content) = fs::read_to_string(&path) {
                         let file_content = Arc::from(file_content);
                         let mut results = analyze(
                             language,
-                            selected_rules,
+                            &rules_for_language,
                             &relative_path,
                             &file_content,
-                            &configuration.argument_provider,
+                            &rule_config,
                             &analysis_options,
                         );
                         results.retain_mut(|r| {

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -346,13 +346,12 @@ mod tests {
     use std::env;
     use std::path::Path;
 
-    use kernel::arguments::ArgumentProvider;
     use tempfile::{tempdir, TempDir};
 
     use common::model::position::Position;
     use kernel::model::common::OutputFormat::Sarif;
     use kernel::model::rule::{RuleCategory, RuleSeverity};
-    use kernel::path_restrictions::PathRestrictions;
+    use kernel::rule_config::RuleConfigProvider;
 
     use super::*;
 
@@ -495,8 +494,7 @@ mod tests {
             output_file: "foo".to_string(),
             num_cpus: 2, // of cpus to use for parallelism
             rules: vec![],
-            path_restrictions: PathRestrictions::default(),
-            argument_provider: ArgumentProvider::new(),
+            rule_config_provider: RuleConfigProvider::default(),
             max_file_size_kb: 1,
             use_staging: false,
             show_performance_statistics: false,

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -2,14 +2,13 @@ use crate::git_utils::get_branch;
 use anyhow::anyhow;
 use common::model::diff_aware::DiffAware;
 use git2::Repository;
-use kernel::arguments::ArgumentProvider;
 use kernel::model::common::OutputFormat;
 use kernel::model::config_file::PathConfig;
+use kernel::rule_config::RuleConfigProvider;
 use sha2::{Digest, Sha256};
 
 use crate::model::datadog_api::DiffAwareRequestArguments;
 use kernel::model::rule::Rule;
-use kernel::path_restrictions::PathRestrictions;
 use secrets::model::secret_rule::SecretRule;
 
 /// represents the CLI configuration
@@ -26,8 +25,7 @@ pub struct CliConfiguration {
     pub output_file: String,
     pub num_cpus: usize, // of cpus to use for parallelism
     pub rules: Vec<Rule>,
-    pub path_restrictions: PathRestrictions,
-    pub argument_provider: ArgumentProvider,
+    pub rule_config_provider: RuleConfigProvider,
     pub max_file_size_kb: u64,
     pub use_staging: bool,
     pub show_performance_statistics: bool,
@@ -63,7 +61,7 @@ impl DiffAware for CliConfiguration {
 
         // println!("rules string: {}", rules_string.join("|"));
         let full_config_string = format!(
-            "{}:{}:{}:{}::{}:{}:{}:{}:{}",
+            "{}:{}:{}:{}::{}:{}:{}:{}",
             self.path_config.ignore.join(","),
             self.path_config
                 .only
@@ -73,8 +71,7 @@ impl DiffAware for CliConfiguration {
             rules_string.join(","),
             self.max_file_size_kb,
             self.source_subdirectories.join(","),
-            self.path_restrictions.generate_diff_aware_digest(),
-            self.argument_provider.generate_diff_aware_digest(),
+            self.rule_config_provider.generate_diff_aware_digest(),
             secrets_rules_string.join(",")
         );
         // compute the hash using sha2
@@ -172,8 +169,7 @@ mod tests {
                 tests: vec![],
                 is_testing: false,
             }],
-            path_restrictions: PathRestrictions::default(),
-            argument_provider: ArgumentProvider::new(),
+            rule_config_provider: RuleConfigProvider::default(),
             max_file_size_kb: 1,
             use_staging: false,
             show_performance_statistics: false,
@@ -215,8 +211,7 @@ mod tests {
             output_file: "foo".to_string(),
             num_cpus: 2, // of cpus to use for parallelism
             rules: vec![],
-            path_restrictions: PathRestrictions::default(),
-            argument_provider: ArgumentProvider::new(),
+            rule_config_provider: Default::default(),
             max_file_size_kb: 1,
             use_staging: false,
             show_performance_statistics: false,

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -271,6 +271,7 @@ mod tests {
 
     use super::*;
     use crate::analysis::tree_sitter::get_query;
+    use crate::config_file::parse_config_file;
     use crate::model::common::Language;
     use crate::model::rule::{RuleCategory, RuleSeverity};
 
@@ -892,7 +893,7 @@ function visit(node, filename, code) {
         "#;
 
         let rule1 = RuleInternal {
-            name: "rule1".to_string(),
+            name: "rs/rule1".to_string(),
             short_description: Some("short desc".to_string()),
             description: Some("description".to_string()),
             category: RuleCategory::CodeStyle,
@@ -902,7 +903,7 @@ function visit(node, filename, code) {
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
         };
         let rule2 = RuleInternal {
-            name: "rule2".to_string(),
+            name: "rs/rule2".to_string(),
             short_description: Some("short desc".to_string()),
             description: Some("description".to_string()),
             category: RuleCategory::CodeStyle,
@@ -913,9 +914,20 @@ function visit(node, filename, code) {
         };
 
         let analysis_options = AnalysisOptions::default();
-        let mut argument_provider = ArgumentProvider::new();
-        argument_provider.add_argument("rule1", &split_path("myfile.py"), "my-argument", "101");
-        argument_provider.add_argument("rule1", &split_path("myfile.py"), "another-arg", "101");
+        let argument_provider = ArgumentProvider::from(
+            &parse_config_file(
+                r#"
+rulesets:
+  - rs:
+    rules:
+      rule1:
+        arguments:
+          my-argument: 101
+          another-arg: 101
+        "#,
+            )
+            .unwrap(),
+        );
 
         let results = analyze(
             &Language::Python,

--- a/crates/static-analysis-kernel/src/arguments.rs
+++ b/crates/static-analysis-kernel/src/arguments.rs
@@ -53,8 +53,8 @@ impl ArgumentProvider {
         let mut provider = ArgumentProvider::new();
         for (ruleset_name, ruleset_cfg) in &config.rulesets {
             for (rule_shortname, rule_cfg) in &ruleset_cfg.rules {
+                let rule_name = format!("{}/{}", ruleset_name, rule_shortname);
                 for (arg_name, arg_values) in &rule_cfg.arguments {
-                    let rule_name = format!("{}/{}", ruleset_name, rule_shortname);
                     for (prefix, value) in arg_values.iter() {
                         provider.add_argument(
                             &rule_name,
@@ -69,7 +69,7 @@ impl ArgumentProvider {
         provider
     }
 
-    pub fn add_argument(&mut self, rule_name: &str, path: &SplitPath, argument: &str, value: &str) {
+    fn add_argument(&mut self, rule_name: &str, path: &SplitPath, argument: &str, value: &str) {
         let by_subtree = self.by_rule.entry(rule_name.to_string()).or_default();
         match by_subtree.get_mut(path) {
             None => {

--- a/crates/static-analysis-kernel/src/lib.rs
+++ b/crates/static-analysis-kernel/src/lib.rs
@@ -4,5 +4,6 @@ pub mod config_file;
 pub mod constants;
 pub mod model;
 pub mod path_restrictions;
+pub mod rule_config;
 pub mod rule_overrides;
 pub mod utils;

--- a/crates/static-analysis-kernel/src/rule_config.rs
+++ b/crates/static-analysis-kernel/src/rule_config.rs
@@ -1,0 +1,80 @@
+use crate::arguments::ArgumentProvider;
+use crate::model::config_file::{split_path, ConfigFile, SplitPath};
+use crate::model::rule::{RuleCategory, RuleSeverity};
+use crate::path_restrictions::PathRestrictions;
+use crate::rule_overrides::RuleOverrides;
+use common::model::diff_aware::DiffAware;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+#[derive(Default, Clone)]
+pub struct RuleConfigProvider {
+    path_restrictions: PathRestrictions,
+    argument_provider: ArgumentProvider,
+    rule_overrides: RuleOverrides,
+}
+
+impl RuleConfigProvider {
+    pub fn from_config(cfg: &ConfigFile) -> RuleConfigProvider {
+        RuleConfigProvider {
+            path_restrictions: PathRestrictions::from_ruleset_configs(&cfg.rulesets),
+            argument_provider: ArgumentProvider::from(cfg),
+            rule_overrides: RuleOverrides::from_config_file(cfg),
+        }
+    }
+
+    pub fn config_for_file(&self, file_path: &str) -> RuleConfig {
+        RuleConfig {
+            provider: self,
+            file_path: file_path.to_string(),
+            split_path: split_path(file_path),
+        }
+    }
+}
+
+impl DiffAware for RuleConfigProvider {
+    fn generate_diff_aware_digest(&self) -> String {
+        format!(
+            "{}:{}",
+            self.path_restrictions.generate_diff_aware_digest(),
+            self.argument_provider.generate_diff_aware_digest()
+        )
+    }
+}
+
+pub struct RuleConfig<'a> {
+    provider: &'a RuleConfigProvider,
+    file_path: String,
+    split_path: SplitPath,
+}
+
+impl<'a> RuleConfig<'a> {
+    pub fn rule_is_enabled(&self, rule_name: &str) -> bool {
+        self.provider
+            .path_restrictions
+            .rule_applies(rule_name, &self.file_path)
+    }
+
+    pub fn get_arguments(&self, rule_name: &str) -> HashMap<String, String> {
+        self.provider
+            .argument_provider
+            .get_arguments(&self.split_path, rule_name)
+    }
+
+    pub fn get_severity(&self, rule_name: &str) -> Option<RuleSeverity> {
+        self.provider.rule_overrides.severity(rule_name)
+    }
+
+    pub fn get_category(&self, rule_name: &str) -> Option<RuleCategory> {
+        self.provider.rule_overrides.category(rule_name)
+    }
+}
+
+impl Default for RuleConfig<'static> {
+    fn default() -> Self {
+        static PROVIDER: OnceLock<RuleConfigProvider> = OnceLock::new();
+        PROVIDER
+            .get_or_init(RuleConfigProvider::default)
+            .config_for_file("")
+    }
+}

--- a/crates/static-analysis-kernel/src/rule_overrides.rs
+++ b/crates/static-analysis-kernel/src/rule_overrides.rs
@@ -3,7 +3,7 @@ use crate::model::rule::{RuleCategory, RuleSeverity};
 use std::collections::HashMap;
 
 /// User-provided overrides for rule definitions.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RuleOverrides {
     severities: HashMap<String, RuleSeverity>,
     categories: HashMap<String, RuleCategory>,

--- a/crates/static-analysis-kernel/src/rule_overrides.rs
+++ b/crates/static-analysis-kernel/src/rule_overrides.rs
@@ -41,12 +41,12 @@ impl RuleOverrides {
     }
 
     // Returns the overridden severity for the given rule name, or the original severity if no override exists.
-    pub fn severity(&self, rule_name: &str, original: RuleSeverity) -> RuleSeverity {
-        *self.severities.get(rule_name).unwrap_or(&original)
+    pub fn severity(&self, rule_name: &str) -> Option<RuleSeverity> {
+        self.severities.get(rule_name).copied()
     }
 
     // Returns the overridden category for the given rule name, or the original category if no override exists.
-    pub fn category(&self, rule_name: &str, original: RuleCategory) -> RuleCategory {
-        *self.categories.get(rule_name).unwrap_or(&original)
+    pub fn category(&self, rule_name: &str) -> Option<RuleCategory> {
+        self.categories.get(rule_name).copied()
     }
 }

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -102,8 +102,13 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
             short_description_base64: r.short_description_base64.clone(),
             description_base64: r.description_base64.clone(),
             category: overrides
-                .category(&r.name, r.category.unwrap_or(RuleCategory::BestPractices)),
-            severity: overrides.severity(&r.name, r.severity.unwrap_or(RuleSeverity::Warning)),
+                .category(&r.name)
+                .or(r.category)
+                .unwrap_or(RuleCategory::BestPractices),
+            severity: overrides
+                .severity(&r.name)
+                .or(r.severity)
+                .unwrap_or(RuleSeverity::Warning),
             language: r.language,
             rule_type: r.rule_type,
             cwe: None,

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -7,11 +7,9 @@ use crate::model::analysis_response::{AnalysisResponse, RuleResponse};
 use crate::model::violation::violation_to_server;
 use common::analysis_options::AnalysisOptions;
 use kernel::analysis::analyze::{analyze, DEFAULT_JS_RUNTIME};
-use kernel::arguments::ArgumentProvider;
 use kernel::config_file::parse_config_file;
 use kernel::model::rule::{Rule, RuleCategory, RuleInternal, RuleSeverity};
-use kernel::path_restrictions::PathRestrictions;
-use kernel::rule_overrides::RuleOverrides;
+use kernel::rule_config::RuleConfigProvider;
 use kernel::utils::decode_base64_string;
 use std::sync::Arc;
 
@@ -54,23 +52,12 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
         };
     }
 
-    // Extract the path restrictions from the configuration file.
-    let path_restrictions = configuration
+    // Extract the rule configuration from the configuration file.
+    let rule_config_provider = configuration
         .as_ref()
-        .map(|cfg_file| PathRestrictions::from_ruleset_configs(&cfg_file.rulesets))
+        .map(RuleConfigProvider::from_config)
         .unwrap_or_default();
-
-    // Extract the overrides from the configuration file.
-    let overrides = configuration
-        .as_ref()
-        .map(RuleOverrides::from_config_file)
-        .unwrap_or_default();
-
-    // Build an argument provider from the configuration file.
-    let argument_provider = configuration
-        .as_ref()
-        .map(ArgumentProvider::from)
-        .unwrap_or_default();
+    let rule_config = rule_config_provider.config_for_file(&request.filename);
 
     let rules_with_invalid_language: Vec<ServerRule> = request
         .rules
@@ -96,19 +83,12 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
     let server_rules_to_rules: Vec<Rule> = request
         .rules
         .iter()
-        .filter(|r| path_restrictions.rule_applies(&r.name, &request.filename))
         .map(|r| Rule {
             name: r.name.clone(),
             short_description_base64: r.short_description_base64.clone(),
             description_base64: r.description_base64.clone(),
-            category: overrides
-                .category(&r.name)
-                .or(r.category)
-                .unwrap_or(RuleCategory::BestPractices),
-            severity: overrides
-                .severity(&r.name)
-                .or(r.severity)
-                .unwrap_or(RuleSeverity::Warning),
+            category: r.category.unwrap_or(RuleCategory::BestPractices),
+            severity: r.severity.unwrap_or(RuleSeverity::Warning),
             language: r.language,
             rule_type: r.rule_type,
             cwe: None,
@@ -200,7 +180,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
         &rules,
         &Arc::from(request.filename),
         &code_decoded_attempt,
-        &argument_provider,
+        &rule_config,
         &AnalysisOptions {
             use_debug: false,
             log_output: request


### PR DESCRIPTION
## What problem are you trying to solve?
We have per-rule enable/disable, per-rule arguments, and per-rule severity/category overrides, all spread across three different objects that are initialized separately, passed separately, and used separately.

We will be adding more.

## What is your solution?
This PR bundles those objects together so only one object needs to be initialized, and only one object needs to be passed to the 'analyze' function.

Since the `analyze` function takes one file name and a list of rules, we can avoid parsing the filename more than once. To that end, the `RuleConfigProvider` has a `config_for_file` function that generates a `RuleConfig` scoped to a particular file, with the file name all parsed up nicely. This is the object that is passed to the `analyze` function.

The `RuleConfig` then has functions to get argument values, severity, enable/disable status, etc., for any rule and for the file it was created for.

## Alternatives considered

## What the reviewer should know
