### PR TITLE
[STAL-2469] Add default folder ignores

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -36,6 +36,7 @@ use cli::violations_table;
 use common::analysis_options::AnalysisOptions;
 use common::model::diff_aware::DiffAware;
 use kernel::analysis::analyze::analyze;
+use kernel::analysis::generated_content::DEFAULT_IGNORED_GLOBS;
 use kernel::constants::{CARGO_VERSION, VERSION};
 use kernel::model::analysis::ERROR_RULE_TIMEOUT;
 use kernel::model::common::OutputFormat;
@@ -302,6 +303,11 @@ fn main() -> Result<()> {
         path_config
             .ignore
             .extend(paths_from_gitignore.iter().map(|p| p.clone().into()));
+    }
+    if ignore_generated_files {
+        path_config
+            .ignore
+            .extend(DEFAULT_IGNORED_GLOBS.iter().map(|&p| p.to_string().into()));
     }
 
     let languages = get_languages_for_rules(&rules);

--- a/crates/static-analysis-kernel/src/analysis/generated_content.rs
+++ b/crates/static-analysis-kernel/src/analysis/generated_content.rs
@@ -49,6 +49,25 @@ pub fn is_generated_file(full_content: &str, language: &Language) -> bool {
     }
 }
 
+/// Glob patterns that are, by default, excluded from analysis. These patterns are for paths
+/// that often contain either vendored 3rd party dependencies or generated files.
+pub const DEFAULT_IGNORED_GLOBS: &[&str] = &[
+    // JavaScript
+    "**/node_modules/**/*",
+    "**/jspm_packages/**/*",
+    "**/.next/**/*",
+    "**/.vuepress/**/*",
+    // Python
+    "**/venv/**/*",
+    "**/__pycache__/**/*",
+    // Ruby
+    "**/_vendor/bundle/ruby/**/*",
+    "**/.vendor/bundle/ruby/**/*",
+    "**/.bundle/**/*",
+    // Java
+    "**/.gradle/**/*",
+];
+
 #[cfg(test)]
 mod tests {
     use crate::analysis::generated_content::{is_generated_file, PROTOBUF_HEADER, THRIFT_HEADER};


### PR DESCRIPTION
## What problem are you trying to solve?
It's not uncommon for repositories to vendor third party dependencies. In this case, the folder will _not_ be in the `.gitignore`, and so the analyzer will, by default, scan them.

The user should not have to explicitly ignore folders that we have confidence represent vendored or generated files.

## What is your solution?

Add default ignore globs with an initial list of patterns based on code in the wild.

Next to each pattern is the number of files we would've scanned that this PR would prevent:

| Pattern              | Matches |
| -------------------- | ------- |
| node_modules         | ???     |
| jspm_packages        | [64k](https://github.com/search?q=path%3A**%2Fjspm_packages%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)     |
| .next                | [145k](https://github.com/search?q=path%3A**%2F.next%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)    |
| .vuepress            | [53.3k](https://github.com/search?q=path%3A**%2F.vuepress%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)   |
| venv                 | [954k](https://github.com/search?q=path%3A**%2Fvenv%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)    |
| \_\_pycache__        | [10.9k](https://github.com/search?q=path%3A**%2F__pycache__%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)    |
| \_vendor/bundle/ruby | [9.4k](https://github.com/search?q=path%3A**%2F_vendor%2Fbundle%2Fruby%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)    |
| .vendor/bundle/ruby  | [7.7k](https://github.com/search?q=path%3A**%2F.vendor%2Fbundle%2Fruby%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)    | 
| .bundle              | [48.9k](https://github.com/search?q=path%3A**%2F.bundle%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)   |
| .gradle              | [14.3k](https://github.com/search?q=path%3A**%2F.gradle%2F**+AND+%28path%3A*.js+OR+path%3A*.ts+OR+path%3A*.rb+OR+path%3A*.cs+OR+path%3A*.java+OR+path%3A*.go+OR+path%3A*.py+OR+path%3A*.php%29&type=code)   |

GitHub seems to exclude `node_modules` from their search, so while there isn't a good way to approximate the number, we can assume it's high.

### Sample scan ([npm/cli](https://github.com/npm/cli)): before
<img width="694" alt="image" src="https://github.com/user-attachments/assets/602983be-d42b-4b22-90cb-507df4769f2f">

### Sample scan ([npm/cli](https://github.com/npm/cli)): after
<img width="698" alt="image" src="https://github.com/user-attachments/assets/c57f068b-b2e7-45b0-b83b-90bd214c0884">

## Alternatives considered

## What the reviewer should know
> [!NOTE]
> CI [breaking here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/10046893587/job/27767361330) is expected/desirable**, as it shows this PR is working.
* We don't iterate top-level ignores within the core analysis loop, so there is no performance impact by injecting them into the `PathConfig`.