### PR TITLE
Fix the unnecessary updating of ddsa FileContext

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_go.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_go.rs
@@ -102,6 +102,12 @@ impl FileContextGo {
     pub(crate) fn package_alias_v8_map(&self) -> &v8::Global<v8::Map> {
         self.packages_aliased.v8_map()
     }
+
+    /// Returns a reference to the `MirroredIndexMap` containing the package to alias map.
+    #[cfg(test)]
+    pub fn package_alias_map(&self) -> &MirroredIndexMap<String, String> {
+        &self.packages_aliased
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What problem are you trying to solve?
https://github.com/DataDog/datadog-static-analyzer/pull/408 fixed a bug that was causing file contexts to be generated for all files, regardless of applicability (e.g. it would calculate a Go package alias map for a JavaScript file).

However, there is still a logic bug that causes the FileContext to be regenerated for every execution, which is wasteful, as it doesn't change between different rule executions.

## What is your solution?
Update the FileContext only when a call to `set_root_context` detects that the tree changed.

## Alternatives considered

## What the reviewer should know
* Relevant change is ~15 LOC, the rest is test boilerplate + tests.
* This PR also tests the transition between two executions to make sure FileContexts aren't co-mingled ([just like we do for Arguments](https://github.com/DataDog/datadog-static-analyzer/blob/d07378c15ec627d9c8a71b8f89366fa14e0276c2/crates/static-analysis-kernel/src/analysis/ddsa_lib/bridge/context.rs#L272))