### PR TITLE
feat(docker): add github-action.sh CI script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN cargo build --release --bin datadog-static-analyzer
 
 FROM base
 
-COPY --from=build /app/target/release/datadog-static-analyzer /usr/local/bin/datadog-static-analyzer
+COPY --from=build /app/target/release/datadog-static-analyzer /usr/bin/datadog-static-analyzer
+COPY --from=build /app/misc/github-action.sh /usr/bin/github-action.sh
 
 RUN apt update && apt install -y curl git \
 	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
@@ -33,5 +34,5 @@ RUN npm install -g @datadog/datadog-ci \
 	&& datadog-ci --version            \
 	&& datadog-static-analyzer --version
 
-ENTRYPOINT ["/usr/local/bin/datadog-static-analyzer"]
+ENTRYPOINT ["/usr/bin/datadog-static-analyzer"]
 CMD ["--help"]


### PR DESCRIPTION
## What problem are you trying to solve?

We need a robust way to run our github action with a script that sets up the necessary environment variables and cli arguments without being too hacky with multi-step composite workflows.

## What is your solution?

Add a `github-action.sh` script (stripped-down version of this [entrypoint.sh](https://github.com/DataDog/datadog-static-analyzer-github-action/blob/main/entrypoint.sh) script) that will set up the necessary environment variables and arguments given the input.

## Alternatives considered

Use the composite workflow [here](https://github.com/DataDog/datadog-static-analyzer-github-action/pull/40)

## What the reviewer should know

I talked with Julien about this and this is the solution we came up with, the added benefits are that whenever we add new features to our analyzer, we can update this script here and the container will be updated in one go instead of having to update the github-action repo as well.