### PR TITLE
StaticAnalysisConfigFile: do not error if the configuration is empty

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -22,6 +22,9 @@ impl TryFrom<String> for StaticAnalysisConfigFile {
 
     fn try_from(base64_str: String) -> Result<Self, Self::Error> {
         let content = decode_base64_string(base64_str)?;
+        if content.trim().is_empty() {
+            return Ok(Self(ConfigFile::default()));
+        }
         let config = parse_config_file(&content)?;
         Ok(config.into())
     }
@@ -340,6 +343,21 @@ rulesets:
 - ruleset1
 - ruleset2
 - a-ruleset3
+";
+            assert_eq!(config.trim(), expected.trim());
+        }
+
+        #[test]
+        fn it_works_empty_content() {
+            let config = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1"],
+                Some(to_encoded_content("\n")),
+            )
+            .unwrap();
+            let expected = r"
+schema-version: v1
+rulesets:
+- ruleset1
 ";
             assert_eq!(config.trim(), expected.trim());
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -9,6 +9,7 @@ use kernel::{
 use std::{borrow::Cow, fmt::Debug, ops::Deref};
 use tracing::instrument;
 
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct StaticAnalysisConfigFile(ConfigFile);
 
 impl From<ConfigFile> for StaticAnalysisConfigFile {
@@ -23,7 +24,7 @@ impl TryFrom<String> for StaticAnalysisConfigFile {
     fn try_from(base64_str: String) -> Result<Self, Self::Error> {
         let content = decode_base64_string(base64_str)?;
         if content.trim().is_empty() {
-            return Ok(Self(ConfigFile::default()));
+            return Ok(Self::default());
         }
         let config = parse_config_file(&content)?;
         Ok(config.into())
@@ -764,5 +765,12 @@ rulesets:
             let config = StaticAnalysisConfigFile::try_from(content).unwrap();
             assert!(config.is_onboarding_allowed())
         }
+    }
+
+    #[test]
+    fn try_from_returns_default_config_file_if_empty_string() {
+        let expected = super::StaticAnalysisConfigFile::default();
+        let config = super::StaticAnalysisConfigFile::try_from(String::new()).unwrap();
+        assert_eq!(config, expected);
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
Do not error if the user deletes everything in the config file, then tries to onboard from scratch again. The previous code would fail because an empty string is technically invalid YAML.

## What is your solution?
When we see an empty string as the config, assume there's no config.

## What the reviewer should know
This code is used from the IDE-plugin-facing API to modify the config file.