### PR TITLE
[STAL-1960] Fix performance issues introduced by creating new v8 Contexts

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -57,6 +57,10 @@ pub struct JsRuntime {
 
 impl JsRuntime {
     pub fn try_new() -> Result<Self, DDSAJsRuntimeError> {
+        Self::try_new_compat(false)
+    }
+
+    pub fn try_new_compat(is_stella: bool) -> Result<Self, DDSAJsRuntimeError> {
         let mut runtime = base_js_runtime();
 
         // Construct the bridges and attach their underlying `v8:Global` object to the
@@ -115,8 +119,10 @@ impl JsRuntime {
                 .expect("v8::Value should be the global object");
 
             true_global.set_prototype(scope, v8_ddsa_object.into());
-            // Freeze the true global
-            true_global.set_integrity_level(scope, v8::IntegrityLevel::Frozen);
+            // Freeze the true global (NOTE: as a temporary scaffold, we conditionally do this.
+            if !is_stella {
+                true_global.set_integrity_level(scope, v8::IntegrityLevel::Frozen);
+            }
 
             let v8_ddsa_global = v8::Global::new(scope, v8_ddsa_object);
             (

--- a/crates/static-analysis-kernel/src/analysis/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/javascript.rs
@@ -21,7 +21,7 @@ const JAVASCRIPT_EXECUTION_TIMEOUT: Duration = Duration::from_millis(5000);
 
 thread_local! {
     static JS_RUNTIME: RefCell<JsRuntime> = {
-        let runtime = JsRuntime::try_new().expect("runtime should have all data required to init");
+        let runtime = JsRuntime::try_new_compat(true).expect("runtime should have all data required to init");
         RefCell::new(runtime)
     };
 }


### PR DESCRIPTION
## What problem are you trying to solve?
TL;DR fixing some performance regressions I introduced.

---

With https://github.com/DataDog/datadog-static-analyzer/pull/398, we implemented `scoped_execute`, which runs a script within a `v8::Context` that is a "blank slate" across executions, so no script can mutate the state in a way that persists to another execution.

I did this by creating a new `v8::Context` for every execution, with the justification that the overall performance hit was acceptable.

However, I made some mistakes in that profiling, and upon re-visiting, it looks like the impact is significant (~15% performance penalty).

### Before (122 seconds
v8 spends a lot of time creating the new contexts (~11% of observed frames).
<img width="1018" alt="new-context" src="https://github.com/DataDog/datadog-static-analyzer/assets/774272/ab68269c-9bca-4cdb-820c-ad366f41f9cc">

## What is your solution?
We need two things:
1. The global state should not be mutable from JavaScript.
2. The global state _should_ be mutable from Rust.

### Technical Details

We now re-use the same `v8::Context` across executions. To achieve an equivalent level of encapsulation as creating a new context, we employ two strategies:

**Freeze the global object and set its prototype**
In JavaScript, calling `Object.freeze(/* obj */)` on an object prevents new properties from being added, existing properties from being modified in any way, and the object's prototype from being changed ([reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze)). We freeze the v8 context's default global object to satisfy #1. However, to satisfy #2, we can't set our bridge variables on the global object directly (because a frozen object cannot be mutated by either JS or Rust). Instead, we set our own persistent object as the prototype of the `v8::Context`'s global object. When a script accesses, e.g. a ddsa bridge variable name, it will walk the [prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) and resolve to a value on _our_ persistent object, allowing us to achieve #2.

**Wrap rule code in an anonymous function**
An anonymous function provides encapsulation by creating a separate scope for all code within it.

For example, a function declaration is effectively an assignment to the scope's most immediate global object:
```js
function greet() { /* ... */ }
// Equivalent to:
//
// globalThis.greet = () => { /* ... */ };
```

Because we've frozen `globalThis`, a standard function declaration won't work. Instead, we have to enter a different scope with an anonymous function:
```js
(() => {
  function greet() { /* ... */ }
  // Equivalent to:
  //
  // const greet = () => { /* ... */ };
})();
```
This prevents local variable declarations from applying to/mutating the v8 context we're re-using.

**"use strict";**
We set the script to run in [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode). This is desirable because it makes code that attempts to write to an unwritable object (e.g. the frozen `globalThis`) throw an error (instead of silently fail).

### After (107 seconds
<img width="940" alt="reused-context" src="https://github.com/DataDog/datadog-static-analyzer/assets/774272/e0779d7f-80a6-481c-8d9c-d073a0e04449">


## Alternatives considered

## What the reviewer should know
* The stella library in production also [re-uses a v8 context](https://github.com/DataDog/datadog-static-analyzer/blob/9a414313553090a03bfaf41fe3ac7de5d25ee12b/crates/static-analysis-kernel/src/analysis/javascript.rs#L161), but this PR takes the encapsulation further.
* Disregard https://github.com/DataDog/datadog-static-analyzer/commit/436349e8888f17b189268882f4f4ed06cf25b471, which was necessary to keep stella working. This will be after switching over to ddsa.
