### PR TITLE
[STAL-2368] refactor: add a retry mechanism anywhere requests are made

### DIFF
--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -113,14 +113,33 @@ fn make_request(
     }
 }
 
+fn perform_request(request_builder: RequestBuilder) -> Result<reqwest::blocking::Response> {
+    let mut server_response = None;
+    let mut retry_time = 1;
+    for _ in 0..5 {
+        match request_builder.try_clone().unwrap().send() {
+            Ok(r) => server_response = Some(r),
+            Err(_) => {
+                eprintln!("Error when querying the datadog server");
+                std::thread::sleep(std::time::Duration::from_secs(retry_time));
+                retry_time *= 2; // Exponential backoff
+            }
+        }
+    }
+    let Some(server_response) = server_response else {
+        return Err(anyhow!("Error when querying the datadog server"));
+    };
+
+    Ok(server_response)
+}
+
 // get rules from one ruleset at datadog
 // it connects to the API using the DD_SITE, DD_APP_KEY and DD_API_KEY and retrieve
 // the rulesets. We then extract all the rulesets
 pub fn get_ruleset(ruleset_name: &str, use_staging: bool) -> Result<RuleSet> {
     let path = format!("rulesets/{ruleset_name}?include_tests=false&include_testing_rules=true");
-    let server_response = make_request(RequestMethod::Get, &path, use_staging, false)?
-        .send()
-        .expect("error when querying the datadog server");
+    let req = make_request(RequestMethod::Get, &path, use_staging, false)?;
+    let server_response = perform_request(req)?;
 
     let status_code = server_response.status();
     let response_text = &server_response.text()?;
@@ -165,7 +184,7 @@ pub fn get_default_rulesets_name_for_language(
     )?
     .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_APPLICATION_JSON);
 
-    let server_response = request_builder.send()?;
+    let server_response = perform_request(request_builder)?;
 
     let response_text = &server_response.text()?;
     let api_response = serde_json::from_str::<ApiResponseDefaultRuleset>(response_text);
@@ -230,17 +249,17 @@ pub fn get_diff_aware_information(arguments: &DiffAwareRequestArguments) -> Resu
         },
     };
 
-    let server_response = make_request(RequestMethod::Post, "analysis/diff-aware", false, true)?
-        .json(&request_payload)
-        .send()
-        .expect("error when querying the datadog server");
+    let req = make_request(RequestMethod::Post, "analysis/diff-aware", false, true)?
+        .json(&request_payload);
+    let server_response = perform_request(req)?;
 
-    let status = server_response.status();
+    let status_code = server_response.status();
     let response_text = &server_response.text()?;
+
     let api_response = serde_json::from_str::<DiffAwareResponse>(response_text);
 
-    if !&status.is_success() {
-        return Err(anyhow!("server returned error {}", &status.as_u16()));
+    if !&status_code.is_success() {
+        return Err(anyhow!("server returned error {}", &status_code.as_u16()));
     }
 
     match api_response {

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -8,8 +8,8 @@ where
     F: FnMut(&mut Command) -> &mut Command,
 {
     let mut command = Command::new(name);
-    println!("Running {command:?}");
     let configured = configure(&mut command);
+    println!("Running {configured:?}");
     configured
         .status()
         .unwrap_or_else(|_| panic!("failed to execute {configured:?}"))
@@ -202,9 +202,21 @@ fn main() {
             assert!(run("git", |cmd| {
                 cmd.args(["remote", "add", "origin", &proj.repository])
             }));
-            assert!(run("git", |cmd| {
-                cmd.args(["fetch", "-q", "--depth", "1", "origin", &proj.commit_hash])
-            }));
+            assert!({
+                let mut ok = false;
+                let mut retry_time = 1;
+                for _ in 0..5 {
+                    ok |= run("git", |cmd| {
+                        cmd.args(["fetch", "-q", "--depth", "1", "origin", &proj.commit_hash])
+                    });
+                    if ok {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs(retry_time));
+                    retry_time *= 2; // Exponential backoff
+                }
+                ok
+            });
             assert!(run("git", |cmd| {
                 cmd.args(["checkout", "-q", "FETCH_HEAD"])
             }));


### PR DESCRIPTION
## What problem are you trying to solve?

This PR will help avoid transient/flaky failures in our CI, as seen [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/9746106627/job/26895629440#step:7:269). The problem is we don't have a retry mechanism in case a request fails due to transient errors/flakiness that is not our fault, which is not ideal because having a retry or two could fix this in some cases.

## What is your solution?

I've added a retry mechanism in three spots that has an exponential backoff, so each successive failure will double the delay in between the next retry, up to five time. Initially the delay is 1 second, and at most it will be 16 seconds (on the 5th attempt). The spots covered are when we fetch the repository from GitHub (an observed failure here is the reason for this ticket), and when we query our API for rules or diff aware.

## Alternatives considered

## What the reviewer should know

I've refactored the request logic + retry mechanism into the `perform_request` function in `datadog_utils.rs` since we have two different spots where we make a request.
