### PR TITLE
[STAL-2179] Add better error message for ruleset fetch failure

### DIFF
--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -138,11 +138,11 @@ pub struct ApiResponseRulesetAttributes {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ApiResponseRuleset {
+pub struct APIResponseRuleset {
     pub attributes: ApiResponseRulesetAttributes,
 }
 
-impl ApiResponseRuleset {
+impl APIResponseRuleset {
     fn into_ruleset(self) -> RuleSet {
         let ruleset_name = self.attributes.name;
         let description = self.attributes.description;
@@ -194,12 +194,24 @@ impl ApiResponseRuleset {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ApiResponse {
-    pub data: ApiResponseRuleset,
+#[derive(Deserialize, Clone)]
+pub struct APIResponse {
+    pub data: APIResponseRuleset,
 }
 
-impl ApiResponse {
+#[derive(Deserialize)]
+pub struct APIErrorResponse {
+    pub errors: Vec<APIError>,
+}
+
+#[derive(Deserialize)]
+pub struct APIError {
+    pub title: String,
+    pub status: Option<String>,
+    pub detail: Option<String>,
+}
+
+impl APIResponse {
     pub fn into_ruleset(self) -> RuleSet {
         self.data.into_ruleset()
     }
@@ -259,7 +271,7 @@ mod tests {
                 }
             }
         });
-        let res: Result<ApiResponse, _> = serde_json::from_value(data);
+        let res = serde_json::from_value::<APIResponse>(data);
         let ruleset = res.unwrap().into_ruleset();
         assert_eq!(1, ruleset.rules.len());
         let rule = ruleset.rules.get(0).unwrap();
@@ -295,7 +307,7 @@ mod tests {
                 }
             }
         });
-        let res: Result<ApiResponse, _> = serde_json::from_value(data);
+        let res = serde_json::from_value::<APIResponse>(data);
         let ruleset = res.unwrap().into_ruleset();
         assert_eq!(0, ruleset.rules.len());
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, if an error is returned from the api when fetching a ruleset, we still attempt to parse it as if it were a valid response, leading to a parsing error which is the error the user sees. This is really incorrect as it does not help diagnose the problem on the user's end to figure out what's actually wrong.

## What is your solution?

The solution is to start actually handling errors that are not successes from our api, we should parse the error message, which is also json, and extract the info from there to show to the user. Currently, we could get a 400 for bad parameters in the URL, a 404 for a ruleset that wasn't found, and a 500 for an internal server error (w.r.t custom rules, which is not yet available)

## Alternatives considered

Keep poorly handling server errors

## What the reviewer should know

There are some changes that are just naming (e.g. Api -> API), so the diff looks a *little* larger than what it really is. The real logic changes are in `datadog_utils.rs`/`get_ruleset`, and with some structs for parsing errors added.