### PR TITLE
Add proximity keywords

### DIFF
--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -65,6 +65,11 @@ pub fn get_secrets_rules(use_staging: bool) -> Result<Vec<SecretRule>> {
                 name: v.attributes.name.clone(),
                 description: v.attributes.description.clone(),
                 pattern: v.attributes.pattern.clone(),
+                default_included_keywords: v
+                    .attributes
+                    .default_included_keywords
+                    .clone()
+                    .unwrap_or(vec![]),
             })
             .collect()),
         Err(e) => {

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -69,7 +69,7 @@ pub fn get_secrets_rules(use_staging: bool) -> Result<Vec<SecretRule>> {
                     .attributes
                     .default_included_keywords
                     .clone()
-                    .unwrap_or(vec![]),
+                    .unwrap_or_default(),
             })
             .collect()),
         Err(e) => {

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -190,6 +190,7 @@ mod tests {
             name: "name1".to_string(),
             description: "description1".to_string(),
             pattern: "pattern1".to_string(),
+            default_included_keywords: vec![],
         };
 
         let secret_rule2 = SecretRule {
@@ -197,6 +198,7 @@ mod tests {
             name: "name2".to_string(),
             description: "description2".to_string(),
             pattern: "pattern2".to_string(),
+            default_included_keywords: vec![],
         };
 
         let cli_configuration_base = CliConfiguration {

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -204,6 +204,7 @@ pub struct SecretRuleApiAttributes {
     pub name: String,
     pub description: String,
     pub pattern: String,
+    pub default_included_keywords: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -95,6 +95,7 @@ mod tests {
             name: "detect a lot of secrets!".to_string(),
             description: "super secret!".to_string(),
             pattern: "FOO(BAR|BAZ)".to_string(),
+            default_included_keywords: vec![],
         }];
         let scanner = build_sds_scanner(rules.as_slice());
         let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";


### PR DESCRIPTION
## What problem are you trying to solve?

To reduce false positives from being raised, we need to pass more data to the rules. The SDS engine also use a `default_included_keywords` which brings additional data used to check for secrets. We did not use them so far but it's suggested to use them to decrease the number of false positives.

## What is your solution?

Consume the `default_included_keywords`

## Testing

Scanning a large Java codebase

**Before**

```
Found 1313 secret(s) in 32905 file(s) using 22 rule(s) within 6 sec(s)
```


**After**

```
Found 16 secret(s) in 32905 file(s) using 22 rule(s) within 6 sec(s)
```