### PR TITLE
Ignore certain files for secrets

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -28,6 +28,7 @@ use rayon::prelude::*;
 use rocket::yansi::Paint;
 use secrets::model::secret_result::SecretResult;
 use secrets::scanner::{build_sds_scanner, find_secrets};
+use secrets::secret_files::should_ignore_file_for_secret;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::exit;
@@ -473,7 +474,10 @@ fn main() -> Result<()> {
     let mut fail_for_secrets = false;
 
     if secrets_enabled {
-        let secrets_files = &files_to_analyze;
+        let secrets_files: Vec<PathBuf> = files_to_analyze
+            .into_iter()
+            .filter(|f| !should_ignore_file_for_secret(f))
+            .collect();
 
         let sds_scanner = build_sds_scanner(&secrets_rules);
 

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -11,5 +11,7 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+lazy_static = "1.4.0"
+
 # remote
 sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", tag = "v0.1.2", package = "dd-sds" }

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod model;
 pub mod scanner;
+pub mod secret_files;

--- a/crates/secrets/src/secret_files.rs
+++ b/crates/secrets/src/secret_files.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use std::path::PathBuf;
+use std::path::Path;
 
 lazy_static! {
     static ref IGNORE_FILENAMES: Vec<&'static str> = vec![
@@ -15,8 +15,9 @@ lazy_static! {
         vec!["ico", "jpeg", "jpg", "png", "tif", "tiff", "gif"];
 }
 
-#[allow(clippy::ptr_arg)]
-pub fn should_ignore_file_for_secret(path: &PathBuf) -> bool {
+/// Return true if the file should be ignored, false otherwise.
+/// This function is only valid for secrets.
+pub fn should_ignore_file_for_secret(path: &Path) -> bool {
     if let Some(ext) = path.extension() {
         if let Some(e) = ext.to_str() {
             if IGNORE_SUFFIXES.contains(&e) {
@@ -36,8 +37,8 @@ pub fn should_ignore_file_for_secret(path: &PathBuf) -> bool {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_should_ignore_file_for_secret() {

--- a/crates/secrets/src/secret_files.rs
+++ b/crates/secrets/src/secret_files.rs
@@ -1,0 +1,59 @@
+use lazy_static::lazy_static;
+use std::path::PathBuf;
+
+lazy_static! {
+    static ref IGNORE_FILENAMES: Vec<&'static str> = vec![
+        "go.mod",
+        "WORKSPACE",
+        "Gopkg.lock",
+        "package-lock.json",
+        "yarn.lock",
+        "repositories.bzl",
+        "mirror.cfg",
+    ];
+    static ref IGNORE_SUFFIXES: Vec<&'static str> =
+        vec!["ico", "jpeg", "jpg", "png", "tif", "tiff", "gif"];
+}
+
+pub fn should_ignore_file_for_secret(path: &PathBuf) -> bool {
+    if let Some(ext) = path.extension() {
+        if let Some(e) = ext.to_str() {
+            if IGNORE_SUFFIXES.contains(&e) {
+                return true;
+            }
+        }
+    }
+    if let Some(filename) = path.file_name() {
+        if let Some(f) = filename.to_str() {
+            if IGNORE_FILENAMES.contains(&f) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_should_ignore_file_for_secret() {
+        assert!(should_ignore_file_for_secret(&PathBuf::from(
+            "/path/to/file.gif"
+        )));
+        assert!(!should_ignore_file_for_secret(&PathBuf::from(
+            "/path/to/file.py"
+        )));
+        assert!(should_ignore_file_for_secret(&PathBuf::from(
+            "/path/to/go.mod"
+        )));
+        assert!(should_ignore_file_for_secret(&PathBuf::from(
+            "/path/to/repositories.bzl"
+        )));
+        assert!(should_ignore_file_for_secret(&PathBuf::from(
+            "/path/to/yarn.lock"
+        )));
+    }
+}

--- a/crates/secrets/src/secret_files.rs
+++ b/crates/secrets/src/secret_files.rs
@@ -15,6 +15,7 @@ lazy_static! {
         vec!["ico", "jpeg", "jpg", "png", "tif", "tiff", "gif"];
 }
 
+#[allow(clippy::ptr_arg)]
 pub fn should_ignore_file_for_secret(path: &PathBuf) -> bool {
     if let Some(ext) = path.extension() {
         if let Some(e) = ext.to_str() {


### PR DESCRIPTION
## What problem are you trying to solve?

We want to prevent analyzing some files that will trigger false positives by default.

## What is your solution?

Ignore common files such as `yarn.lock` or `WORKSPACE`. Such files contains `shas` and other sequences with large entropy, which may trigger false positives.
