### PR TITLE
[STAL-2337] feat: add Starlark support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -28,10 +28,13 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Terraform, &["tf"]),
     (Language::TypeScript, &["ts", "tsx"]),
     (Language::Yaml, &["yml", "yaml"]),
+    (Language::Starlark, &["bzl", "ipd", "star", "starlark"]),
 ];
 
-static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] =
-    &[(Language::Dockerfile, &["Dockerfile"])];
+static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
+    (Language::Dockerfile, &["Dockerfile"]),
+    (Language::Starlark, &["BUILD", "BUILD.bazel"]),
+];
 
 static FILE_PREFIX_PER_LANGUAGE_LIST: &[(Language, &[&str])] =
     &[(Language::Dockerfile, &["Dockerfile"])];
@@ -692,6 +695,7 @@ mod tests {
         extensions_per_languages.insert(Language::TypeScript, 2);
         extensions_per_languages.insert(Language::Dockerfile, 2);
         extensions_per_languages.insert(Language::Yaml, 2);
+        extensions_per_languages.insert(Language::Starlark, 4);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -28,7 +28,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Terraform, &["tf"]),
     (Language::TypeScript, &["ts", "tsx"]),
     (Language::Yaml, &["yml", "yaml"]),
-    (Language::Starlark, &["bzl", "ipd", "star", "starlark"]),
+    (Language::Starlark, &["bzl"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -695,7 +695,7 @@ mod tests {
         extensions_per_languages.insert(Language::TypeScript, 2);
         extensions_per_languages.insert(Language::Dockerfile, 2);
         extensions_per_languages.insert(Language::Yaml, 2);
-        extensions_per_languages.insert(Language::Starlark, 4);
+        extensions_per_languages.insert(Language::Starlark, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -1,8 +1,6 @@
-use std::{
-    env,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Executes a [`Command`], returning true if the command finished with exit status 0, otherwise false
 fn run<F>(name: &str, mut configure: F) -> bool
@@ -32,6 +30,8 @@ fn main() {
         build_dir: PathBuf,
         /// The files to pass to the `cc::Build` instance
         files: Vec<String>,
+        /// Whether compilation of this project requires C++ support or not
+        cpp: bool,
     }
 
     fn compile_project(tree_sitter_project: &TreeSitterProject) {
@@ -41,11 +41,12 @@ fn main() {
             .iter()
             .map(|x| dir.join(x))
             .collect();
+        let cpp = tree_sitter_project.cpp;
         cc::Build::new()
             .include(dir)
             .files(files)
             .warnings(false)
-            .cpp(false)
+            .cpp(cpp)
             .compile(tree_sitter_project.compilation_unit.as_str());
     }
 
@@ -57,6 +58,7 @@ fn main() {
             commit_hash: "82fa8f05f41a33e9bc830f85d74a9548f0291738".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-dockerfile".to_string(),
@@ -65,6 +67,7 @@ fn main() {
             commit_hash: "33e22c33bcdbfc33d42806ee84cfd0b1248cc392".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-go".to_string(),
@@ -73,6 +76,7 @@ fn main() {
             commit_hash: "ff86c7f1734873c8c4874ca4dd95603695686d7a".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-hcl".to_string(),
@@ -81,6 +85,7 @@ fn main() {
             commit_hash: "e135399cb31b95fac0760b094556d1d5ce84acf0".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-kotlin".to_string(),
@@ -89,6 +94,7 @@ fn main() {
             commit_hash: "4e909d6cc9ac96b4eaecb3fb538eaca48e9e9ee9".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-java".to_string(),
@@ -97,6 +103,7 @@ fn main() {
             commit_hash: "5e62fbb519b608dfd856000fdc66536304c414de".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-javascript".to_string(),
@@ -113,6 +120,7 @@ fn main() {
             commit_hash: "3fef30de8aee74600f25ec2e319b62a1a870d51e".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-python".to_string(),
@@ -121,6 +129,7 @@ fn main() {
             commit_hash: "4bfdd9033a2225cc95032ce77066b7aeca9e2efc".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-rust".to_string(),
@@ -129,6 +138,7 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "79456e6080f50fc1ca7c21845794308fa5d35a51".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-typescript".to_string(),
@@ -137,6 +147,7 @@ fn main() {
             build_dir: "tsx/src".into(),
             commit_hash: "d847898fec3fe596798c9fda55cb8c05a799001a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-yaml".to_string(),
@@ -145,6 +156,7 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "ee093118211be521742b9866a8ed8ce6d87c7a94".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-ruby".to_string(),
@@ -153,6 +165,7 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "7a010836b74351855148818d5cb8170dc4df8e6a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-swift".to_string(),
@@ -161,6 +174,7 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "b1b66955d420d5cf5ff268ae552f0d6e43ff66e1".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-starlark".to_string(),
@@ -170,6 +184,7 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "018d0e09d9d0f0dd6740a37682b8ee4512e8b2ac".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
     ];
 

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -112,6 +112,7 @@ fn main() {
             commit_hash: "f1e5a09b8d02f8209a68249c93f0ad647b228e6e".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-json".to_string(),

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -1,8 +1,10 @@
-use std::env;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
-/// Executes a [Command], returning true if the command finished with exit status 0, otherwise false
+/// Executes a [`Command`], returning true if the command finished with exit status 0, otherwise false
 fn run<F>(name: &str, mut configure: F) -> bool
 where
     F: FnMut(&mut Command) -> &mut Command,
@@ -30,8 +32,6 @@ fn main() {
         build_dir: PathBuf,
         /// The files to pass to the `cc::Build` instance
         files: Vec<String>,
-        /// Whether compilation of this project requires C++ support or not
-        cpp: bool,
     }
 
     fn compile_project(tree_sitter_project: &TreeSitterProject) {
@@ -41,12 +41,11 @@ fn main() {
             .iter()
             .map(|x| dir.join(x))
             .collect();
-        let cpp = tree_sitter_project.cpp;
         cc::Build::new()
             .include(dir)
             .files(files)
             .warnings(false)
-            .cpp(cpp)
+            .cpp(false)
             .compile(tree_sitter_project.compilation_unit.as_str());
     }
 
@@ -58,7 +57,6 @@ fn main() {
             commit_hash: "82fa8f05f41a33e9bc830f85d74a9548f0291738".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-dockerfile".to_string(),
@@ -67,7 +65,6 @@ fn main() {
             commit_hash: "33e22c33bcdbfc33d42806ee84cfd0b1248cc392".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-go".to_string(),
@@ -76,7 +73,6 @@ fn main() {
             commit_hash: "ff86c7f1734873c8c4874ca4dd95603695686d7a".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-hcl".to_string(),
@@ -85,7 +81,6 @@ fn main() {
             commit_hash: "e135399cb31b95fac0760b094556d1d5ce84acf0".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-kotlin".to_string(),
@@ -94,7 +89,6 @@ fn main() {
             commit_hash: "4e909d6cc9ac96b4eaecb3fb538eaca48e9e9ee9".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-java".to_string(),
@@ -103,7 +97,6 @@ fn main() {
             commit_hash: "5e62fbb519b608dfd856000fdc66536304c414de".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-javascript".to_string(),
@@ -112,7 +105,6 @@ fn main() {
             commit_hash: "f1e5a09b8d02f8209a68249c93f0ad647b228e6e".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-json".to_string(),
@@ -121,7 +113,6 @@ fn main() {
             commit_hash: "3fef30de8aee74600f25ec2e319b62a1a870d51e".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-python".to_string(),
@@ -130,7 +121,6 @@ fn main() {
             commit_hash: "4bfdd9033a2225cc95032ce77066b7aeca9e2efc".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-rust".to_string(),
@@ -139,7 +129,6 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "79456e6080f50fc1ca7c21845794308fa5d35a51".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-typescript".to_string(),
@@ -148,7 +137,6 @@ fn main() {
             build_dir: "tsx/src".into(),
             commit_hash: "d847898fec3fe596798c9fda55cb8c05a799001a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-yaml".to_string(),
@@ -157,7 +145,6 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "ee093118211be521742b9866a8ed8ce6d87c7a94".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-ruby".to_string(),
@@ -166,7 +153,6 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "7a010836b74351855148818d5cb8170dc4df8e6a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
         },
         TreeSitterProject {
             name: "tree-sitter-swift".to_string(),
@@ -175,7 +161,15 @@ fn main() {
             build_dir: "src".into(),
             commit_hash: "b1b66955d420d5cf5ff268ae552f0d6e43ff66e1".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
-            cpp: false,
+        },
+        TreeSitterProject {
+            name: "tree-sitter-starlark".to_string(),
+            compilation_unit: "tree-sitter-starlark".to_string(),
+            repository: "https://github.com/tree-sitter-grammars/tree-sitter-starlark.git"
+                .to_string(),
+            build_dir: "src".into(),
+            commit_hash: "018d0e09d9d0f0dd6740a37682b8ee4512e8b2ac".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
         },
     ];
 

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -21,6 +21,7 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
     let mut line_number = 1u32;
     let disabling_patterns = match language {
         Language::Python
+        | Language::Starlark
         | Language::Dockerfile
         | Language::Ruby
         | Language::Terraform

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -907,4 +907,56 @@ function visit(node, filename, code) {
         assert!(result1.violations[0].message.contains("argument = 101"));
         assert_eq!(result2.violations.len(), 0);
     }
+
+    #[test]
+    fn test_execution_for_starlark() {
+        let rule_code = r#"
+function visit(query, filename, code) {
+    const functionName = query.captures.name;
+    if (functionName) {
+        const error = buildError(
+            functionName.start.line, functionName.start.col,
+            functionName.end.line, functionName.end.col,
+            `invalid name`
+        );
+        addError(error);
+    }
+}"#;
+
+        let rule = RuleInternal {
+            name: "rule1".to_string(),
+            short_description: Some("short desc".to_string()),
+            description: Some("description".to_string()),
+            category: RuleCategory::CodeStyle,
+            severity: RuleSeverity::Notice,
+            language: Language::Starlark,
+            code: rule_code.to_string(),
+            tree_sitter_query: get_query(QUERY_CODE, &Language::Starlark).unwrap(),
+        };
+
+        let analysis_options = AnalysisOptions {
+            log_output: true,
+            use_debug: false,
+            ignore_generated_files: false,
+        };
+
+        let starlark_code = r#"
+def foo():
+    pass
+"#;
+
+        let results = analyze(
+            &Language::Starlark,
+            &vec![rule],
+            "myfile.star",
+            starlark_code,
+            &ArgumentProvider::new(),
+            &analysis_options,
+        );
+
+        assert_eq!(results.len(), 1);
+        let result = results.get(0).unwrap();
+        assert_eq!(result.violations.len(), 1);
+        assert_eq!(result.violations[0].message, "invalid name");
+    }
 }

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -1,45 +1,51 @@
-use crate::model::analysis::{MatchNode, MatchNodeContext, TreeSitterNode};
-use crate::model::common::{Language, Position};
+use std::{collections::HashMap, sync::Arc};
+
 use anyhow::Result;
 use indexmap::IndexMap;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tree_sitter::CaptureQuantifier;
 
+use crate::model::{
+    analysis::{MatchNode, MatchNodeContext, TreeSitterNode},
+    common::{Language, Position},
+};
+
+extern "C" {
+    fn tree_sitter_c_sharp() -> tree_sitter::Language;
+    fn tree_sitter_dockerfile() -> tree_sitter::Language;
+    fn tree_sitter_go() -> tree_sitter::Language;
+    fn tree_sitter_java() -> tree_sitter::Language;
+    fn tree_sitter_javascript() -> tree_sitter::Language;
+    fn tree_sitter_json() -> tree_sitter::Language;
+    fn tree_sitter_kotlin() -> tree_sitter::Language;
+    fn tree_sitter_python() -> tree_sitter::Language;
+    fn tree_sitter_ruby() -> tree_sitter::Language;
+    fn tree_sitter_rust() -> tree_sitter::Language;
+    fn tree_sitter_swift() -> tree_sitter::Language;
+    fn tree_sitter_tsx() -> tree_sitter::Language;
+    fn tree_sitter_hcl() -> tree_sitter::Language;
+    fn tree_sitter_yaml() -> tree_sitter::Language;
+    fn tree_sitter_starlark() -> tree_sitter::Language;
+}
+
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
-    extern "C" {
-        fn tree_sitter_c_sharp() -> tree_sitter::Language;
-        fn tree_sitter_dockerfile() -> tree_sitter::Language;
-        fn tree_sitter_go() -> tree_sitter::Language;
-        fn tree_sitter_java() -> tree_sitter::Language;
-        fn tree_sitter_javascript() -> tree_sitter::Language;
-        fn tree_sitter_json() -> tree_sitter::Language;
-        fn tree_sitter_kotlin() -> tree_sitter::Language;
-        fn tree_sitter_python() -> tree_sitter::Language;
-        fn tree_sitter_ruby() -> tree_sitter::Language;
-        fn tree_sitter_rust() -> tree_sitter::Language;
-        fn tree_sitter_swift() -> tree_sitter::Language;
-        fn tree_sitter_tsx() -> tree_sitter::Language;
-        fn tree_sitter_hcl() -> tree_sitter::Language;
-        fn tree_sitter_yaml() -> tree_sitter::Language;
-
-    }
-
-    match language {
-        Language::Csharp => unsafe { tree_sitter_c_sharp() },
-        Language::Dockerfile => unsafe { tree_sitter_dockerfile() },
-        Language::Go => unsafe { tree_sitter_go() },
-        Language::Java => unsafe { tree_sitter_java() },
-        Language::JavaScript => unsafe { tree_sitter_javascript() },
-        Language::Kotlin => unsafe { tree_sitter_kotlin() },
-        Language::Json => unsafe { tree_sitter_json() },
-        Language::Python => unsafe { tree_sitter_python() },
-        Language::Ruby => unsafe { tree_sitter_ruby() },
-        Language::Rust => unsafe { tree_sitter_rust() },
-        Language::Swift => unsafe { tree_sitter_swift() },
-        Language::Terraform => unsafe { tree_sitter_hcl() },
-        Language::TypeScript => unsafe { tree_sitter_tsx() },
-        Language::Yaml => unsafe { tree_sitter_yaml() },
+    unsafe {
+        match language {
+            Language::Csharp => tree_sitter_c_sharp(),
+            Language::Dockerfile => tree_sitter_dockerfile(),
+            Language::Go => tree_sitter_go(),
+            Language::Java => tree_sitter_java(),
+            Language::JavaScript => tree_sitter_javascript(),
+            Language::Kotlin => tree_sitter_kotlin(),
+            Language::Json => tree_sitter_json(),
+            Language::Python => tree_sitter_python(),
+            Language::Ruby => tree_sitter_ruby(),
+            Language::Rust => tree_sitter_rust(),
+            Language::Swift => tree_sitter_swift(),
+            Language::Terraform => tree_sitter_hcl(),
+            Language::TypeScript => tree_sitter_tsx(),
+            Language::Yaml => tree_sitter_yaml(),
+            Language::Starlark => tree_sitter_starlark(),
+        }
     }
 }
 
@@ -545,6 +551,20 @@ rulesets:
         let t = get_tree(source_code, &Language::Yaml);
         assert!(t.is_some());
         assert_eq!("stream", t.unwrap().root_node().kind());
+    }
+
+    #[test]
+    fn test_starlark_get_tree() {
+        let source_code = r#"
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+container_image(
+    name = "base",
+    base = "@io_bazel_rules_docker//images/ubuntu-1604:latest",
+)
+"#;
+        let t = get_tree(source_code, &Language::Starlark);
+        assert!(t.is_some());
+        assert_eq!("module", t.unwrap().root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use anyhow::Result;
-use indexmap::IndexMap;
-use tree_sitter::CaptureQuantifier;
-
 use crate::model::analysis::{MatchNode, MatchNodeContext, TreeSitterNode};
 use crate::model::common::{Language, Position};
+use anyhow::Result;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tree_sitter::CaptureQuantifier;
 
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
     extern "C" {

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -1,13 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::Result;
 use indexmap::IndexMap;
 use tree_sitter::CaptureQuantifier;
 
-use crate::model::{
-    analysis::{MatchNode, MatchNodeContext, TreeSitterNode},
-    common::{Language, Position},
-};
+use crate::model::analysis::{MatchNode, MatchNodeContext, TreeSitterNode};
+use crate::model::common::{Language, Position};
 
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
     extern "C" {

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -9,43 +9,41 @@ use crate::model::{
     common::{Language, Position},
 };
 
-extern "C" {
-    fn tree_sitter_c_sharp() -> tree_sitter::Language;
-    fn tree_sitter_dockerfile() -> tree_sitter::Language;
-    fn tree_sitter_go() -> tree_sitter::Language;
-    fn tree_sitter_java() -> tree_sitter::Language;
-    fn tree_sitter_javascript() -> tree_sitter::Language;
-    fn tree_sitter_json() -> tree_sitter::Language;
-    fn tree_sitter_kotlin() -> tree_sitter::Language;
-    fn tree_sitter_python() -> tree_sitter::Language;
-    fn tree_sitter_ruby() -> tree_sitter::Language;
-    fn tree_sitter_rust() -> tree_sitter::Language;
-    fn tree_sitter_swift() -> tree_sitter::Language;
-    fn tree_sitter_tsx() -> tree_sitter::Language;
-    fn tree_sitter_hcl() -> tree_sitter::Language;
-    fn tree_sitter_yaml() -> tree_sitter::Language;
-    fn tree_sitter_starlark() -> tree_sitter::Language;
-}
-
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
-    unsafe {
-        match language {
-            Language::Csharp => tree_sitter_c_sharp(),
-            Language::Dockerfile => tree_sitter_dockerfile(),
-            Language::Go => tree_sitter_go(),
-            Language::Java => tree_sitter_java(),
-            Language::JavaScript => tree_sitter_javascript(),
-            Language::Kotlin => tree_sitter_kotlin(),
-            Language::Json => tree_sitter_json(),
-            Language::Python => tree_sitter_python(),
-            Language::Ruby => tree_sitter_ruby(),
-            Language::Rust => tree_sitter_rust(),
-            Language::Swift => tree_sitter_swift(),
-            Language::Terraform => tree_sitter_hcl(),
-            Language::TypeScript => tree_sitter_tsx(),
-            Language::Yaml => tree_sitter_yaml(),
-            Language::Starlark => tree_sitter_starlark(),
-        }
+    extern "C" {
+        fn tree_sitter_c_sharp() -> tree_sitter::Language;
+        fn tree_sitter_dockerfile() -> tree_sitter::Language;
+        fn tree_sitter_go() -> tree_sitter::Language;
+        fn tree_sitter_java() -> tree_sitter::Language;
+        fn tree_sitter_javascript() -> tree_sitter::Language;
+        fn tree_sitter_json() -> tree_sitter::Language;
+        fn tree_sitter_kotlin() -> tree_sitter::Language;
+        fn tree_sitter_python() -> tree_sitter::Language;
+        fn tree_sitter_ruby() -> tree_sitter::Language;
+        fn tree_sitter_rust() -> tree_sitter::Language;
+        fn tree_sitter_swift() -> tree_sitter::Language;
+        fn tree_sitter_tsx() -> tree_sitter::Language;
+        fn tree_sitter_hcl() -> tree_sitter::Language;
+        fn tree_sitter_yaml() -> tree_sitter::Language;
+        fn tree_sitter_starlark() -> tree_sitter::Language;
+    }
+
+    match language {
+        Language::Csharp => unsafe { tree_sitter_c_sharp() },
+        Language::Dockerfile => unsafe { tree_sitter_dockerfile() },
+        Language::Go => unsafe { tree_sitter_go() },
+        Language::Java => unsafe { tree_sitter_java() },
+        Language::JavaScript => unsafe { tree_sitter_javascript() },
+        Language::Kotlin => unsafe { tree_sitter_kotlin() },
+        Language::Json => unsafe { tree_sitter_json() },
+        Language::Python => unsafe { tree_sitter_python() },
+        Language::Ruby => unsafe { tree_sitter_ruby() },
+        Language::Rust => unsafe { tree_sitter_rust() },
+        Language::Swift => unsafe { tree_sitter_swift() },
+        Language::Terraform => unsafe { tree_sitter_hcl() },
+        Language::TypeScript => unsafe { tree_sitter_tsx() },
+        Language::Yaml => unsafe { tree_sitter_yaml() },
+        Language::Starlark => unsafe { tree_sitter_starlark() },
     }
 }
 

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -1,6 +1,7 @@
+use std::fmt;
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[derive(Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub enum OutputFormat {
@@ -50,6 +51,8 @@ pub enum Language {
     TypeScript,
     #[serde(rename = "YAML")]
     Yaml,
+    #[serde(rename = "STARLARK")]
+    Starlark,
 }
 
 #[allow(dead_code)]
@@ -68,6 +71,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::TypeScript,
     Language::Terraform,
     Language::Yaml,
+    Language::Starlark,
 ];
 
 impl fmt::Display for Language {
@@ -87,6 +91,7 @@ impl fmt::Display for Language {
             Self::Terraform => "terraform",
             Self::TypeScript => "typescript",
             Self::Yaml => "yaml",
+            Self::Starlark => "starlark",
         };
         write!(f, "{s}")
     }

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -1,7 +1,6 @@
-use std::fmt;
-
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub enum OutputFormat {


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support Bazel (Starlark) files. Even though it is very similar to Python, there are some slight differences, which would make it not ideal to reuse the grammar for Python for Starlark files.

## What is your solution?

Add the Starlark grammar to the analyzer itself, which is fetched from https://github.com/tree-sitter-grammars/tree-sitter-starlark. This grammar accounts for the minute differences between Starlark and Python, making it a good candidate to add in the analyzer. This will allow us (and customers down the line) to begin writing rules targeting Bazel/Isopod files

## Alternatives considered

Not adding another grammar and reusing the Python grammar for Starlark

## What the reviewer should know

A couple notes, since I tacked on a few code changes that are not *directly* needed for this PR, but are more plumbing/nice-to-haves and relate to it more or less.

- Removed the CPP field in the TSProject struct, C++ scanners are deprecated and no grammars that are actively maintained use C++ anymore.
- moved the extern declaration to the root of the file, it's okay to have it in the function but it's clearer in general when there's a lot of externally-linked functions to have them be declared at the top level, and it's right above the function anyway, so clarity only increases here imo that these are functions defined elsewhere (inside C source files that are compiled into the final object)
- removed wrapping each `tree_sitter_foo` call with an `unsafe` block and just wrapping the whole match arm with `unsafe`
