### PR TITLE
Release 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.3.7": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.3.7/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
 		"0.3.6": {
 			"cli": {
 				"windows": {


### PR DESCRIPTION
Release version 0.3.7.

This switches our analyzer over to the ddsa JavaScript runtime, which is faster, more memory-efficient, and more powerful.

Note: ddsa was introduced with https://github.com/DataDog/datadog-static-analyzer/pull/381 and activated with https://github.com/DataDog/datadog-static-analyzer/pull/446
