### PR TITLE
Add stopgap cache clearing for ddsa on the analyzer server

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -210,6 +210,15 @@ impl JsRuntime {
         })
     }
 
+    /// Clears the [`v8::UnboundScript`] cache for the given rule name, returning `true` if a script
+    /// existed and was removed from the cache, or `false` if it didn't exist.
+    ///
+    /// # Panics
+    /// Panics if the `script_cache` has an existing borrow.
+    pub fn clear_rule_cache(&self, rule_name: &str) -> bool {
+        self.script_cache.borrow_mut().remove(rule_name).is_some()
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn execute_rule_internal(
         &mut self,


### PR DESCRIPTION
## What problem are you trying to solve?
We currently cache a `v8::Script` for each rule once per runtime and re-use it for every execution. [This cache is keyed by the rule's name](https://github.com/DataDog/datadog-static-analyzer/blob/639e29829d90c94a4d9ee18f0d58efc44cf055c8/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs#L162-L164). This works well for analysis, however, when authoring a rule, that the key is the rule's name means the first version will always be returned.

## What is your solution?
Clear the rule cache for the rules in the HTTP request before executing any of them. This isn't the most elegant solution, but it serves as a stopgap to fix a behavior regression on ddsa that effectively makes rule authoring impossible.

## Alternatives considered
* Hash the rule so that in the `execute_rule` function, the cache miss happens without manual intervention. I think the perf hit of having to hash a bunch of text on each execution is not acceptable, given that the rule authoring use case is not performance-sensitive, but analysis is.

## What the reviewer should know
