### PR TITLE
Fix overly-restrictive lifetime of `tree_sitter::Node` during ops

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
@@ -3,7 +3,7 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::ddsa_lib::common::NodeId;
-use crate::analysis::ddsa_lib::{bridge, runtime};
+use crate::analysis::ddsa_lib::{bridge, runtime, RawTSNode};
 use deno_core::{op2, OpState};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -64,24 +64,36 @@ pub fn op_ts_node_text(state: &OpState, #[smi] node_id: u32) -> Option<String> {
         .get_text()
         .expect("tree text should always be `Some` during rule execution");
     let node_bridge = state.borrow::<Rc<RefCell<bridge::TsNodeBridge>>>().borrow();
-    let ts_node = restore_ts_node_for_op(&node_bridge, node_id)?;
+    let safe_raw_ts_node = OpSafeRawTSNode::try_new(&node_bridge, node_id)?;
+    let ts_node = safe_raw_ts_node.to_node();
     tree_text
         .get(ts_node.start_byte()..ts_node.end_byte())
         .map(ToString::to_string)
 }
 
-/// A function that restores a `tree_sitter::Node` given its `NodeId`.
-fn restore_ts_node_for_op(
-    bridge: &bridge::TsNodeBridge,
-    node_id: NodeId,
-) -> Option<tree_sitter::Node> {
-    bridge.get_raw(node_id).map(|raw_node| {
+/// A newtype wrapper over a [`RawTSNode`] that guarantees safe generation of a [`tree_sitter::Node`].
+///
+/// Whereas `RawTSNode` is not inherently safe to convert to a `tree_sitter::Node`, because of how
+/// we manage the tree's lifetime, it's guaranteed to be safe to access this during an op (i.e. during JavaScript execution).
+struct OpSafeRawTSNode(RawTSNode);
+
+impl OpSafeRawTSNode {
+    /// Creates an `OpSafeRawTSNode` if the `node_id` exists on the [`TsNodeBridge`](bridge::TsNodeBridge).
+    pub fn try_new(bridge: &bridge::TsNodeBridge, node_id: NodeId) -> Option<Self> {
+        bridge.get_raw(node_id).cloned().map(Self)
+    }
+
+    /// Returns a `tree_sitter::Node` representing this raw node.
+    pub fn to_node(&self) -> tree_sitter::Node {
         // Safety:
-        // 1. An op will only be called during a JavaScript rule execution, where it's guaranteed that
-        //    the `tree_sitter::Tree` exists (and is owned by the `ddsa_lib::RootContext` on the `bridge::ContextBridge`).
-        // 2. We never mutate the `tree_sitter::Tree` or any related nodes.
-        // 3. While the `node_id` can be modified by a JavaScript rule, only Rust can insert RawTSNode data
-        //    into the bridge, so there is no risk of user data flowing into this unsafe block.
-        unsafe { raw_node.to_node() }
-    })
+        // 1. An `OpSafeRawTSNode` can only be created by fetching a `RawTsNode` from the `bridge::TsNodeBridge`,
+        //    which guarantees that its `v8::Value` counterpart exists within the v8 context. Even though the
+        //    requested `node_id` can be arbitrarily modified by JavaScript, a `RawTsNode` will only be
+        //    returned if we explicitly added it to the bridge via Rust, making it impossible for this function
+        //    to access unintended memory.
+        // 2. An op will only be called during a JavaScript rule execution, where it's guaranteed that
+        //    the `tree_sitter::Tree` exists (because it is owned by the `ddsa_lib::RootContext` on the `bridge::ContextBridge`).
+        // 3. We never mutate the `tree_sitter::Tree` or any related nodes.
+        unsafe { self.0.to_node() }
+    }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
TL;DR Due to how we currently handle the lifetime of a `tree_sitter::Node`, we can't implement ops that perform actions like fetching the children of a tree-sitter node.

---

Within a deno `op`, we convert a `RawTsNode` into its `tree_sitter::Node` form via `restore_ts_node_for_ops`, which has the function signature:
```rust
fn restore_ts_node_for_op(
    bridge: &bridge::TsNodeBridge,
    node_id: NodeId,
) -> Option<tree_sitter::Node> { }
```

The compiler elides the lifetimes, and so the signature is actually:
```rust
fn restore_ts_node_for_op<'tree>(
    bridge: &'tree bridge::TsNodeBridge,
    node_id: NodeId,
) -> Option<tree_sitter::Node<'tree>> { }
```

This ties the lifetime of the `tree_sitter::Node` to the borrowed `TsNodeBridge`. This makes it so we can't mutably borrow the `TsNodeBridge` if we have created ` tree_sitter::Node` (which would happen if we want to, e.g. get the children of a node via an op).

## What is your solution?
Add newtype wrapper `OpSafeRawTSNode`, which allows us to create a `tree_sitter::Node` without tying it to a borrow of the `TsNodeBridge` (which is inaccurate and overly restrictive).

This has the same safety guarantees as before, but they are [further documented here](https://github.com/DataDog/datadog-static-analyzer/commit/07a8fe04ee7d69c6494b9e4a16f5027e552ee537#diff-26f4d9f443f20bcbb4a010c53170b9bfe10ef4fd8d4bca2c233ca50729621cd6R88-R95).

In addition to fixing the lifetime, this is an overall cleaner and more idiomatic solution.

## Alternatives considered

## What the reviewer should know
