### PR TITLE
[STAL] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.*                                                               @DataDog/static-analysis-core
+**/*                                                              @DataDog/static-analysis-core
 /crates/bins/src/bin/datadog_static_analyzer_server/ide/**/*      @DataDog/ide-integration


### PR DESCRIPTION
## What problem are you trying to solve?

After opening https://github.com/DataDog/datadog-static-analyzer/pull/453, I noticed that the CODEOWNERS file didn't automatically assign anyone.

## What is your solution?

Update the pattern to `**/*` to catch everything in the repository