### PR TITLE
[STAL-2515] Introduce `release-dev` cargo profile

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,6 +31,6 @@ jobs:
       - uses: ./.github/actions/rust-cache
         with:
           cargo-target: x86_64-unknown-linux-gnu
-          cargo-cache-key: release
+          cargo-cache-key: release-dev
       - name: Execute script
         run: ${{ matrix.scripts.file }}

--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -23,11 +23,11 @@ jobs:
           cargo-cache-key: release
       - name: Test all production rules
         run: |
-          cargo build -r --bin datadog-static-analyzer && \
-          cargo build -r --bin datadog-static-analyzer-server && \
+          cargo build --profile release-dev --bin datadog-static-analyzer && \
+          cargo build --profile release-dev --bin datadog-static-analyzer-server && \
           sudo apt-get install python3-requests && \
           for language in go python typescript javascript csharp java ruby; do \
-            python misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l $language ; \
+            python misc/test-rules.py -c $PWD/target/release-dev/datadog-static-analyzer -s $PWD/target/release-dev/datadog-static-analyzer-server -l $language ; \
           done
   staging_rules:
     runs-on: ubuntu-latest
@@ -46,9 +46,9 @@ jobs:
           cargo-cache-key: release
       - name: Test all staging rules
         run: |
-          cargo build -r --bin datadog-static-analyzer && \
-          cargo build -r --bin datadog-static-analyzer-server && \
+          cargo build --profile release-dev --bin datadog-static-analyzer && \
+          cargo build --profile release-dev --bin datadog-static-analyzer-server && \
           sudo apt-get install python3-requests && \
           for language in go python typescript javascript csharp java ruby; do \
-            python misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l $language ; \
+            python misc/test-rules.py -c $PWD/target/release-dev/datadog-static-analyzer -s $PWD/target/release-dev/datadog-static-analyzer-server -l $language ; \
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,15 @@ version = "0.3.7"
 [profile.release]
 lto = true
 
+[profile.release-dev]
+inherits = "release"
+lto = false
+debug = true
+debug-assertions = true
+overflow-checks = true
+incremental = true
+codegen-units = 256
+
 [workspace.dependencies]
 anyhow = "1"
 base64 = "0.21.2"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,22 +5,23 @@ You need to have all the necessary [tree-sitter](https://github.com/tree-sitter)
 in `kernel` for the analysis to work. The `build` process will take care of this for you:
 
 ```shell
-cargo build
+cargo build --profile release-dev
 ```
-
-**NOTE**: you may need extra dependencies to install. Read [these instructions](crates/vectorscan-sys/README.md).
+> [!TIP]
+> The use of the `release-dev` cargo profile is highly recommended, as runtime analysis speed is effectively
+> the same as `release` mode, but compile times are comparable to `debug` mode.
 
 ## Analyze a directory
 
 ```shell
 
-cargo run --bin datadog-static-analyzer -- --directory <SOURCE> --output result.json --format sarif --debug yes
+cargo run --profile release-dev --bin datadog-static-analyzer -- --directory <SOURCE> --output result.json --format sarif --debug yes
 ```
 
 ## Start a local server
 
 ```shell
-cargo run --bin datadog-static-analyzer-server -- --port <server-port> -a <server-address>
+cargo run --profile release-dev --bin datadog-static-analyzer-server -- --port <server-port> -a <server-address>
 ```
 
 ## Run tests
@@ -51,7 +52,7 @@ cargo test -- --nocapture
 First, start the server using
 
 ```shell
-cargo run --bin datadog-static-analyzer-server
+cargo run --profile release-dev --bin datadog-static-analyzer-server
 ```
 
 

--- a/misc/integration-test-docker.sh
+++ b/misc/integration-test-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 ## A Python repository
 echo "Checking docker repository"
@@ -10,7 +10,7 @@ git clone --depth=1 https://github.com/juli1/dd-sa-dockerfile.git "${REPO_DIR}"
 
 echo "Try without the static-analysis.datadog.yml file"
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze docker repository"
@@ -31,7 +31,7 @@ echo "Try with the static-analysis.datadog.yml file"
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - docker-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze docker repository"

--- a/misc/integration-test-filter-rules.sh
+++ b/misc/integration-test-filter-rules.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 echo "Checking juice shop"
 REPO_DIR="$(mktemp -d)"
@@ -14,7 +14,7 @@ rulesets:
   - typescript-node-security
 EOT
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${UNFILTERED_OUTPUT}" -f csv
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${UNFILTERED_OUTPUT}" -f csv
 
 if [ $? -ne 0 ]; then
   echo "failed to analyze juice-shop (without rule filters)"
@@ -37,7 +37,7 @@ rulesets:
           - "data/static"
 EOT
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${FILTERED_OUTPUT}" -f csv
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${FILTERED_OUTPUT}" -f csv
 
 if [ $? -ne 0 ]; then
   echo "failed to analyze juice-shop (with rule filters)"

--- a/misc/integration-test-git.sh
+++ b/misc/integration-test-git.sh
@@ -5,14 +5,14 @@
 # 2. Run the latest version of the analyzer on it
 # 3. Check that we get the SHA of the commit and the category in the output SARIF file.
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 ## First, test a repository to check that the commit that indicates the repo information for a violation
 echo "Checking rosie tests"
 REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x -g
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x -g
 if [ $? -ne 0 ]; then
   echo "fail to analyze rosie-tests"
   exit 1

--- a/misc/integration-test-js-ts.sh
+++ b/misc/integration-test-js-ts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 echo "Checking juice shop"
 REPO_DIR=$(mktemp -d)
@@ -19,7 +19,7 @@ echo " - tsx-react" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - javascript-node-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - typescript-node-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze juice-shop"

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 ## A Python repository
 echo "Checking django repository"
@@ -10,7 +10,7 @@ git clone --depth=1 https://github.com/gothinkster/django-realworld-example-app.
 
 # Test without the static-analysis.datadog.yml file
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze django repository"
@@ -33,7 +33,7 @@ echo " - python-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-django" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze django repository"
@@ -50,7 +50,7 @@ if [ "$RES" -lt "18" ]; then
 fi
 
 # Test that --fail-on-any-violation returns a non-zero return code
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
 
 if [ $? -eq 0 ]; then
   echo "static analyzer reports 0 when it should not"

--- a/misc/integration-test-secrets.sh
+++ b/misc/integration-test-secrets.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build -r --bin datadog-static-analyzer
+cargo build --profile release-dev --bin datadog-static-analyzer
 
 ## A Python repository
 echo "Checking secrets-tests repository"
@@ -10,7 +10,7 @@ git clone --depth=1 https://github.com/muh-nee/secrets-tests.git "${REPO_DIR}"
 
 # Test without the static-analysis.datadog.yml file
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x --secrets
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x --secrets
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze secrets-tests repository"

--- a/misc/test-rules.py
+++ b/misc/test-rules.py
@@ -2,10 +2,10 @@
 # We assume that everything is correctly built and available in the `target` directory.
 
 # If you want to try this locally
-# 1. Build the binary locally (e.g. cargo run -r)
+# 1. Build the binary locally (e.g. cargo build --profile release-dev)
 # 2. Bootstrap a Python environment with requests (e.g python -mvenv venv && source venv/bin/activate && pip install requests)
-# 3. Execute the script: python misc/test-rules.py -l <LANGUAGE> -c target/release/datadog-static-analyzer -s target/release/datadog-static-analyzer-server
-# Example: python misc/test-rules.py -l python -c target/release/datadog-static-analyzer -s target/release/datadog-static-analyzer-server
+# 3. Execute the script: python misc/test-rules.py -l <LANGUAGE> -c target/release-dev/datadog-static-analyzer -s target/release-dev/datadog-static-analyzer-server
+# Example: python misc/test-rules.py -l python -c target/release-dev/datadog-static-analyzer -s target/release-dev/datadog-static-analyzer-server
 
 import base64
 import json


### PR DESCRIPTION
TL;DR increase developer iteration speed (incremental compilation time reduced by 95%+)

## What problem are you trying to solve?

It is currently common to use `cargo build --release` when developing the analyzer because the runtime performance of an optimized build is ~3x faster, making it optimal for testing the analyzer against large repos (it makes the difference between a 3 minute monorepo scan and a 10 minute one).

However, when using `--release`, when a single line changes, the binaries need to be rebuilt, and that takes over 2 minutes (on a very fast M1 Macbook), significantly reducing the ability to iterate quickly.

The reason for this is that we currently use [`lto = true`](https://github.com/DataDog/datadog-static-analyzer/blob/9deac25424c5e56d7d5fa6e30f7bdf5d7a8e3469/Cargo.toml#L16) for `release` mode (which is important for actual releases, but not development).

To illustrate, here is a trace of a `--release` compilation where all crates have been compiled and then 1 single line of code in `analyze.rs` is changed:

<img width="839" alt="release" src="https://github.com/user-attachments/assets/4d7c4fcb-3528-4b08-89c3-b9fe6bfcf036">

As you can see, 1m56s are spent in the linker, (despite only 1 second of actual codegen).

## What is your solution?

Introduce a `release-dev` [Cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html), which is inherited from `--release` mode, but turns off `lto` and includes standard functionality from `--debug` (symbols, assertions, etc.)

This has numerous benefits
* We get the same runtime speed as `--release` (tested on a mono-repo, 96s analysis vs 95s analysis)
* We get debug assertions, debug symbols, etc.
* We get comparable compile times to `--debug`.

### Effect

Whereas before, an incremental `--release` build took 2m1s, an incremental `release-dev` build takes around 2s:

<img width="829" alt="release-dev" src="https://github.com/user-attachments/assets/6a510363-e344-4122-8880-83370497d2fa">

### Methodology
1. Build the `datadog-static-analyzer` binary completely from scratch.
```sh
❯ cargo build --release --bin datadog-static-analyzer
Finished `release` profile [optimized + debuginfo] target(s) in 2m 30s

❯ cargo build --profile release-dev --bin datadog-static-analyzer
Finished `release-dev` profile [optimized + debuginfo] target(s) in 1m 07s
```

2. Change a single line of code:
```rust
// crates/static-analysis-kernel/src/analysis/analyze.rs
// ...
let cache_bust = 1; // (number changed to trigger recompilation)
```

3. Re-run cargo build with timing information

```sh
❯ RUSTC_BOOTSTRAP=1 cargo rustc --profile release --bin datadog-static-analyzer -- -Z self-profile
Finished `release` profile [optimized + debuginfo] target(s) in 2m 01s

❯ RUSTC_BOOTSTRAP=1 cargo rustc --profile release-dev --bin datadog-static-analyzer -- -Z self-profile
Finished `release-dev` profile [optimized + debuginfo] target(s) in 2.60s
```

## Alternatives considered

## What the reviewer should know
* Because we get debug assertions in this new profile, I changed our GHA tests to use it, which improves test coverage.
    * Actual release/images (GitHub artifacts, GHCR Docker image, GitLab) are unchanged (they still use `--release` mode)