### PR TITLE
[STAL-2474] Fix edge case with v8::String creation with wide characters

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs
@@ -104,6 +104,7 @@ pub fn load_function(
 /// # Panics
 /// * Panics if the provided string is not ASCII.
 /// * Panics if `str` is longer than the v8 string length limit.
+#[inline(always)]
 pub fn v8_interned<'s>(scope: &mut HandleScope<'s>, str: &str) -> v8::Local<'s, v8::String> {
     // This is a debug assertion because `is_ascii()` is O(N), and the `v8_interned` function is called
     // frequently in performance-critical paths.
@@ -117,12 +118,14 @@ pub fn v8_interned<'s>(scope: &mut HandleScope<'s>, str: &str) -> v8::Local<'s, 
 ///
 /// # Panics
 /// Panics if `str` is longer than the v8 string length limit.
+#[inline(always)]
 pub fn v8_string<'s>(scope: &mut HandleScope<'s>, str: &str) -> v8::Local<'s, v8::String> {
     v8::String::new_from_utf8(scope, str.as_bytes(), v8::NewStringType::Normal)
         .expect("str length should be less than v8 limit")
 }
 
 /// A shorthand for creating a [`v8::Integer`].
+#[inline(always)]
 pub fn v8_uint<'s>(scope: &mut HandleScope<'s>, number: u32) -> v8::Local<'s, v8::Integer> {
     v8::Integer::new_from_unsigned(scope, number)
 }


### PR DESCRIPTION
TL;DR: Effectively `+1 -1` PR handling edge cases in user-provided JavaScript (the other lines are documentation + tests).

## What problem are you trying to solve?
The ddsa runtime has a shorthand function called [v8_string](https://github.com/DataDog/datadog-static-analyzer/blob/f3febaf004d75a6e2a2fbb0b63085348f71719d7/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs#L112-L115) that creates a v8::String.

It does this by calling [new_from_one_byte](https://github.com/denoland/rusty_v8/blob/b590c12fe93c36fc70036200b1dc44ea8d6c60c0/src/string.rs#L358-L361), which tells v8 to expect a Latin-1 encoded string.

`v8_string` is used to create [kNormal](https://github.com/v8/v8/blob/35938f8c9b05a55819d9ac741226b4fdc7f6b832/include/v8-primitive.h#L108-L111) string. kNormal strings are used for "long" strings, or strings that we do not expect to be repeated frequently. Thus, we use `v8_string` to create a v8::Script.

In general, this should not be a problem. However, there are some perfectly normal cases where a user uses text that we will incorrectly mangle. For example, a Violation error message using non-Latin-1 encoding, e.g. reporting an SQL injection vulnerability:
```js
const error = buildError(node.start.line, node.start.col, node.end.line, node.end.col, "SQL注入漏洞");
```
In this case, the rule logic will function as normal, however, the user's string message will become malformed: (`"SQLæ³¨å\u{85}¥æ¼\u{8f}æ´\u{9e}"`).

There is additionally a particularly degenerate case where a user writes a script that uses JavaScript variable names with wide characters. For example, the following is valid JavaScript:
```js
// ("𓀗".length === 2)
const 𓀗 = buildError(node.start.line, node.start.col, node.end.line, node.end.col, "SQL injection vulnerability");
addError(𓀗);
```
In this case, the rule will fail to compile (even though it _should_ work without issue).

## What is your solution?
Use [new_from_utf8](https://github.com/denoland/rusty_v8/blob/b590c12fe93c36fc70036200b1dc44ea8d6c60c0/src/string.rs#L334-L337) instead.

## Alternatives considered

## What the reviewer should know
* This only affects usages of `v8_string`. The rest of ddsa properly handles UTF-8 input (for example, `node.text` on a node with wide characters works as-expected).
* We keep `v8_interned` using `v8::String::new_from_one_byte` because 1) we know beforehand all strings that will be used, and so we can guarantee they are ASCII and 2) the performance is faster. A `debug_assert` is added for additional coverage.
* `[inline(always)]` should've been added initially -- might as well do it now.