### PR TITLE
[STAL-2456] feat: add PHP support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -30,6 +30,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Yaml, &["yml", "yaml"]),
     (Language::Starlark, &["bzl"]),
     (Language::Bash, &["sh", "bash"]),
+    (Language::PHP, &["php"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -697,6 +698,7 @@ mod tests {
         extensions_per_languages.insert(Language::Yaml, 2);
         extensions_per_languages.insert(Language::Starlark, 1);
         extensions_per_languages.insert(Language::Bash, 2);
+        extensions_per_languages.insert(Language::PHP, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -196,6 +196,15 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-php".to_string(),
+            compilation_unit: "tree-sitter-php".to_string(),
+            repository: "https://github.com/tree-sitter/tree-sitter-php.git".to_string(),
+            build_dir: "php/src".into(),
+            commit_hash: "575a0801f430c8672db70b73493c033a9dcfc328".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -71,6 +71,16 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         Language::Json => {
             vec!["impossiblestringtoreach"]
         }
+        Language::PHP => {
+            vec![
+                "//no-dd-sa",
+                "/*no-dd-sa",
+                "//datadog-disable",
+                "/*datadog-disable",
+                "#no-dd-sa",
+                "#datadog-disable",
+            ]
+        }
     };
     let mut ignore_file_all_rules: bool = false;
     let mut rules_to_ignore: Vec<String> = vec![];

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -25,6 +25,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_yaml() -> tree_sitter::Language;
         fn tree_sitter_starlark() -> tree_sitter::Language;
         fn tree_sitter_bash() -> tree_sitter::Language;
+        fn tree_sitter_php() -> tree_sitter::Language;
     }
 
     match language {
@@ -44,6 +45,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::Yaml => unsafe { tree_sitter_yaml() },
         Language::Starlark => unsafe { tree_sitter_starlark() },
         Language::Bash => unsafe { tree_sitter_bash() },
+        Language::PHP => unsafe { tree_sitter_php() },
     }
 }
 
@@ -573,6 +575,20 @@ echo "Hello, World!"
         let t = get_tree(source_code, &Language::Bash);
         assert!(t.is_some());
         assert_eq!("program", t.unwrap().root_node().kind());
+    }
+
+    #[test]
+    fn test_php_get_tree() {
+        let source_code = r#"
+<?php
+echo "Hello, World!";
+?>
+"#;
+        let t = get_tree(source_code, &Language::PHP);
+        assert!(t.is_some());
+        let t = t.unwrap();
+        assert!(!t.root_node().has_error());
+        assert_eq!("program", t.root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -53,6 +53,7 @@ pub enum Language {
     Starlark,
     #[serde(rename = "BASH")]
     Bash,
+    PHP,
 }
 
 #[allow(dead_code)]
@@ -73,6 +74,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::Yaml,
     Language::Starlark,
     Language::Bash,
+    Language::PHP,
 ];
 
 impl fmt::Display for Language {
@@ -94,6 +96,7 @@ impl fmt::Display for Language {
             Self::Yaml => "yaml",
             Self::Starlark => "starlark",
             Self::Bash => "bash",
+            Self::PHP => "php",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support PHP files. We need a way to parse and query PHP files, but we do not currently fetch and build a PHP grammar.

## What is your solution?

Add the PHP grammar to the analyzer itself, which is fetched from https://github.com/tree-sitter/tree-sitter-php. This will allow us (and customers down the line) to begin writing rules targeting PHP files.

## Alternatives considered

## What the reviewer should know
