### PR TITLE
[STAL-1960] Add ability to fetch tree-sitter node children from JavaScript

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
@@ -9,8 +9,9 @@ deno_core::extension!(
     ops = [
         ops::op_current_filename,
         ops::op_console_push,
-        ops::op_ts_node_text,
         ops::op_current_ts_tree_text,
+        ops::op_ts_node_children,
+        ops::op_ts_node_text,
     ],
     esm_entry_point = "ext:ddsa_lib/__bootstrap.js",
     esm = [ dir "src/analysis/ddsa_lib/js", "__bootstrap.js" ],

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.js
@@ -2,7 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-const { op_ts_node_text } = Deno.core.ops;
+import { SEALED_EMPTY_ARRAY } from "ext:ddsa_lib/utility";
+
+const { op_ts_node_children, op_ts_node_text } = Deno.core.ops;
 
 /**
  * A non-zero integer assigned by the Rust static-analysis-kernel.
@@ -144,6 +146,26 @@ export class TreeSitterNode {
         // Note: the map lookup should only return undefined if either `this._typeId` or the symbol map were mutated.
         // Although that should never happen, we handle it by returning an empty string.
         return globalThis.__RUST_BRIDGE__ts_symbol_lookup.get(this._typeId) ?? "";
+    }
+
+    /**
+     * A getter to return the children of this tree-sitter node.
+     * NOTE: This is deprecated, because it is a compatibility layer to support the stella API.
+     * Do not rely on this, as it will be removed.
+     *
+     * @returns {Array<TreeSitterNode>}
+     * @deprecated
+     */
+    get children() {
+        const childIds = op_ts_node_children(this.id);
+        if (childIds === undefined) {
+            return SEALED_EMPTY_ARRAY;
+        }
+        const children = [];
+        for (const childId of childIds) {
+            children.push(globalThis.__RUST_BRIDGE__ts_node.get(childId))
+        }
+        return children;
     }
 }
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
@@ -84,6 +84,7 @@ mod tests {
             "type",
             "start",
             "end",
+            "children",
         ];
         assert!(js_instance_eq(TreeSitterNodeFn::CLASS_NAME, expected));
         let expected = &[];


### PR DESCRIPTION
## What problem are you trying to solve?
Currently, the JavaScript runtime does not have any ability to inspect or operate on the tree-sitter tree powering the analysis.

To partially address this, we currently preemptively serialize children and send them along with the captured nodes. This introduces two main inefficiencies:

**Not every rule needs to inspect children**
Less than 25% of our current rules access the children. And of those that do, nearly 1/3 of them are only querying the number of children, which means they don't need the actual serialized node.

**We serialize children recursively**
It would be unexpected for a user if they couldn't write a rule that accesses the children of a child, the children of that...and so on. So to address this, we currently [serialize children recursively](https://github.com/DataDog/datadog-static-analyzer/blob/e5bf4979b6381a05d5160511839de628a12fb402/crates/static-analysis-kernel/src/analysis/tree_sitter.rs#L318). This leads to v8 footguns, where a small change to a query's captures can reduce performance of a rule by an order of magnitude. For example, let's say a rule wants to count the number of functions within a Java class.

Given a sample file: [BenchmarkTest00012.java](https://github.com/OWASP-Benchmark/BenchmarkJava/blob/d6a3e016b9239c486f3fe1bf2af2bf3e7b01fa56/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00021.java), and a query:
```
(class_declaration
    (class_body) @class_body
)
```

And a rule:
```js
function visit(query, filename, code) {
  const { body } = query.captures;
  if (body.children.length > 10) { /* ... */ }
}
```

We currently serialize **395** nodes--almost the entire tree--for a rule that only needs to count the number of children.

## What is your solution?

In prior PRs, we implemented all the plumbing necessary for a JavaScript rule to perform operations on the tree-sitter tree. This PR has two goals:
1. Add function parity with the existing runtime by allowing rules to access a node's children.
2. Provide a reference example for contributors for how they can implement Rust hooks to expose the tree-sitter tree to rules.

This example shows the efficiency of the ddsa runtime's lazy serialization: for the above rule, we only serialize **3** extra nodes instead of 395. (sidenote: this could be further optimized in a future PR to 0 by providing an API to request count instead of actual nodes).

## Alternatives considered

## What the reviewer should know
