### PR TITLE
[STAL-2289] feat: add terraform file context helper in the JS code

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context.rs
@@ -6,6 +6,8 @@ mod file;
 pub use file::FileContext;
 pub(crate) mod file_go;
 pub use file_go::FileContextGo;
+pub(crate) mod file_tf;
+pub use file_tf::FileContextTerraform;
 mod root;
 pub use root::RootContext;
 mod rule;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file.rs
@@ -2,12 +2,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
+use super::FileContextTerraform;
 use crate::analysis::ddsa_lib::context::file_go::FileContextGo;
 
 #[derive(Debug, Default)]
 pub struct FileContext {
     // Supported file contexts:
     go: Option<FileContextGo>,
+    terraform: Option<FileContextTerraform>,
 }
 
 impl FileContext {
@@ -24,5 +26,20 @@ impl FileContext {
     // Assigns the [`FileContextGo`] to this `FileContext`, returning the old value, if it exists.
     pub fn set_go(&mut self, file_ctx_go: FileContextGo) -> Option<FileContextGo> {
         Option::replace(&mut self.go, file_ctx_go)
+    }
+
+    /// Returns a mutable reference to the [`FileContextTerraform`] owned by this `FileContext`, if it exists.
+    pub fn tf_mut(&mut self) -> Option<&mut FileContextTerraform> {
+        self.terraform.as_mut()
+    }
+
+    /// Returns a reference to the [`FileContextTerraform`] owned by this `FileContext`, if it exists.
+    pub fn tf(&self) -> Option<&FileContextTerraform> {
+        self.terraform.as_ref()
+    }
+
+    /// Assigns the [`FileContextTerraform`] to this `FileContext`, returning the old value, if it exists.
+    pub fn set_tf(&mut self, file_ctx_tf: FileContextTerraform) -> Option<FileContextTerraform> {
+        self.terraform.replace(file_ctx_tf)
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use deno_core::v8::{self, HandleScope};
+
+use crate::analysis::ddsa_lib::common::{Class, DDSAJsRuntimeError};
+use crate::analysis::ddsa_lib::js;
+use crate::analysis::ddsa_lib::v8_ds::MirroredVec;
+use crate::analysis::tree_sitter::get_tree_sitter_language;
+use crate::model::common::Language;
+
+/// Terraform-specific file context
+#[derive(Debug)]
+pub struct FileContextTerraform {
+    query: tree_sitter::Query,
+    resources: MirroredVec<Resource, js::TerraformResource<Class>>,
+}
+
+/// Terraform resource representation, which consists of a type and a name.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Resource {
+    pub r#type: String,
+    pub name: String,
+}
+
+const TF_QUERY: &str = r#"
+(block
+  (identifier) @_resource
+  (#eq? @_resource "resource")
+  .
+  (string_lit (template_literal) @type)
+  .
+  (string_lit (template_literal) @name)
+)
+"#;
+
+impl FileContextTerraform {
+    pub fn new(scope: &mut HandleScope) -> Result<Self, DDSAJsRuntimeError> {
+        let resources = MirroredVec::new(js::TerraformResource::try_new(scope)?, scope);
+
+        let ts_query =
+            tree_sitter::Query::new(&get_tree_sitter_language(&Language::Terraform), TF_QUERY)
+                .expect("query has valid syntax");
+
+        Ok(Self {
+            query: ts_query,
+            resources,
+        })
+    }
+
+    /// Queries the `tree_sitter::Tree` and updates the internal [`MirroredIndexMap`] with the query results.
+    pub fn update_state(&mut self, scope: &mut HandleScope, tree: &tree_sitter::Tree, code: &str) {
+        let mut query_cursor = tree_sitter::QueryCursor::new();
+        let query_result = query_cursor.matches(&self.query, tree.root_node(), code.as_bytes());
+
+        let resources = query_result
+            .into_iter()
+            .map(|query_match| {
+                let mut resource_type = None;
+                let mut resource_name = None;
+
+                for capture in query_match.captures {
+                    let start = capture.node.byte_range().start;
+                    let end = capture.node.byte_range().end;
+                    let capture_name = self.query.capture_names()[capture.index as usize];
+                    match capture_name {
+                        "type" => resource_type = Some(code.get(start..end).unwrap().to_string()),
+                        "name" => resource_name = Some(code.get(start..end).unwrap().to_string()),
+                        "_resource" => {}
+                        _ => unreachable!(),
+                    }
+                }
+
+                Resource {
+                    r#type: resource_type.unwrap(),
+                    name: resource_name.unwrap(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        self.resources.set_data(scope, resources);
+    }
+
+    /// Clears the internal [`MirroredVec`] of any resources.
+    pub fn clear(&mut self, scope: &mut HandleScope) {
+        self.resources.clear(scope);
+    }
+
+    /// Returns a reference to the [`v8::Global`] map backing the resources.
+    pub(crate) fn resources_v8_array(&self) -> &v8::Global<v8::Array> {
+        self.resources.v8_array()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analysis::ddsa_lib::context::file_tf::FileContextTerraform;
+    use crate::analysis::ddsa_lib::context::file_tf::Resource;
+    use crate::analysis::ddsa_lib::test_utils::cfg_test_runtime;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    #[test]
+    fn test_get_file_context_tf() {
+        let mut runtime = cfg_test_runtime();
+        let scope = &mut runtime.handle_scope();
+        let mut ctx_tf = FileContextTerraform::new(scope).unwrap();
+
+        struct TestCase {
+            code: &'static str,
+            expected: Vec<Resource>,
+        }
+
+        let test = TestCase {
+            code: r#"
+                    resource "aws_instance" "app" {
+                        ami           = "ami-1234567890"
+                        instance_type = "t2.micro"
+                    }
+
+                    resource "aws_instance" "db" {
+                        ami           = "ami-1234567890"
+                        instance_type = "t2.micro"
+                    }
+
+                    resource "google_compute_instance" "web" {
+                        project      = "my-project"
+                        name         = "web"
+                        machine_type = "n1-standard-1"
+                    }
+                "#,
+            expected: vec![
+                Resource {
+                    r#type: "aws_instance".to_string(),
+                    name: "app".to_string(),
+                },
+                Resource {
+                    r#type: "aws_instance".to_string(),
+                    name: "db".to_string(),
+                },
+                Resource {
+                    r#type: "google_compute_instance".to_string(),
+                    name: "web".to_string(),
+                },
+            ],
+        };
+
+        let tree = get_tree(test.code, &Language::Terraform).unwrap();
+        ctx_tf.update_state(scope, &tree, test.code);
+        assert_eq!(ctx_tf.resources.len(), test.expected.len());
+
+        for (idx, expected) in test.expected.iter().enumerate() {
+            let actual = ctx_tf.resources.get(idx).unwrap();
+            assert_eq!(actual, expected, "Mismatch at index {idx}");
+        }
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
@@ -21,6 +21,7 @@ deno_core::extension!(
         dir "src/analysis/ddsa_lib/js",
         ("ext:ddsa_lib/context_file", "context_file.js"),
         ("ext:ddsa_lib/context_file_go", "context_file_go.js"),
+        ("ext:ddsa_lib/context_file_tf", "context_file_tf.js"),
         ("ext:ddsa_lib/context_root", "context_root.js"),
         ("ext:ddsa_lib/context_rule", "context_rule.js"),
         ("ext:ddsa_lib/context_ts_lang", "context_ts_lang.js"),

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
@@ -11,6 +11,8 @@ mod context_file;
 pub(crate) use context_file::FileContext;
 mod context_file_go;
 pub(crate) use context_file_go::FileContextGo;
+mod context_file_tf;
+pub(crate) use context_file_tf::*;
 mod context_root;
 pub(crate) use context_root::RootContext;
 mod context_rule;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
@@ -7,6 +7,7 @@
 import {DDSA_Console} from "ext:ddsa_lib/utility";
 import {FileContext} from "ext:ddsa_lib/context_file";
 import {FileContextGo} from "ext:ddsa_lib/context_file_go";
+import {FileContextTerraform, TerraformResource} from "ext:ddsa_lib/context_file_tf";
 import {QueryMatch} from "ext:ddsa_lib/query_match";
 import {QueryMatchCompat} from "ext:ddsa_lib/query_match_compat";
 import {RootContext} from "ext:ddsa_lib/context_root";
@@ -18,6 +19,8 @@ import {TsLanguageContext} from "ext:ddsa_lib/context_ts_lang";
 globalThis.DDSA_Console = DDSA_Console;
 globalThis.FileContext = FileContext;
 globalThis.FileContextGo = FileContextGo;
+globalThis.FileContextTerraform = FileContextTerraform;
+globalThis.TerraformResource = TerraformResource;
 globalThis.QueryMatch = QueryMatch;
 globalThis.QueryMatchCompat = QueryMatchCompat;
 globalThis.RootContext = RootContext;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file.js
@@ -15,5 +15,10 @@ export class FileContext {
          * @type {FileContextGo | undefined}
          */
         this.go = undefined;
+        /**
+         * A `terraform` file context.
+         * @type {FileContextTerraform | undefined}
+         */
+        this.terraform = undefined;
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file_tf.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file_tf.js
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+/**
+ * An object representing a resource within a `Terraform` file.
+ * @typedef {Object} Resource
+ * @property {string} type
+ * @property {string} name
+ */
+
+export class FileContextTerraform {
+    /**
+     * Creates a new `FileContextTerraform`.
+     * @param {Resource[]} resourceList
+     */
+    constructor(resourceList) {
+        /**
+         * A list of resources within the file.
+         * @type {Resource[]}
+         * */
+        this.resources = resourceList;
+    }
+
+    /**
+     * Returns whether the file has a resource with the given type and name.
+     * @param {string} type
+     * @param {string} name
+     * @returns {boolean}
+     */
+    hasResource(type, name) {
+        return this.resources.some(resource => resource.type === type && resource.name === name);
+    }
+
+    /**
+     * Returns the resources with the given type.
+     * @param {string} type
+     * @returns {Resource[]}
+     */
+    getResourcesOfType(type) {
+        return this.resources.filter(resource => resource.type === type);
+    }
+}
+
+export class TerraformResource {
+    /**
+     * @param {string} type
+     * @param {string} name
+     */
+    constructor(type, name) {
+        /**
+        * The type of the resource.
+        * @type {string}
+        */
+        this.type = type;
+
+        /**
+         * The name of the resource.
+         * @type {string}
+         */
+        this.name = name;
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file_tf.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_file_tf.rs
@@ -1,0 +1,228 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use std::marker::PhantomData;
+
+use deno_core::v8::{self, HandleScope};
+
+use crate::analysis::ddsa_lib::common::{
+    load_function, set_key_value, set_undefined, v8_interned, v8_string, Class, DDSAJsRuntimeError,
+    Instance,
+};
+use crate::analysis::ddsa_lib::file_tf::Resource;
+use crate::rust_converter;
+
+/// A [`v8::Global`] object created from the ES6 class `FileContextTerraform`.
+#[derive(Debug)]
+pub struct FileContextTerraform<T> {
+    v8_object: v8::Global<v8::Object>,
+    // Cached keys
+    s_resource_map: v8::Global<v8::String>,
+    _pd: PhantomData<T>,
+}
+
+/// A function representing the ES6 class `TerraformResource`.
+#[derive(Debug)]
+pub struct TerraformResource<T> {
+    class: v8::Global<v8::Function>,
+    _pd: PhantomData<T>,
+}
+
+rust_converter!(
+    (TerraformResource<Class>, Resource),
+    |&self, scope, value| {
+        let r#type = v8_string(scope, &value.r#type).into();
+        let name = v8_string(scope, &value.name).into();
+        let args = [r#type, name];
+        self.class
+            .open(scope)
+            .new_instance(scope, &args[..])
+            .expect("class constructor should not throw")
+            .into()
+    }
+);
+
+impl FileContextTerraform<Instance> {
+    pub const CLASS_NAME: &'static str = "FileContextTerraform";
+
+    /// Creates a new [`v8::Global`] object by loading [`Self::CLASS_NAME`] from the `scope` and creating an instance.
+    pub fn try_new(scope: &mut HandleScope) -> Result<Self, DDSAJsRuntimeError> {
+        let js_class = load_function(scope, Self::CLASS_NAME)?;
+        let js_class = js_class.open(scope);
+        let args = [v8::undefined(scope).into()];
+        let v8_object = js_class
+            .new_instance(scope, &args[..])
+            .expect("class constructor should not throw");
+        let v8_object = v8::Global::new(scope, v8_object);
+        let s_resource_map = v8_interned(scope, "resources");
+        let s_resource_map = v8::Global::new(scope, s_resource_map);
+        Ok(Self {
+            v8_object,
+            s_resource_map,
+            _pd: PhantomData,
+        })
+    }
+
+    /// Assigns either the provided [`v8::Global`] array to the JavaScript object's [`FileContextTerraform::s_resource_map`] key,
+    /// or `undefined` if no array is provided.
+    pub fn set_module_resource_array(
+        &self,
+        scope: &mut HandleScope,
+        array: Option<&v8::Global<v8::Array>>,
+    ) {
+        if let Some(v8_map) = array {
+            set_key_value(&self.v8_object, scope, &self.s_resource_map, |inner| {
+                v8::Local::new(inner, v8_map).into()
+            });
+        } else {
+            set_undefined(&self.v8_object, scope, &self.s_resource_map);
+        }
+    }
+
+    /// Provides a reference to the [`v8::Global`] class instance object
+    pub(crate) fn v8_object(&self) -> &v8::Global<v8::Object> {
+        &self.v8_object
+    }
+}
+
+impl TerraformResource<Class> {
+    pub const CLASS_NAME: &'static str = "TerraformResource";
+
+    /// Creates a new [`v8::Global`] function by loading [`Self::CLASS_NAME`] from the `scope`.
+    pub fn try_new(
+        scope: &mut v8::HandleScope,
+    ) -> Result<Self, crate::analysis::ddsa_lib::common::DDSAJsRuntimeError> {
+        let class = load_function(scope, Self::CLASS_NAME)?;
+        Ok(Self {
+            class,
+            _pd: PhantomData,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use deno_core::{v8, v8::HandleScope};
+
+    use super::{FileContextTerraform, TerraformResource};
+    use crate::analysis::ddsa_lib::common::{v8_interned, v8_uint, Instance};
+    use crate::analysis::ddsa_lib::test_utils::{
+        attach_as_global, cfg_test_runtime, js_class_eq, js_instance_eq, try_execute,
+    };
+
+    /// Creates a `FileContextTerraform`, prepopulated with the provided `resource_array` and exposed on `globalThis`
+    /// with the provided `variable_name`.
+    fn mount_context(
+        scope: &mut HandleScope,
+        variable_name: &str,
+        resource_array: &[(&str, &str)],
+    ) {
+        let resources = v8::Array::new(scope, 0);
+        for (index, (resource_type, resource_name)) in resource_array.iter().enumerate() {
+            let resource = v8::Object::new(scope);
+
+            let s_type = v8_interned(scope, "type");
+            let resource_type = v8_interned(scope, resource_type);
+            resource.set(scope, s_type.into(), resource_type.into());
+
+            let s_name = v8_interned(scope, "name");
+            let resource_name = v8_interned(scope, resource_name);
+            resource.set(scope, s_name.into(), resource_name.into());
+
+            let index = v8_uint(scope, index as u32);
+            resources.set(scope, index.into(), resource.into());
+        }
+        let tf_resources = v8::Global::new(scope, resources);
+        let tf_ctx = FileContextTerraform::<Instance>::try_new(scope).unwrap();
+        tf_ctx.set_module_resource_array(scope, Some(&tf_resources));
+
+        let tf_ctx_local = v8::Local::new(scope, tf_ctx.v8_object());
+        attach_as_global(scope, tf_ctx_local, variable_name);
+    }
+
+    #[test]
+    fn js_properties_canary() {
+        // FileContextTerraform
+        let instance_expected = &[
+            // Variables
+            "resources",
+            // Methods
+            "hasResource",
+            "getResourcesOfType",
+        ];
+        assert!(js_instance_eq(
+            FileContextTerraform::CLASS_NAME,
+            instance_expected
+        ));
+        let class_expected = &[];
+        assert!(js_class_eq(
+            FileContextTerraform::CLASS_NAME,
+            class_expected
+        ));
+
+        // TerraformResource
+        let instance_expected = &[
+            // Variables
+            "type", "name",
+            // Methods
+        ];
+        assert!(js_instance_eq(
+            TerraformResource::CLASS_NAME,
+            instance_expected
+        ));
+        let class_expected = &[];
+        assert!(js_class_eq(TerraformResource::CLASS_NAME, class_expected));
+    }
+
+    /// We only pass in the `resources`, which has unique type <> name pairs, but potentially has
+    /// several resources with the same types.
+    /// Thus, we use `hasResource` to see if a specific resource given a type and name is present.
+    /// It's also possible we want every resource of a given type, so we also use `getResourcesOfType` to test this.
+    #[test]
+    fn unique_resources() {
+        let mut runtime = cfg_test_runtime();
+        let scope = &mut runtime.handle_scope();
+        let tf_resources = &[
+            ("aws_instance", "app"),
+            ("google_compute_instance", "cache"),
+            ("google_storage_bucket", "db"),
+            ("aws_instance", "cache"),
+        ];
+        mount_context(scope, "TERRAFORM", tf_resources);
+
+        let code = "\
+TERRAFORM.hasResource('google_storage_bucket', 'db');
+";
+        let return_val = try_execute(scope, code).unwrap().is_true();
+
+        assert_eq!(return_val, true);
+
+        let code = "\
+TERRAFORM.getResourcesOfType('aws_instance').map(r => r.name).join(',');
+";
+        let return_val = try_execute(scope, code)
+            .unwrap()
+            .to_rust_string_lossy(scope);
+        assert_eq!(return_val, "app,cache");
+    }
+
+    /// Here we test that we can fetch all the resources.
+    #[test]
+    fn get_all_resources() {
+        let mut runtime = cfg_test_runtime();
+        let scope = &mut runtime.handle_scope();
+        let tf_resources = &[
+            ("aws_instance", "app"),
+            ("google_compute_instance", "cache"),
+        ];
+        mount_context(scope, "TERRAFORM", tf_resources);
+        let code = "\
+TERRAFORM.resources.map(r => `${r.type}:${r.name}`).join(',');
+";
+        let return_val = try_execute(scope, code)
+            .unwrap()
+            .to_rust_string_lossy(scope);
+        assert_eq!(return_val, "aws_instance:app,google_compute_instance:cache");
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/v8_ds.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/v8_ds.rs
@@ -145,6 +145,10 @@ where
         v8::Local::new(scope, &self.v8_array)
     }
 
+    pub fn v8_array(&self) -> &v8::Global<v8::Array> {
+        &self.v8_array
+    }
+
     /// Returns a handle to the v8 element at the given index.
     #[cfg(test)]
     pub fn get_v8<'s>(&self, scope: &mut HandleScope<'s>, index: u32) -> v8::Local<'s, v8::Value> {


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, implementing a rule that checks for the existence or validity of a similar resource is nearly impossible, and is very difficult to express in the query syntax. The issue that sparked this PR was that given a specific resource, with a type of `foo`, a user wanted to check that a corresponding resource with the type`foo_public_access_block` existed. Implementing this with a query is very difficult with a lot of edge cases and loop holes to consider (e.g. does this corresponding resource come before or after the main one, is it immediately after, etc), and just having all the resources in a given Terraform module exposed nicely in the JS api would be much more preferable, in a way where a user can simply just check every resource and their type and name in a given Terraform module.

## What is your solution?

The solution is to create a file context for terraform files that exposes a `resources` array for users to interact with in the JS rule code. It is similar to what we currently do for Golang, but instead of having a map of aliases to resolved package names, we have an array of resources, where each `Resource` is an object with a `type` and `name` field.

For example, given the following TF module

```terraform
resource "aws_s3_bucket" "unsafe-bucket" {
  region       = "us-east-1"
  bucket        = "my_bucket"
  acl           = "public-read"
  force_destroy = 3
  tags {
    Name = "my-bucket"
  }
}

resource "aws_s3_bucket_public_access_block" "access" {
  bucket = aws_s3_bucket.safe-bucket.id
}
```

The resources array would look like the following, as a JS object:

```js
[
  { type: "aws_s3_bucket", name: "unsafe-bucket" },
  { type: "aws_s3_bucket_public_acccess_block", name: "access" }
]
```

A user can now query for only *one* resource, and have access to all the other resources available in the module, instead of having to write complex queries to capture two resources, where the order might not matter but is difficult to express in a tree-sitter query.

Users also have access to some helper functions that they can use to make the experience better. Currently there are two functions a user can call on the Terraform file context:

`hasResource(type: string, name: string): boolean` simply checks if a resource with the given type and name exists, and returns true if it does. This is useful for validation.

`getResourcesOfType(type: string): Resource[]` fetches every resource that is of a given type, it's a convenience filter for users that only care about resources of one type, and not all of them.

Tests were added for all new functionality added to make the purpose and intent clear of each component added or changed to support the Terraform file context.

## Alternatives considered

N/A

## What the reviewer should know

The changes made closely mimic what was done in #385, except we're using a `MirroredVec` instead of a `MirroredIndexMap` since we have an array of resources.