### PR TITLE
[STAL-2508] add php to default rulesets language

### DIFF
--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -33,6 +33,7 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "PYTHON",
     "RUBY",
     "TYPESCRIPT",
+    "PHP",
 ];
 
 // Get secrets rules from the static analysis API


### PR DESCRIPTION
## What problem are you trying to solve?

PHP rulesets are not being fetched by default

## What is your solution?

Fetch them by default by adding PHP to the `DEFAULT_RULESETS_LANGUAGES` array

## Alternatives considered

## What the reviewer should know

Testing:

With no configuration file, we can see the default rulesets of `php-security` and `php-best-practices` running.
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/a902d1cd-7f7f-4f68-b5a9-024d2d1230f7">

We can also see the API returning the correct default rulesets here.
<img width="912" alt="image" src="https://github.com/user-attachments/assets/c2502da8-99aa-437f-b41e-d4b6de091771">


