### PR TITLE
[STAL-2336] Include paths configuration for diff-aware hash

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -30,6 +30,7 @@ use getopts::Options;
 use indicatif::ProgressBar;
 use kernel::arguments::ArgumentProvider;
 use kernel::model::config_file::{ConfigFile, PathConfig};
+use kernel::model::diff_aware::DiffAware;
 use kernel::path_restrictions::PathRestrictions;
 use kernel::rule_overrides::RuleOverrides;
 use rayon::prelude::*;

--- a/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
@@ -111,6 +111,8 @@ pub struct TraceSpan {
     /// An HTTP request id.
     ///
     /// Note: This could either be an arbitrary user-supplied string or auto-generated as a UUID v4
+    ///
+    #[allow(dead_code)]
     pub request_id: String,
 }
 

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -56,7 +56,7 @@ impl DiffAware for CliConfiguration {
 
         // println!("rules string: {}", rules_string.join("|"));
         let full_config_string = format!(
-            "{}:{}:{}:{}::{}:{}:{}",
+            "{}:{}:{}:{}::{}:{}:{}:{}",
             self.path_config.ignore.join(","),
             self.path_config
                 .only
@@ -67,6 +67,7 @@ impl DiffAware for CliConfiguration {
             self.max_file_size_kb,
             self.source_subdirectories.join(","),
             self.path_restrictions.generate_diff_aware_digest(),
+            self.argument_provider.generate_diff_aware_digest()
         );
         // compute the hash using sha2
         format!("{:x}", Sha256::digest(full_config_string.as_bytes()))
@@ -175,7 +176,7 @@ mod tests {
         };
         assert_eq!(
             cli_configuration.generate_diff_aware_digest(),
-            "9271c93630cc971d489eba01264408eb804c27c384c9ca09bc02486f2e616d75"
+            "e62e95f2662c983b01ac932709b760718815ae1ca777de9eec51b72d90b8ddd6"
         );
     }
 }

--- a/crates/static-analysis-kernel/src/arguments.rs
+++ b/crates/static-analysis-kernel/src/arguments.rs
@@ -18,15 +18,15 @@ impl DiffAware for ArgumentProvider {
             .flat_map(|(rule, subtree)| {
                 subtree.iter().flat_map(|(st, v)| {
                     st.into_iter().flat_map(|path_component| {
-                        v.into_iter()
+                        v.iter()
                             .map(|(arg1, arg2)| {
-                                return format!(
+                                format!(
                                     "{}:{}:{}:{}",
                                     rule.clone(),
                                     &path_component.generate_diff_aware_digest(),
                                     arg1.clone(),
                                     arg2.clone()
-                                );
+                                )
                             })
                             .collect::<Vec<String>>()
                     })

--- a/crates/static-analysis-kernel/src/model.rs
+++ b/crates/static-analysis-kernel/src/model.rs
@@ -1,6 +1,7 @@
 pub mod analysis;
 pub mod common;
 pub mod config_file;
+pub mod diff_aware;
 pub mod rule;
 pub mod rule_test;
 pub mod ruleset;

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -169,6 +169,12 @@ impl PathConfig {
 #[derive(Debug, PartialEq, Eq, Hash, Default, Clone)]
 pub struct PathComponent(String);
 
+impl DiffAware for PathComponent {
+    fn generate_diff_aware_digest(&self) -> String {
+        self.0.clone()
+    }
+}
+
 // The key for operations on BySubtree.
 pub type SplitPath = Vec<PathComponent>;
 

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -29,7 +29,7 @@ impl DiffAware for PathPattern {
             .map(|v| v.to_string())
             .unwrap_or("".to_string());
 
-        return format!("{}:{}", glob, prefix);
+        format!("{}:{}", glob, prefix)
     }
 }
 
@@ -62,7 +62,7 @@ impl DiffAware for PathConfig {
             .collect::<Vec<String>>()
             .join(",");
 
-        return format!("{}:{}", only, ignore);
+        format!("{}:{}", only, ignore)
     }
 }
 

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::model::rule::{RuleCategory, RuleSeverity};
-use crate::path_restrictions::PathRestrictions;
 
 // A pattern for an 'only' or 'ignore' field. The 'glob' field contains a precompiled glob pattern,
 // while the 'prefix' field contains a path prefix.

--- a/crates/static-analysis-kernel/src/model/diff_aware.rs
+++ b/crates/static-analysis-kernel/src/model/diff_aware.rs
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+/// This trait defines what is required for diff-aware to run correctly. Diff-aware needs to
+/// be activated for a certain configuration. All elements that makes the configuration
+/// or the results change should implement this trait and generate a unique string
+/// that is used to produce a configuration hash.
+pub trait DiffAware {
+    /// The string that generates a string used to produce a unique hash for the configuration.
+    /// This string should always be the same at each run if the configuration did not change.
+    fn generate_diff_aware_digest(&self) -> String;
+}

--- a/crates/static-analysis-kernel/src/path_restrictions.rs
+++ b/crates/static-analysis-kernel/src/path_restrictions.rs
@@ -23,7 +23,7 @@ impl DiffAware for RestrictionsForRuleset {
         rules.sort();
         let rules_str = rules.join(",");
 
-        return format!("{}:{}", paths, rules_str);
+        format!("{}:{}", paths, rules_str)
     }
 }
 
@@ -43,7 +43,7 @@ impl DiffAware for PathRestrictions {
             .collect::<Vec<String>>();
         res.sort();
 
-        return res.join(",");
+        res.join(",")
     }
 }
 


### PR DESCRIPTION
## What problem are you trying to solve?

When we generate the config hash for diff-aware, some parts of the configuration are not being included, especially the results about where to apply the rules (`only` and `ignore` configuration attributes).

## What is your solution?

Add a trait `DiffAware` that contains the method that needs to be implemented for each configuration element that may be used to calculate the hash for diff-aware. This trait is then implemented for many configuration elements, including the one for `only` and `ignore` attributes.