### PR TITLE
[STAL-1960] Implement ddsa NamedCapture

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
@@ -5,6 +5,8 @@
 // These lints are temporarily disabled while transitioning to ddsa_lib.
 #![allow(unused_imports, dead_code)]
 
+mod capture;
+pub(crate) use capture::*;
 mod context_file;
 pub(crate) use context_file::FileContext;
 mod context_file_go;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.js
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+/**
+ * @typedef {SingleCapture | MultiCapture} NamedCapture
+ * Note that both interfaces use `string` for `name` because these objects are only created directly
+ * via the v8 API, so we can guarantee that these will be implemented as interned strings.
+ */
+
+/**
+ * @typedef {Object} SingleCapture
+ * @property {string} name The name of the capture.
+ * @property {NodeId} nodeId The node that was captured.
+ *
+ * Example tree-sitter query:
+ * ```
+ * (identifier) @capture_name
+ * ```
+ */
+
+/**
+ * @typedef {Object} MultiCapture
+ * @property {string} name The name of the capture.
+ * @property {Uint32Array} nodeIds The nodes that were captured.
+ *
+ * Example tree-sitter query:
+ * ```
+ * (identifier) @duplicate_name
+ * (number) @duplicate_name
+ * ```
+ */

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.rs
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::ddsa_lib::common::{v8_interned, v8_uint, NodeId};
+use deno_core::v8;
+use deno_core::v8::HandleScope;
+
+/// A [`v8::Global`] template for creating `SingleCapture` v8 objects.
+#[derive(Debug)]
+pub(crate) struct SingleCaptureTemplate {
+    template: v8::Global<v8::ObjectTemplate>,
+    // Cached keys
+    s_name: v8::Global<v8::String>,
+    s_node_id: v8::Global<v8::String>,
+}
+
+impl SingleCaptureTemplate {
+    pub fn new(scope: &mut HandleScope) -> Self {
+        let s_name = v8_interned(scope, "name");
+        let s_node_id = v8_interned(scope, "nodeId");
+        let undefined = v8::undefined(scope);
+        let zero_smi = v8_uint(scope, 0);
+
+        let template = v8::ObjectTemplate::new(scope);
+        template.set(s_name.into(), undefined.into());
+        template.set(s_node_id.into(), zero_smi.into());
+        let template = v8::Global::new(scope, template);
+
+        let s_name = v8::Global::new(scope, s_name);
+        let s_node_id = v8::Global::new(scope, s_node_id);
+
+        Self {
+            template,
+            s_name,
+            s_node_id,
+        }
+    }
+
+    /// Creates a new local [`v8::Object`] for a `SingleCapture`.
+    pub fn new_instance<'s>(
+        &self,
+        scope: &mut HandleScope<'s>,
+        name: &str,
+        node_id: NodeId,
+    ) -> v8::Local<'s, v8::Object> {
+        let capture = self
+            .template
+            .open(scope)
+            .new_instance(scope)
+            .expect("v8 object should be able to be created");
+        let key = v8::Local::new(scope, &self.s_name);
+        let name = v8_interned(scope, name);
+        capture.set(scope, key.into(), name.into());
+        let key = v8::Local::new(scope, &self.s_node_id);
+        let id = v8_uint(scope, node_id);
+        capture.set(scope, key.into(), id.into());
+        capture
+    }
+}
+
+/// A [`v8::Global`] template for creating `MultiCapture` v8 objects.
+#[derive(Debug)]
+pub(crate) struct MultiCaptureTemplate {
+    template: v8::Global<v8::ObjectTemplate>,
+    // Cached keys
+    s_name: v8::Global<v8::String>,
+    s_node_ids: v8::Global<v8::String>,
+}
+
+impl MultiCaptureTemplate {
+    pub fn new(scope: &mut HandleScope) -> Self {
+        let s_name = v8_interned(scope, "name");
+        let s_node_ids = v8_interned(scope, "nodeIds");
+        let undefined = v8::undefined(scope);
+
+        let template = v8::ObjectTemplate::new(scope);
+        template.set(s_name.into(), undefined.into());
+        template.set(s_node_ids.into(), undefined.into());
+        let template = v8::Global::new(scope, template);
+
+        let s_name = v8::Global::new(scope, s_name);
+        let s_node_ids = v8::Global::new(scope, s_node_ids);
+
+        Self {
+            template,
+            s_name,
+            s_node_ids,
+        }
+    }
+
+    /// Creates a new local [`v8::Object`] for a `MultiCapture`.
+    pub fn new_instance<'s>(
+        &self,
+        scope: &mut HandleScope<'s>,
+        name: &str,
+        node_ids: &[NodeId],
+    ) -> v8::Local<'s, v8::Object> {
+        let capture = self
+            .template
+            .open(scope)
+            .new_instance(scope)
+            .expect("v8 object should be able to be created");
+        let key = v8::Local::new(scope, &self.s_name);
+        let name = v8_interned(scope, name);
+        capture.set(scope, key.into(), name.into());
+
+        let key = v8::Local::new(scope, &self.s_node_ids);
+        let ids_buf = v8::ArrayBuffer::new(scope, 4 * node_ids.len());
+        let ids_array = v8::Uint32Array::new(scope, ids_buf, 0, node_ids.len())
+            .expect("v8 Uint32Array should be able to be created");
+        for (i, node_id) in node_ids.iter().enumerate() {
+            let id = v8_uint(scope, *node_id);
+            ids_array.set_index(scope, i as u32, id.into());
+        }
+        capture.set(scope, key.into(), ids_array.into());
+        capture
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analysis::ddsa_lib::common::{attach_as_global, v8_string};
+    use crate::analysis::ddsa_lib::js::{MultiCaptureTemplate, SingleCaptureTemplate};
+    use crate::analysis::ddsa_lib::test_utils::{cfg_test_runtime, try_execute};
+
+    // These objects are created entirely in v8, so the property canary tests are implemented
+    // slightly differently than in other files where we use `js_instance_eq`.
+
+    /// Verifies the object shape of a `SingleCapture`.
+    #[test]
+    fn single_capture_js_properties_canary() {
+        let mut runtime = cfg_test_runtime();
+        let scope = &mut runtime.handle_scope();
+        let template = SingleCaptureTemplate::new(scope);
+        let capture = template.new_instance(scope, "alpha", 16);
+        attach_as_global(scope, capture, "CAPTURE");
+
+        let code = r#"
+const assert = (val, msg) => { if (!val) throw new Error(msg); };
+assert(Object.keys(CAPTURE).length === 2, "must be exactly 2 properties");
+assert(CAPTURE.name === "alpha", "name was incorrect");
+assert(CAPTURE.nodeId === 16, "nodeId was incorrect");
+"#;
+        let result = try_execute(scope, code).map(|v| v.to_rust_string_lossy(scope));
+        assert_eq!(result, Ok("undefined".to_string()));
+    }
+
+    /// Verifies the object shape of a `MultiCapture`.
+    #[test]
+    fn multi_capture_js_properties_canary() {
+        let mut runtime = cfg_test_runtime();
+        let scope = &mut runtime.handle_scope();
+        let template = MultiCaptureTemplate::new(scope);
+        let capture = template.new_instance(scope, "bravo", &[16, 32, 48]);
+        attach_as_global(scope, capture, "CAPTURE");
+
+        let code = r#"
+const assert = (val, msg) => { if (!val) throw new Error(msg); };
+assert(Object.keys(CAPTURE).length === 2, "must be exactly 2 properties");
+assert(CAPTURE.name === "bravo", "name was incorrect");
+assert(CAPTURE.nodeIds instanceof Uint32Array, "nodeIds had wrong type");
+assert(CAPTURE.nodeIds.join(",") === "16,32,48", "nodeIds were incorrect");
+"#;
+        let result = try_execute(scope, code).map(|v| v.to_rust_string_lossy(scope));
+        assert_eq!(result, Ok("undefined".to_string()));
+
+        // Single capture within an array should still be an array
+        let capture = template.new_instance(scope, "bravo", &[16]);
+        attach_as_global(scope, capture, "CAPTURE");
+        let code = r#"
+assert(CAPTURE.nodeIds instanceof Uint32Array, "nodeIds had wrong type");
+assert(CAPTURE.nodeIds.join(",") === "16", "nodeIds were incorrect");
+"#;
+        let result = try_execute(scope, code).map(|v| v.to_rust_string_lossy(scope));
+        assert_eq!(result, Ok("undefined".to_string()));
+    }
+}


### PR DESCRIPTION
## What problem are you trying to solve?
When a tree-sitter query is run, it generates "match"es, which are a collection of "captures" (which are nodes tagged by a string name). Because some rules may want to implement a majority of their logic within JavaScript (as opposed to via the tree-sitter query itself), we need to be able to handle a large number of matches and captures performantly.

## What is your solution?
Unlike all of our other JavaScript abstractions (which are classes with constructors), a "NamedCapture" is a plain object with only primitive values (no functions, getters, etc.). This means that we can (ergonomically) create these objects performantly from a [v8 ObjectTemplate](https://v8docs.nodesource.com/node-20.3/db/d5f/classv8_1_1_object_template.html).

For this reason, we don't define the class in JavaScript. Rather, we just use [capture.js](https://github.com/DataDog/datadog-static-analyzer/blob/5bc7b5a06f3dda5c1a7f9d3e63f754c95b76c276/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.js) to write JSDoc type annotations.

_(Note: While it's true that we could also use an ObjectTemplate for our JavaScript classes, it would make the code much less maintainable, because it is much easier to change the JavaScript representation in JavaScript instead of via the v8 API--especially when it comes to functions and non-trivial objects)._

### Single vs Multi Capture
The most common capture will be a [`SingleCapture`](https://github.com/DataDog/datadog-static-analyzer/blob/5bc7b5a06f3dda5c1a7f9d3e63f754c95b76c276/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.js). This is generated by a query like
```
(variable_declarator
    name: (identifier) @varName
    value: (number) @numVal
)
```
In this case, `@varName` would be a `SingleCapture`, and `@numVal` would also be a `SingleCapture`.

However, some queries can be written like this:
```
(variable_declarator
    name: (identifier) @varName
    value: (array
         (number) @numVal
         (number) @numVal
         (number) @numVal
    )
```
`@varName` would still be a `SingleCapture`. However, `@numVal` would be a `MultiCapture` because the capture name is re-used across multiple query capture nodes.

`SingleCapture` contains a single v8 smi as the `nodeId`.
`MultiCapture` contains multiple v8 smis as the `nodeIds`.

### Why a Uint32Array?
When there is a `MultiCapture`, we represent this as a `Uint32Array`, not a standard array (`[]`). The reason for this is performance. While both would end up storing `uint32`s, there is no way to pre-allocate a JavaScript array without having it be treated as "holey", [which triggers v8 de-optimizations](https://v8.dev/blog/elements-kinds#packed-vs.-holey-kinds). For example, if we used the v8 equivalent of `const captureIds = new Array(2)`:
```
d8> %DebugPrint(new Array(2))
DebugPrint: 0x1ab00047f7d: [JSArray]
 - map: 0x01ab0028ccdd <Map[16](HOLEY_SMI_ELEMENTS)> [FastProperties]
```
...it would still be a holey array because it is sparse upon initialization.

We could use an empty generic array, and then just do the equivalent of `[].push(1, 2, 3, /* ... */)`, but then we risk triggering additional allocations and memcpy if the array needs to be resized.

Instead, by using a `Uint32Array`, we can preallocate exactly the amount of space needed, using just one allocation, and have the exact same indexing/iterable interface that a generic array provides.

### Why a string name, not an integer id?
[We use a string name for captures.](https://github.com/DataDog/datadog-static-analyzer/blob/5bc7b5a06f3dda5c1a7f9d3e63f754c95b76c276/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/capture.js#L13)

Elsewhere, ddsa uses integers for performing. So why not here? Because we are creating these v8 objects entirely from the v8 API, we can guarantee the use of a [kInternalized string](https://v8docs.nodesource.com/node-20.3/d2/dc3/namespacev8.html#aef3852f4561ef81187a88e028968fe54ade6a7f11cd845d59e52b388d18929295), which does not allocate. This simplifies our implementation, because even though we know all of a rule's capture names ahead of time, we don't have to deal with parsing them and creating a map from id to string.

## Alternatives considered

## What the reviewer should know
* This is purely the (isolated) JavaScript implementation of a "capture"
  * This doesn't implement the "match", as described in the description intro. That will be in a future PR.
  * The translation between the tree-sitter query Rust bindings to this JavaScript object will be implemented in a future PR that switches the use of stella over to ddsa.