### PR TITLE
[STAL-2508] ci: add regression checks for PHP repositories

### DIFF
--- a/.github/workflows/check-regressions.yml
+++ b/.github/workflows/check-regressions.yml
@@ -17,6 +17,7 @@ jobs:
           - { org: "google", name: "guava" }
           - { org: "reduxjs", name: "redux" }
           - { org: "ruby", name: "spec" }
+          - { org: "laravel", name: "framework" }
           - { org: "muh-nee", name: "BenchmarkJava" }
           - { org: "muh-nee", name: "NodeGoat" }
           - { org: "muh-nee", name: "WebGoat" }
@@ -26,6 +27,7 @@ jobs:
           - { org: "muh-nee", name: "SecurityShepherd" }
           - { org: "muh-nee", name: "DSVW" }
           - { org: "muh-nee", name: "NIST-Juliet-CSharp-1.3" }
+          - { org: "muh-nee", name: "DVWA" }
     env:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       DD_APP_KEY: ${{ secrets.DD_APP_KEY }}


### PR DESCRIPTION
## What problem are you trying to solve?

We now support PHP in the analyzer and rule editor, and have 10 rules available in prod, so we should check for regressions for this language as well. We also provide default rulesets for PHP as well.

## What is your solution?

Add two PHP repos to check for regressions, one focused on security and one focused on best practices/code style.

## Alternatives considered

## What the reviewer should know

This PR only adds two repos to be checked in the `check_regressions` job.
