### PR TITLE
[STAL-1960] Add functionality to configure a v8 isolate's default context

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+import {DDSA_Console} from "ext:ddsa_lib/utility";
 import {FileContext} from "ext:ddsa_lib/context_file";
 import {FileContextGo} from "ext:ddsa_lib/context_file_go";
 import {QueryMatch} from "ext:ddsa_lib/query_match";
@@ -13,6 +14,7 @@ import {RuleContext} from "ext:ddsa_lib/context_rule";
 import {TreeSitterNode} from "ext:ddsa_lib/ts_node";
 // TODO(JF): These are only used by the Rust runtime, which currently expects them in global scope, but
 //           these should be hidden inside another object, not `globalThis`.
+globalThis.DDSA_Console = DDSA_Console;
 globalThis.FileContext = FileContext;
 globalThis.FileContextGo = FileContextGo;
 globalThis.QueryMatch = QueryMatch;
@@ -30,5 +32,4 @@ for (const [name, obj] of Object.entries(stellaCompat)) {
 }
 ///////////
 
-import {DDSA_Console} from "ext:ddsa_lib/utility";
 globalThis.console = new DDSA_Console();


### PR DESCRIPTION
## What problem are you trying to solve?

TL;DR `console.log` in our [scoped_execute](https://github.com/DataDog/datadog-static-analyzer/blob/a740e135382c4c4ce513a897cd393a4b199d50b5/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs#L264) function currently resolves to `deno_core`'s console, not our custom ddsa console.

--

In https://github.com/DataDog/datadog-static-analyzer/pull/398, we introduced `scoped_execute`, which creates a new `v8::Context` to execute a `v8::Script` in. The global proxy object for this new v8 context is constructed from the [`v8::ObjectTemplate`](https://v8docs.nodesource.com/node-20.3/db/df7/classv8_1_1_template.html) of the v8 isolate "default" context (which is its baseline [current context](https://v8docs.nodesource.com/node-20.3/d5/dda/classv8_1_1_isolate.html#ac0fef7336ebf1bf0eef176ff627cc103)).

In order to re-use a `v8::Persistent` global object (for ddsa-specific values) across executions, we [set the prototype](https://github.com/DataDog/datadog-static-analyzer/blob/453ac89f0da2b3f039fea4af29edad911cb46ec6/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs#L112) of the new v8 context's global object to our `v8::Persistent` object.

Because of how the [JavaScript prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) works, resolving a value on `globalThis` will first check the v8 context's immediate global object, and then failing a match, walk up the prototype chain.

In practice, because `deno_core` [injects its own `globalThis.console`](https://github.com/denoland/deno_core/blob/79e73e500e409063cfbc165b58314d2c66cbf371/core/01_core.js#L506), this means when we run a script through `scoped_execute`, calls to `console` are caught by the `console` deno_core injected.

## What is your solution?
Because `deno_core` doesn't provide hooks to configure the values it sets on the default v8 context global object, we introduce a function that allows the caller to provide a function that can mutate the default v8 context. This runs _after_ deno_core has finished executing its own default context mutation, so we can, e.g. remove `console` from the global proxy object so it will resolve to our "console" (via the prototype chain).

Effectively what we're doing is creating a v8 isolate, mutating its base context, and then serializing it into a "snapshot" (see https://v8docs.nodesource.com/node-20.3/d6/d77/classv8_1_1_snapshot_creator.html).

Then we create the final v8 isolate based on this snapshot, which means any new `v8::Context` we create will use the snapshot's default v8 context as a template.

## Alternatives considered

## What the reviewer should know
* We could also use this function to further secure the runtime by removing things built-ins like [`eval`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval).