### PR TITLE
Update op to only return named children

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
@@ -10,7 +10,7 @@ deno_core::extension!(
         ops::op_current_filename,
         ops::op_console_push,
         ops::op_current_ts_tree_text,
-        ops::op_ts_node_children,
+        ops::op_ts_node_named_children,
         ops::op_ts_node_text,
     ],
     esm_entry_point = "ext:ddsa_lib/__bootstrap.js",

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.js
@@ -4,7 +4,7 @@
 
 import { SEALED_EMPTY_ARRAY } from "ext:ddsa_lib/utility";
 
-const { op_ts_node_children, op_ts_node_text } = Deno.core.ops;
+const { op_ts_node_named_children, op_ts_node_text } = Deno.core.ops;
 
 /**
  * A non-zero integer assigned by the Rust static-analysis-kernel.
@@ -149,7 +149,7 @@ export class TreeSitterNode {
     }
 
     /**
-     * A getter to return the children of this tree-sitter node.
+     * A getter to return the named children of this tree-sitter node.
      * NOTE: This is deprecated, because it is a compatibility layer to support the stella API.
      * Do not rely on this, as it will be removed.
      *
@@ -157,7 +157,7 @@ export class TreeSitterNode {
      * @deprecated
      */
     get children() {
-        const childIds = op_ts_node_children(this.id);
+        const childIds = op_ts_node_named_children(this.id);
         if (childIds === undefined) {
             return SEALED_EMPTY_ARRAY;
         }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
@@ -72,12 +72,12 @@ pub fn op_ts_node_text(state: &OpState, #[smi] node_id: u32) -> Option<String> {
 }
 
 /// Given a tree-sitter node (via its `node_id`), this function traverses the tree to find the
-/// children of the node, inserting them into the `TsNodeBridge`. Nodes are returned as a
+/// named children of the node, inserting them into the `TsNodeBridge`. Nodes are returned as a
 /// `v8::Uint32Array` of node ids.
 ///
-/// If the node doesn't exist, or it has no children, `None` is returned.
+/// If the node doesn't exist, or it has no named children, `None` is returned.
 #[op2]
-pub fn op_ts_node_children<'s>(
+pub fn op_ts_node_named_children<'s>(
     state: &OpState,
     scope: &mut v8::HandleScope<'s>,
     #[smi] node_id: u32,
@@ -88,7 +88,7 @@ pub fn op_ts_node_children<'s>(
     let ts_node = safe_raw_ts_node.to_node();
     let mut tree_cursor = ts_node.walk();
 
-    let children = ts_node.children(&mut tree_cursor);
+    let children = ts_node.named_children(&mut tree_cursor);
     let count = children.len();
     if count == 0 {
         None

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -864,8 +864,9 @@ function visit(captures) {
         assert_eq!(console_lines[1], expected_nested);
     }
 
+    /// Tests that `op_ts_node_named_children` returns only named children.
     #[test]
-    fn op_ts_node_children() {
+    fn op_ts_node_named_children() {
         let mut rt = JsRuntime::try_new().unwrap();
         let source_text = "function echo(a, b, c) {}";
         let filename = "some_filename.js";
@@ -880,7 +881,7 @@ function visit(captures) { }
 function visit(captures) {
     const node = captures.get("paramList");
     const children = node.children;
-    console.log(children);
+    console.log(children.map((c) => c.text));
 }
 "#;
         // First run a no-op rule to assert that only 1 (captured) node is sent to the bridge.
@@ -890,9 +891,8 @@ function visit(captures) {
         shorthand_execute_rule_internal(&mut rt, source_text, filename, ts_query, get_children)
             .unwrap();
         let console_lines = rt.console.borrow_mut().drain().collect::<Vec<_>>();
-        // We should've newly pushed the captured node's 7 children to the bridge.
-        assert_eq!(rt.bridge_ts_node.borrow().len(), 8);
-        let expected = r#"[{"type":"","start":{"line":1,"col":14},"end":{"line":1,"col":15},"text":"("},{"type":"identifier","start":{"line":1,"col":15},"end":{"line":1,"col":16},"text":"a"},{"type":"","start":{"line":1,"col":16},"end":{"line":1,"col":17},"text":","},{"type":"identifier","start":{"line":1,"col":18},"end":{"line":1,"col":19},"text":"b"},{"type":"","start":{"line":1,"col":19},"end":{"line":1,"col":20},"text":","},{"type":"identifier","start":{"line":1,"col":21},"end":{"line":1,"col":22},"text":"c"},{"type":"","start":{"line":1,"col":22},"end":{"line":1,"col":23},"text":")"}]"#;
-        assert_eq!(console_lines[0], expected);
+        // We should've newly pushed the captured node's 3 children to the bridge.
+        assert_eq!(rt.bridge_ts_node.borrow().len(), 4);
+        assert_eq!(console_lines[0], r#"["a","b","c"]"#);
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
Currently, when a rule requests the children of a tree-sitter node, they get both [anonymous and named nodes](https://tree-sitter.github.io/tree-sitter/using-parsers#named-vs-anonymous-nodes), which is unintuitive and does not follow the semantics of [what we currently do with the stella library](https://github.com/DataDog/datadog-static-analyzer/blob/e0f4f7685a69ac825a80f44055ff505dcf9c931f/crates/static-analysis-kernel/src/analysis/tree_sitter.rs#L317-L318).

```js
function echo(a, b, c) {}
```

For the query:
```
((function_declaration
    (formal_parameters) @paramList))
```

The (anonymous + named) children of `@paramList` are:
`(`, `a`, `,`, `b`, `,`, `c`, `)`

The named children are:
`a`, `b`, `c`

## What is your solution?
Use tree-sitter's [`named_children`](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/binding_rust/lib.rs#L1268) API instead of `children`.

## Alternatives considered

## What the reviewer should know
