### PR TITLE
Per-subtree rule severity overrides

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -1001,4 +1001,131 @@ def foo():
         assert_eq!(result.violations.len(), 1);
         assert_eq!(result.violations[0].message, "invalid name");
     }
+
+    #[test]
+    fn test_severity_override() {
+        let rule_code = r#"
+function visit(node, filename, code) {
+    const functionName = node.captures["name"];
+    const error = buildError(
+        functionName.start.line, functionName.start.col,
+        functionName.end.line, functionName.end.col,
+        `error`);
+    addError(error);
+}
+        "#;
+
+        let rule1 = RuleInternal {
+            name: "rs/rule1".to_string(),
+            short_description: Some("short desc".to_string()),
+            description: Some("description".to_string()),
+            category: RuleCategory::CodeStyle,
+            severity: RuleSeverity::Notice,
+            language: Language::Python,
+            code: rule_code.to_string(),
+            tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+        };
+        let rule2 = RuleInternal {
+            name: "rs/rule2".to_string(),
+            short_description: Some("short desc".to_string()),
+            description: Some("description".to_string()),
+            category: RuleCategory::CodeStyle,
+            severity: RuleSeverity::Notice,
+            language: Language::Python,
+            code: rule_code.to_string(),
+            tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+        };
+
+        let analysis_options = AnalysisOptions {
+            log_output: true,
+            use_debug: false,
+            ignore_generated_files: false,
+        };
+        let rule_config_provider = RuleConfigProvider::from_config(
+            &parse_config_file(
+                r#"
+rulesets:
+  - rs:
+    rules:
+      rule1:
+        severity: ERROR
+      rule2:
+        severity:
+          /: WARNING
+          uno: NOTICE
+          dos/myfile.py: ERROR
+        "#,
+            )
+            .unwrap(),
+        );
+        let rules = vec![rule1, rule2];
+
+        let results = analyze(
+            &Language::Python,
+            &rules,
+            &Arc::from("myfile.py"),
+            &Arc::from(PYTHON_CODE),
+            &rule_config_provider.config_for_file("myfile.py"),
+            &analysis_options,
+        );
+        assert_eq!(
+            results.get(0).unwrap().violations[0].severity,
+            RuleSeverity::Error
+        );
+        assert_eq!(
+            results.get(1).unwrap().violations[0].severity,
+            RuleSeverity::Warning
+        );
+
+        let results = analyze(
+            &Language::Python,
+            &rules,
+            &Arc::from("uno/myfile.py"),
+            &Arc::from(PYTHON_CODE),
+            &rule_config_provider.config_for_file("uno/myfile.py"),
+            &analysis_options,
+        );
+        assert_eq!(
+            results.get(0).unwrap().violations[0].severity,
+            RuleSeverity::Error
+        );
+        assert_eq!(
+            results.get(1).unwrap().violations[0].severity,
+            RuleSeverity::Notice
+        );
+
+        let results = analyze(
+            &Language::Python,
+            &rules,
+            &Arc::from("dos/myfile.py"),
+            &Arc::from(PYTHON_CODE),
+            &rule_config_provider.config_for_file("dos/myfile.py"),
+            &analysis_options,
+        );
+        assert_eq!(
+            results.get(0).unwrap().violations[0].severity,
+            RuleSeverity::Error
+        );
+        assert_eq!(
+            results.get(1).unwrap().violations[0].severity,
+            RuleSeverity::Error
+        );
+
+        let results = analyze(
+            &Language::Python,
+            &rules,
+            &Arc::from("tres/myfile.py"),
+            &Arc::from(PYTHON_CODE),
+            &rule_config_provider.config_for_file("tres/myfile.py"),
+            &analysis_options,
+        );
+        assert_eq!(
+            results.get(0).unwrap().violations[0].severity,
+            RuleSeverity::Error
+        );
+        assert_eq!(
+            results.get(1).unwrap().violations[0].severity,
+            RuleSeverity::Warning
+        );
+    }
 }

--- a/crates/static-analysis-kernel/src/config_file.rs
+++ b/crates/static-analysis-kernel/src/config_file.rs
@@ -288,9 +288,9 @@ struct YamlRuleConfig {
     #[serde(flatten)]
     paths: YamlPathConfig,
     #[serde(default, skip_serializing_if = "UniqueKeyMap::is_empty")]
-    arguments: UniqueKeyMap<YamlArgumentValues>,
+    arguments: UniqueKeyMap<YamlBySubtree<AnyAsString>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    severity: Option<RuleSeverity>,
+    severity: Option<YamlBySubtree<RuleSeverity>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     category: Option<YamlRuleCategory>,
 }
@@ -305,7 +305,7 @@ impl From<YamlRuleConfig> for RuleConfig {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
-            severity: value.severity,
+            severity: value.severity.map(YamlBySubtree::into),
             category: value.category.map(|c| c.0),
         }
     }
@@ -322,48 +322,54 @@ impl From<RuleConfig> for YamlRuleConfig {
                     .map(|(k, v)| (k, v.into()))
                     .collect(),
             ),
-            severity: value.severity,
+            severity: value.severity.map(BySubtree::into),
             category: value.category.map(YamlRuleCategory),
         }
     }
 }
 
-// YAML-serializable argument value map.
+// YAML-serializable element whose value depends on the position in the repo tree.
 // If it only contains one value for the root directory, it serializes and deserializes as
-// a string; otherwise, as a map from path prefix to value.
+// a singular value; otherwise, as a map from path prefix to value.
 #[derive(Default, PartialEq)]
-struct YamlArgumentValues(IndexMap<String, String>);
+struct YamlBySubtree<V>(IndexMap<String, V>);
 
-impl<'de> Deserialize<'de> for YamlArgumentValues {
+impl<'de, V> Deserialize<'de> for YamlBySubtree<V>
+where
+    V: Deserialize<'de>,
+{
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
         #[serde(untagged)]
-        enum Holder {
-            Single(AnyAsString),
-            ByPath(UniqueKeyMap<AnyAsString>),
+        enum Holder<T> {
+            Single(T),
+            ByPath(UniqueKeyMap<T>),
         }
-        let values = match Holder::deserialize(deserializer)? {
-            Holder::Single(v) => IndexMap::from([("".to_string(), v.to_string())]),
+        let values = match Holder::<V>::deserialize(deserializer)? {
+            Holder::Single(v) => IndexMap::from([("".to_string(), v)]),
             Holder::ByPath(m) => {
                 m.0.into_iter()
                     .map(|(k, v)| {
                         if k == "/" || k == "**" {
-                            ("".to_string(), v.to_string())
+                            ("".to_string(), v)
                         } else {
-                            (k, v.to_string())
+                            (k, v)
                         }
                     })
                     .collect()
             }
         };
-        Ok(YamlArgumentValues(values))
+        Ok(YamlBySubtree(values))
     }
 }
 
-impl Serialize for YamlArgumentValues {
+impl<V> Serialize for YamlBySubtree<V>
+where
+    V: Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -386,8 +392,8 @@ impl Serialize for YamlArgumentValues {
     }
 }
 
-impl From<YamlArgumentValues> for BySubtree<String> {
-    fn from(value: YamlArgumentValues) -> Self {
+impl<V> From<YamlBySubtree<V>> for BySubtree<V> {
+    fn from(value: YamlBySubtree<V>) -> Self {
         let mut out = BySubtree::new();
         for (k, v) in value.0 {
             out.insert(&split_path(k), v);
@@ -396,12 +402,41 @@ impl From<YamlArgumentValues> for BySubtree<String> {
     }
 }
 
-impl From<BySubtree<String>> for YamlArgumentValues {
-    fn from(value: BySubtree<String>) -> Self {
-        YamlArgumentValues(
+impl<V> From<BySubtree<V>> for YamlBySubtree<V>
+where
+    V: Clone,
+{
+    fn from(value: BySubtree<V>) -> Self {
+        YamlBySubtree(
             value
                 .iter()
                 .map(|(k, v)| (join_path(&k.into_iter().cloned().collect()), v.clone()))
+                .collect(),
+        )
+    }
+}
+
+impl From<YamlBySubtree<AnyAsString>> for BySubtree<String> {
+    fn from(value: YamlBySubtree<AnyAsString>) -> Self {
+        let mut out = BySubtree::new();
+        for (k, v) in value.0 {
+            out.insert(&split_path(k), v.to_string());
+        }
+        out
+    }
+}
+
+impl From<BySubtree<String>> for YamlBySubtree<AnyAsString> {
+    fn from(value: BySubtree<String>) -> Self {
+        YamlBySubtree(
+            value
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        join_path(&k.into_iter().cloned().collect()),
+                        AnyAsString::Str(v.clone()),
+                    )
+                })
                 .collect(),
         )
     }
@@ -480,7 +515,7 @@ where
 }
 
 // A value that, when deserializing, is cast to a string.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 enum AnyAsString {
     Bool(bool),
@@ -490,6 +525,12 @@ enum AnyAsString {
     U128(u128),
     F64(f64),
     Str(String),
+}
+
+impl Default for AnyAsString {
+    fn default() -> Self {
+        AnyAsString::Str("".to_string())
+    }
 }
 
 impl Display for AnyAsString {

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -76,7 +76,7 @@ pub struct RuleConfig {
     // Arguments to pass to this rule.
     pub arguments: IndexMap<String, BySubtree<String>>,
     // Override this rule's severity.
-    pub severity: Option<RuleSeverity>,
+    pub severity: Option<BySubtree<RuleSeverity>>,
     // Override this rule's category.
     pub category: Option<RuleCategory>,
 }

--- a/crates/static-analysis-kernel/src/rule_config.rs
+++ b/crates/static-analysis-kernel/src/rule_config.rs
@@ -62,7 +62,9 @@ impl<'a> RuleConfig<'a> {
     }
 
     pub fn get_severity(&self, rule_name: &str) -> Option<RuleSeverity> {
-        self.provider.rule_overrides.severity(rule_name)
+        self.provider
+            .rule_overrides
+            .severity(&self.split_path, rule_name)
     }
 
     pub fn get_category(&self, rule_name: &str) -> Option<RuleCategory> {

--- a/crates/static-analysis-kernel/src/rule_overrides.rs
+++ b/crates/static-analysis-kernel/src/rule_overrides.rs
@@ -1,25 +1,25 @@
-use crate::model::config_file::ConfigFile;
+use crate::model::config_file::{BySubtree, ConfigFile, SplitPath};
 use crate::model::rule::{RuleCategory, RuleSeverity};
 use std::collections::HashMap;
 
 /// User-provided overrides for rule definitions.
 #[derive(Default, Clone)]
 pub struct RuleOverrides {
-    severities: HashMap<String, RuleSeverity>,
+    severities: HashMap<String, BySubtree<RuleSeverity>>,
     categories: HashMap<String, RuleCategory>,
 }
 
 impl RuleOverrides {
     // Reads the overrides from the configuration file.
     pub fn from_config_file(cfg: &ConfigFile) -> Self {
-        let severities: HashMap<String, RuleSeverity> = cfg
+        let severities: HashMap<String, BySubtree<RuleSeverity>> = cfg
             .rulesets
             .iter()
             .flat_map(|(rs_name, cfg)| {
                 cfg.rules.iter().filter_map(move |(rule_name, rule)| {
                     rule.severity
                         .as_ref()
-                        .map(|sev| (format!("{}/{}", rs_name, rule_name), *sev))
+                        .map(|sev| (format!("{}/{}", rs_name, rule_name), sev.clone()))
                 })
             })
             .collect();
@@ -41,8 +41,10 @@ impl RuleOverrides {
     }
 
     // Returns the overridden severity for the given rule name, or the original severity if no override exists.
-    pub fn severity(&self, rule_name: &str) -> Option<RuleSeverity> {
-        self.severities.get(rule_name).copied()
+    pub fn severity(&self, file_path: &SplitPath, rule_name: &str) -> Option<RuleSeverity> {
+        self.severities
+            .get(rule_name)
+            .and_then(|s| s.get_ancestor(file_path).cloned())
     }
 
     // Returns the overridden category for the given rule name, or the original category if no override exists.

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -729,6 +729,38 @@ rulesets:
             RuleSeverity::Error,
             response.rule_responses[0].violations[0].severity
         );
+
+        // Per-path severity override.
+        let request = AnalysisRequest {
+            configuration_base64: Some(encode_base64_string(
+                r#"
+rulesets:
+  - myrs:
+    rules:
+      myrule:
+        severity:
+          /: ERROR
+          somepath: WARNING
+          mypath: NOTICE
+          mypath/my: ERROR
+        category: CODE_STYLE
+            "#
+                .to_string(),
+            )),
+            ..base_request.clone()
+        };
+        let response = process_analysis_request(request);
+        assert!(response.errors.is_empty());
+        assert_eq!(1, response.rule_responses.len());
+        assert_eq!(1, response.rule_responses[0].violations.len());
+        assert_eq!(
+            RuleCategory::CodeStyle,
+            response.rule_responses[0].violations[0].category
+        );
+        assert_eq!(
+            RuleSeverity::Notice,
+            response.rule_responses[0].violations[0].severity
+        );
     }
 
     /// Tests that subsequent requests to analyze a rule with the same name can have different code.

--- a/schema/examples/valid/severity.yml
+++ b/schema/examples/valid/severity.yml
@@ -1,0 +1,14 @@
+schema-version: v1
+rulesets:
+  - java-best-practices:
+    rules:
+      avoid-printstacktrace:
+        severity: ERROR
+      one-declaration-per-line:
+        severity:
+          /: WARNING
+          uno/dos: ERROR
+          elsewhere: NOTICE
+      loose-coupling:
+        tres: NOTICE
+        tres/cuatro: ERROR

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -61,11 +61,16 @@
           }
         },
         "severity": {
-          "enum": [
-            "ERROR",
-            "WARNING",
-            "NOTICE",
-            "NONE"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/singularSeverityValue"
+            },
+            {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/singularSeverityValue"
+              }
+            }
           ]
         },
         "category": {
@@ -138,6 +143,14 @@
           "type": "boolean",
           "$comment": "will be internally coerced to string"
         }
+      ]
+    },
+    "singularSeverityValue": {
+      "enum": [
+        "ERROR",
+        "WARNING",
+        "NOTICE",
+        "NONE"
       ]
     }
   }


### PR DESCRIPTION
## What problem are you trying to solve?
Severity overrides are global. We want to be able to set different overrides in different parts of the repo.

## What is your solution?
Modify the schema so the configuration can take severity values or maps from subdirectory to severity. This also makes the 'per subtree' mechanism general so other things can be per-subtree later on.

This is the last PR of the series.