### PR TITLE
[STAL-1960] Implement "field name" for tree-sitter node children

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
@@ -11,7 +11,7 @@ import {QueryMatch} from "ext:ddsa_lib/query_match";
 import {QueryMatchCompat} from "ext:ddsa_lib/query_match_compat";
 import {RootContext} from "ext:ddsa_lib/context_root";
 import {RuleContext} from "ext:ddsa_lib/context_rule";
-import {TreeSitterNode} from "ext:ddsa_lib/ts_node";
+import {TreeSitterFieldChildNode, TreeSitterNode} from "ext:ddsa_lib/ts_node";
 import {TsLanguageContext} from "ext:ddsa_lib/context_ts_lang";
 // TODO(JF): These are only used by the Rust runtime, which currently expects them in global scope, but
 //           these should be hidden inside another object, not `globalThis`.
@@ -23,6 +23,7 @@ globalThis.QueryMatchCompat = QueryMatchCompat;
 globalThis.RootContext = RootContext;
 globalThis.RuleContext = RuleContext;
 globalThis.TreeSitterNode = TreeSitterNode;
+globalThis.TreeSitterFieldChildNode = TreeSitterFieldChildNode;
 globalThis.TsLanguageContext = TsLanguageContext;
 
 ///////////

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/utility.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/utility.js
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-import {TreeSitterNode} from "ext:ddsa_lib/ts_node";
+import {TreeSitterNode, TreeSitterFieldChildNode} from "ext:ddsa_lib/ts_node";
 const { op_console_push } = Deno.core.ops;
 
 export class DDSA_Console {
@@ -60,7 +60,9 @@ export class DDSA_Console {
      * @constructor
      */
     static JSONReplacer(key, value) {
-        if (value instanceof TreeSitterNode) {
+        if (value instanceof TreeSitterFieldChildNode) {
+            return asDebugFieldChild(value);
+        } else if (value instanceof TreeSitterNode) {
             return asDebugTsNode(value);
         }
         return value;
@@ -75,6 +77,28 @@ export class DDSA_Console {
  * @param {Position} end
  * @param {string} text
  */
+
+/**
+ * A human-friendly representation of a {@link TreeSitterFieldChildNode}, helpful for debugging a rule.
+ * @typedef DebugTreeSitterFieldChildNode
+ * @param {string} fieldName
+ * @extends {TreeSitterNode}
+ */
+
+/**
+ * Converts a {@link TreeSitterFieldChildNode} to a {@link DebugTreeSitterFieldChildNode}.
+ * @param {TreeSitterFieldChildNode} childNode
+ * @returns {DebugTreeSitterFieldChildNode}
+ */
+function asDebugFieldChild(childNode) {
+    const dNode = asDebugTsNode(childNode);
+    // Spread the object to use a custom property ordering.
+    return {
+        type: dNode.type,
+        fieldName: childNode.fieldName,
+        ...dNode,
+    };
+}
 
 /**
  * Converts a {@link TreeSitterNode} to a {@link DebugTreeSitterNode}.


### PR DESCRIPTION
## What problem are you trying to solve?
Rules in the stella runtime can access the [field name](https://tree-sitter.github.io/tree-sitter/using-parsers#node-field-names) of a child node. This is currently unimplemented in ddsa.

## What is your solution?

### Primer on field names
A tree-sitter node that is a child can be referred to be a field name, however, it's important to clarify that it is _not_ "the node's field name" -- it is "a field name linked to a node (only because it's the child of another)".

Not every child has a field name:
For the given JavaScript, we have the tree:
```js
function echo(a, b, c) {
    // Implementation here
}
```
<img width="327" alt="image" src="https://github.com/DataDog/datadog-static-analyzer/assets/774272/3c7bff22-fb33-4711-aff0-fa3905e62a8c">

In this example, the `(function_declaration)` node has three children, and they all have field names associated with them:
* `(identifier)`, with field name "name"
* `(formal_parameters)`, with field name "parameters"
* `(statement_block)`, with field name "body".

The `(formal_parameters)` node likewise has three children, but none of them have field names
* `(identifier)`, with no field name
* `(identifier)`, with no field name
* `(identifier)`, with no field name

### Serialization
ddsa is designed around passing around [smi](https://github.com/v8/v8/blob/c803f15380d8ce9f618aaf3f31a2adb527e9da68/src/objects/smi.h#L17-L22)s, and this use case is no different.

When we fetch the children of a node, we now need to pass in an additional id so that a rule can look up its string name. This is done by passing a tuple for each child, where it is now `(NodeId, FieldId)` instead of just `NodeId`. tree-sitter itself uses [one-based field ids](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/binding_rust/lib.rs#L118), so we can conveniently use 0 to indicate the absence of a field name.
```
(The contents of the Uint32Array that is sent to v8)

|             Node A              |             Node B              |
|    NodeId A    |    FieldId A   |    NodeId B    |    FieldId B   |
 ________________ ________________ ________________ ________________
|                |                |                |                |
0                1                2                3
     32 bits          32 bits          32 bits          32 bits
```

### Deserialization
When a child has a field name, we effectively "wrap" the `TreeSitterNode` with another object ([a newly-introduced class](https://github.com/DataDog/datadog-static-analyzer/blob/b307dbe3652848707f846efea5f58a3304677303/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.js#L192)) that provides the field name. To callers, this has the exact same interface as a `TreeSitterNode`, but it additionally contains `fieldName`. For a visual representation, when console.logged:
```js
console.log(tsNode);
// {"type":"identifier","start":{"line":1,"col":15},"end":{"line":1,"col":16},"text":"a"}
console.log(childNode);
// {"type":"identifier","fieldName":"name","start":{"line":1,"col":10},"end":{"line":1,"col":14},"text":"echo"}
```

### Getting field ids
In order to performantly access the field ids, we need to perform child lookup manually using the cursor API instead of the provided iterators. What we end up doing here is [copy/pasting](https://github.com/DataDog/datadog-static-analyzer/blob/b307dbe3652848707f846efea5f58a3304677303/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs#L111-L113) the [binding's iterator implementation](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/binding_rust/lib.rs#L1268-L1284), but adding a call to `cursor.field_id()` where required.

## Alternatives considered
* Instead of wrapping the `TreeSitterNode` with `TreeSitterFieldChildNode`, do something like `export class ChildClass extends TreeSitterNode { /* ... */ }`, and just add an additional property for the field name here. In theory, that should provide faster property lookup than our current solution because the prototype chain won't need to be walked for every access. I passed on this because my intuition is that my current solution makes better tradeoffs since it will prevent duplicate allocations (e.g. of the `start` object, `_cachedText`, etc)

## What the reviewer should know
* This provides the exact same functionality as the stella "fieldName"