### PR TITLE
[STAL-2338] feat: add Bash support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -29,6 +29,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::TypeScript, &["ts", "tsx"]),
     (Language::Yaml, &["yml", "yaml"]),
     (Language::Starlark, &["bzl"]),
+    (Language::Bash, &["sh", "bash"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -696,6 +697,7 @@ mod tests {
         extensions_per_languages.insert(Language::Dockerfile, 2);
         extensions_per_languages.insert(Language::Yaml, 2);
         extensions_per_languages.insert(Language::Starlark, 1);
+        extensions_per_languages.insert(Language::Bash, 2);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -187,6 +187,15 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-bash".to_string(),
+            compilation_unit: "tree-sitter-bash".to_string(),
+            repository: "https://github.com/tree-sitter/tree-sitter-bash.git".to_string(),
+            build_dir: "src".into(),
+            commit_hash: "2fbd860f802802ca76a6661ce025b3a3bca2d3ed".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -25,7 +25,8 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         | Language::Dockerfile
         | Language::Ruby
         | Language::Terraform
-        | Language::Yaml => {
+        | Language::Yaml
+        | Language::Bash => {
             vec!["#no-dd-sa", "#datadog-disable"]
         }
         Language::JavaScript | Language::TypeScript => {

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -23,6 +23,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_hcl() -> tree_sitter::Language;
         fn tree_sitter_yaml() -> tree_sitter::Language;
         fn tree_sitter_starlark() -> tree_sitter::Language;
+        fn tree_sitter_bash() -> tree_sitter::Language;
     }
 
     match language {
@@ -41,6 +42,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::TypeScript => unsafe { tree_sitter_tsx() },
         Language::Yaml => unsafe { tree_sitter_yaml() },
         Language::Starlark => unsafe { tree_sitter_starlark() },
+        Language::Bash => unsafe { tree_sitter_bash() },
     }
 }
 
@@ -560,6 +562,16 @@ container_image(
         let t = get_tree(source_code, &Language::Starlark);
         assert!(t.is_some());
         assert_eq!("module", t.unwrap().root_node().kind());
+    }
+
+    #[test]
+    fn test_bash_get_tree() {
+        let source_code = r#"
+echo "Hello, World!"
+"#;
+        let t = get_tree(source_code, &Language::Bash);
+        assert!(t.is_some());
+        assert_eq!("program", t.unwrap().root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -52,6 +52,8 @@ pub enum Language {
     Yaml,
     #[serde(rename = "STARLARK")]
     Starlark,
+    #[serde(rename = "BASH")]
+    Bash,
 }
 
 #[allow(dead_code)]
@@ -71,6 +73,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::Terraform,
     Language::Yaml,
     Language::Starlark,
+    Language::Bash,
 ];
 
 impl fmt::Display for Language {
@@ -91,6 +94,7 @@ impl fmt::Display for Language {
             Self::TypeScript => "typescript",
             Self::Yaml => "yaml",
             Self::Starlark => "starlark",
+            Self::Bash => "bash",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support Bash files. We need a way to parse and query bash files, but we do not currently fetch and build a Bash grammar.

## What is your solution?

Add the Bash grammar to the analyzer itself, which is fetched from https://github.com/tree-sitter/tree-sitter-bash. This will allow us (and customers down the line) to begin writing rules targeting Bash files.

## Alternatives considered

Not supporting bash files

## What the reviewer should know

I renamed the python example code string to be prefixed with `PYTHON_` since I added a bash one too, and reused this in the Starlark test hence why the code relating to the Starlark test was modified.