### PR TITLE
feat(config): preserve comments in the static analysis configuration file - IDE-2599

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [
     "crates/cli",
     "crates/static-analysis-kernel",
     "crates/static-analysis-server",
-    "crates/secrets"
+    "crates/secrets",
 ]
 resolver = "2"
 
@@ -39,3 +39,4 @@ sha2 = "0.10.7"
 num_cpus = "1.15.0"
 tracing = "0.1.40"
 uuid = { version = "1.6.1", features = ["v4"] }
+tree-sitter = "0.22.6"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,6 +13,7 @@ num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean Mc
 percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
 prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD-3-Clause,Copyright (c) 2022 Pierre-Henri Symoneaux
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
+pretty_yaml, https://github.com/g-plane/pretty_yaml, MIT, Copyright (c) 2024-present Pig Fang
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld
 sarif-rs,https://github.com/psastras/sarif-rs,MIT,Copyright (c) 2021 Paul Sastrasinh

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,7 +13,7 @@ num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean Mc
 percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
 prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD-3-Clause,Copyright (c) 2022 Pierre-Henri Symoneaux
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
-pretty_yaml, https://github.com/g-plane/pretty_yaml, MIT, Copyright (c) 2024-present Pig Fang
+pretty_yaml,https://github.com/g-plane/pretty_yaml,MIT,Copyright (c) 2024-present Pig Fang
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld
 sarif-rs,https://github.com/psastras/sarif-rs,MIT,Copyright (c) 2021 Paul Sastrasinh

--- a/crates/bins/Cargo.toml
+++ b/crates/bins/Cargo.toml
@@ -48,9 +48,11 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 indexmap = { workspace = true }
-num_cpus = { workspace = true}
+num_cpus = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
+tree-sitter = { workspace = true }
+
 # other
 terminal-emoji = "0.4.1"
 getopts = "0.2.21"
@@ -59,6 +61,7 @@ rayon = "1.7.0"
 rocket = { version = "=0.5.0", features = ["json"] }
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 thiserror = "1"
+pretty_yaml = "0.4"
 
 
 # For linux and macos, we need the vendored ssl

--- a/crates/bins/src/bin/datadog-static-analyzer-server.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-server.rs
@@ -2,5 +2,5 @@ mod datadog_static_analyzer_server;
 
 #[rocket::main]
 async fn main() {
-    datadog_static_analyzer_server::start().await
+    datadog_static_analyzer_server::start().await;
 }

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -500,7 +500,7 @@ fn main() -> Result<()> {
                 "Analyzing {}, {} files detected",
                 language,
                 files_for_language.len()
-            )
+            );
         }
 
         // take the relative path for the analysis

--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -8,7 +8,7 @@ use std::{env, process, thread};
 use super::state::ServerState;
 use super::utils::get_current_timestamp_ms;
 
-fn print_usage(program: &str, opts: Options) {
+fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options]", program);
     print!("{}", opts.usage(&brief));
 }
@@ -61,7 +61,7 @@ pub fn prepare_rocket() -> (Rocket<Build>, ServerState, Sender<Shutdown>) {
     }
 
     if matches.opt_present("h") {
-        print_usage(&program, opts);
+        print_usage(&program, &opts);
         process::exit(0);
     }
 
@@ -122,7 +122,7 @@ pub fn prepare_rocket() -> (Rocket<Build>, ServerState, Sender<Shutdown>) {
 
                     if latest_timestamp > 0 && current_timestamp > latest_timestamp + timeout_ms {
                         eprintln!("exiting because of timeout, trying to exit gracefully");
-                        shutdown_handle.clone().notify();
+                        shutdown_handle.notify();
                         // we give 10 seconds for the process to terminate
                         // if it does not, we abort
                         thread::sleep(Duration::from_secs(10));

--- a/crates/bins/src/bin/datadog_static_analyzer_server/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/endpoints.rs
@@ -149,9 +149,9 @@ async fn serve_static(
 
 /// Catches all OPTION requests in order to get the CORS related Fairing triggered.
 #[rocket::options("/<_..>")]
-fn get_options() -> String {
+const fn get_options() -> String {
     /* Intentionally left empty */
-    "".to_string()
+    String::new()
 }
 
 /// Simple ping method that will return "pong" as response.

--- a/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
@@ -96,9 +96,9 @@ impl Fairing for KeepAlive {
     }
 }
 
-/// Provides functionality to associate a UUIDv4 per request.
+/// Provides functionality to associate a `UUIDv4` per request.
 ///
-/// Rocket 0.5.0 does not generate per-request IDs (see: https://github.com/rwf2/Rocket/issues/21)
+/// Rocket 0.5.0 does not generate per-request IDs (see: [#21](https://github.com/rwf2/Rocket/issues/21))
 /// Until upstream natively supports this, we use a custom [Fairing] to generate one.
 pub struct TracingFairing;
 
@@ -122,10 +122,10 @@ impl TraceSpan {
     }
 }
 
-/// A newtype Option representing a [Span] that is used to conform to the [Request::local_cache] API
+/// A newtype Option representing a [Span] that is used to conform to the [`Request::local_cache`] API
 struct FairingTraceSpan(Option<Span>);
 
-/// A newtype Option representing a [String] request ID that is used to conform to the [Request::local_cache] API
+/// A newtype Option representing a [String] request ID that is used to conform to the [`Request::local_cache`] API
 struct FairingRequestId(Option<String>);
 
 #[rocket::async_trait]
@@ -141,8 +141,7 @@ impl Fairing for TracingFairing {
         let request_id = req
             .headers()
             .get_one("X-Request-Id")
-            .map(String::from)
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
+            .map_or_else(|| Uuid::new_v4().to_string(), String::from);
 
         let request_span = tracing::info_span!(
             "http_request",

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/mod.rs
@@ -1,3 +1,3 @@
 mod models;
 mod reconciler;
-pub use reconciler::{reconcile_comments, ReconcileError};
+pub use reconciler::{prettify_yaml, reconcile_comments, ReconcileError};

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/mod.rs
@@ -1,0 +1,3 @@
+mod models;
+mod reconciler;
+pub use reconciler::{reconcile_comments, ReconcileError};

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
@@ -1,0 +1,40 @@
+#[derive(Debug, Clone, Default)]
+pub struct Line {
+    pub row: usize,
+    pub content: String,
+}
+
+impl Line {
+    pub fn new(row: usize, content: String) -> Self {
+        Self { row, content }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Comment {
+    Inline {
+        line: Line,
+        original_content: String,
+    },
+    Block {
+        line: Line,
+        above_line: Option<Line>,
+        below_line: Option<Line>,
+    },
+}
+
+impl Comment {
+    pub const fn get_line(&self) -> &Line {
+        match self {
+            Self::Inline {
+                line,
+                original_content: _,
+            }
+            | Self::Block {
+                line,
+                above_line: _,
+                below_line: _,
+            } => line,
+        }
+    }
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
@@ -5,7 +5,7 @@ pub struct Line {
 }
 
 impl Line {
-    pub fn new(row: usize, content: String) -> Self {
+    pub const fn new(row: usize, content: String) -> Self {
         Self { row, content }
     }
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/models.rs
@@ -22,19 +22,3 @@ pub enum Comment {
         below_line: Option<Line>,
     },
 }
-
-impl Comment {
-    pub const fn get_line(&self) -> &Line {
-        match self {
-            Self::Inline {
-                line,
-                original_content: _,
-            }
-            | Self::Block {
-                line,
-                above_line: _,
-                below_line: _,
-            } => line,
-        }
-    }
-}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -20,6 +20,27 @@ pub fn prettify_yaml(content: &str) -> Result<String, ReconcileError> {
     })
 }
 
+/// This is a best-effort comment reconciler, which uses a simple diff algorithm to try to locate
+/// comments in the new content.
+///
+/// The algorithm applies for the majority of the cases affecting the static analysis configuration files but has some limitations:
+///
+/// * Repeated elements may lead to false positives if there are lines added before or between the existing content.
+/// * If the original content uses a different syntax than the one emitted by the serializer, we may not be able to determine the location of those comments (e.g. dictionaries and list can be represented in an abbreviated form)
+///  
+///
+/// # Returns
+///
+/// If successful, it returns a `Result` containing a `String`. The `String` is the reconciled configuration
+/// file content.
+///
+/// # Errors
+///
+/// This function will return an error of type `ReconcileError` if:
+///
+/// * There's an issue getting the tree-sitter tree
+/// * There's an issue trying to apply the format to the reconciled yaml content
+///
 pub fn reconcile_comments(
     original_content: &str,
     new_content: &str,
@@ -332,6 +353,7 @@ rulesets:
         let modified = r#"
 schema-version: v1
 rulesets:
+  - java-0
   - java-security
   - java-1
   - java-2
@@ -348,6 +370,7 @@ rulesets:
         let expected = r#"
 schema-version: v1
 rulesets:
+  - java-0
   # this is a comment above java-security
   - java-security
   - java-1
@@ -395,6 +418,7 @@ rulesets:
         let modified = r#"
 schema-version: v1
 rulesets:
+  - java-0
   - java-security
   - java-1
   - java-2
@@ -411,6 +435,7 @@ rulesets:
         let expected = r#"
 schema-version: v1
 rulesets:
+  - java-0
   # this is a comment above java-security
   - java-security
   - java-1 # inline comment for java-1

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -25,7 +25,7 @@ pub fn prettify_yaml(content: &str) -> Result<String, ReconcileError> {
 ///
 /// The algorithm applies for the majority of the cases affecting the static analysis configuration files but has some limitations:
 ///
-/// * Repeated elements with `inline` comments may lead to false positives in some edge cases.
+/// * Repeated elements with `inline` comments may lead to false positives in some edge cases (see mode inline_limitations in tests for more info)
 /// * If the original content uses a different syntax than the one emitted by the serializer, we may not be able to determine the location of those comments (e.g. dictionaries and list can be represented in an abbreviated form)
 ///  
 ///
@@ -46,8 +46,9 @@ pub fn reconcile_comments(
     new_content: &str,
     prettify: bool,
 ) -> Result<String, ReconcileError> {
-    // parse the original content and look for comments
     let original_content = original_content.trim();
+    let new_content = new_content.trim();
+    // parse the original content and look for comments
     let tree = get_tree(original_content, &Language::Yaml).ok_or_else(|| {
         anyhow::anyhow!("Failed to parse the original content with the tree-sitter parser")
     })?;
@@ -175,6 +176,7 @@ fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &s
     // if the content of the line is different, we have to look for the original content in the document (as it may have been moved)
     // if we find it, we add the comment to the end of the line, if we don't find it, we ignore the comment.
     let current_content = &lines.get(line.row);
+
     if current_content
         .filter(|c| starts_with_and_no_comment(c, original_content))
         .is_some()
@@ -184,7 +186,6 @@ fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &s
         lines[line.row] = comment_added;
     } else {
         // content is different, try to find the original content in another line
-
         if let Some((row, found_line)) = lines
             .iter()
             .enumerate()
@@ -466,7 +467,8 @@ rulesets:
     }
 
     #[test]
-    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence() {
+    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence_case_1(
+    ) {
         let original_content = r#"
 schema-version: v1
 rulesets:
@@ -488,6 +490,39 @@ rulesets:
   - rule-1 # inline 1
   - rule-1 # inline 2
   - rule-2
+"#;
+
+        let result = reconcile_comments(original_content, modified, true).unwrap();
+        assert_eq!(result.trim(), expected.trim());
+    }
+
+    #[test]
+    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence_case_2(
+    ) {
+        let original_content = r#"
+schema-version: v1
+rulesets:
+  - java-1 # inline comment 1
+  - java-1
+  - java-1 # inline comment 2
+"#;
+
+        let modified = r#"
+schema-version: v1
+rulesets:
+  - java-1
+  - java-1
+  - java-1
+  - java-2
+"#;
+
+        let expected = r#"
+schema-version: v1
+rulesets:
+  - java-1 # inline comment 1
+  - java-1
+  - java-1 # inline comment 2
+  - java-2
 "#;
 
         let result = reconcile_comments(original_content, modified, true).unwrap();
@@ -522,5 +557,41 @@ rulesets:
 
         let result = reconcile_comments(original_content, modified, true).unwrap();
         assert_eq!(result.trim(), expected.trim());
+    }
+
+    mod inline_limitations {
+        use super::*;
+
+        #[test]
+        fn it_does_not_work_for_repeated_keys_with_inline_comments_case_1() {
+            let original_content = r#"
+schema-version: v1
+rulesets:
+  - java-1 # inline comment 1
+  - java-1
+  - java-1 # inline comment 2
+"#;
+
+            let modified = r#"
+schema-version: v1
+rulesets:
+  - java-0
+  - java-1
+  - java-1
+  - java-1
+"#;
+
+            let expected = r#"
+schema-version: v1
+rulesets:
+  - java-0
+  - java-1 # inline comment 1
+  - java-1
+  - java-1 # inline comment 2
+"#;
+
+            let result = reconcile_comments(original_content, modified, true).unwrap();
+            assert_ne!(result.trim(), expected.trim());
+        }
     }
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -1,0 +1,209 @@
+use super::models::{Comment, Line};
+use kernel::analysis::tree_sitter::get_tree;
+use kernel::model::common::Language;
+use thiserror::Error;
+use tree_sitter::Node;
+
+#[derive(Debug, Error)]
+#[error("Reconciler error")]
+pub struct ReconcileError {
+    #[from]
+    pub source: anyhow::Error,
+}
+
+pub fn reconcile_comments(
+    original_content: &str,
+    new_content: &str,
+) -> Result<String, ReconcileError> {
+    // parse the original content and look for comments
+    let tree = get_tree(original_content, &Language::Yaml).ok_or_else(|| {
+        anyhow::anyhow!("Failed to parse the original content with the tree-sitter parser")
+    })?;
+
+    let root_node = tree.root_node();
+
+    let mut comments = vec![];
+    extract_comments_from_node(root_node, original_content, &mut comments);
+
+    let reconciled_content = reconcile(new_content, &comments);
+
+    // make it pretty
+    let options = pretty_yaml::config::FormatOptions::default();
+    let formatted = pretty_yaml::format_text(&reconciled_content, &options)
+        .map_err(|e| anyhow::anyhow!("Failed to format the reconciled content: {}", e))?;
+
+    Ok(formatted)
+}
+
+fn extract_comments_from_node(node: Node<'_>, source: &str, comments: &mut Vec<Comment>) {
+    if node.kind() == "comment" {
+        let start_byte = node.start_byte();
+        let end_byte = node.end_byte();
+        let comment = &source[start_byte..end_byte];
+        let row = node.start_position().row;
+
+        let prev = node.prev_sibling();
+        let final_comment = prev
+            .and_then(|p| {
+                if p.start_position().row == row {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .map_or_else(
+                || Comment::Block {
+                    line: Line::new(row, comment.to_string()),
+                    above_line: prev.map(|prev| {
+                        let content = get_line_content(source, prev.end_byte());
+                        Line::new(row, content.to_string())
+                    }),
+                    below_line: node.next_sibling().map(|next| {
+                        let content = get_line_content(source, next.start_byte());
+                        Line::new(next.start_position().row, content.to_string())
+                    }),
+                },
+                |original| Comment::Inline {
+                    line: Line::new(row, comment.to_string()),
+                    original_content: source[original.start_byte()..start_byte - 1].to_string(),
+                },
+            );
+        comments.push(final_comment);
+    }
+
+    for child in node.children(&mut node.walk()) {
+        extract_comments_from_node(child, source, comments);
+    }
+}
+
+fn reconcile(modified: &str, comments: &[Comment]) -> String {
+    let mut lines: Vec<String> = modified.lines().map(ToString::to_string).collect();
+    let lines_len = lines.len();
+
+    for comment in comments {
+        let line = comment.get_line();
+        if line.row < lines_len {
+            match comment {
+                Comment::Inline {
+                    line,
+                    original_content,
+                } => {
+                    manage_inline_comment(&mut lines, line, original_content);
+                }
+                Comment::Block {
+                    line,
+                    above_line,
+                    below_line,
+                } => manage_block_comment(&mut lines, line, above_line, below_line),
+            }
+        }
+    }
+    // rejoin the lines again
+    lines.join("\n")
+}
+
+fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &str) {
+    // for comments added to a node line, we can detect the row and the original content, and then just go to that line,
+    // if the content of the line is the same as the original content, we can add the comment to the end of the line.
+    // if the content of the line is different, we have to look for the original content in the document, as it may have been moved
+    // if we find it, we add the comment to the end of the line, if we don't find it, we add the comment to the end of the line of the original content even if the content is different.
+    let current_content = &lines[line.row];
+    if current_content.starts_with(original_content) {
+        // line is ok, just add the comment
+        let comment_added = format!("{} {}", lines[line.row], line.content.clone());
+        lines[line.row] = comment_added;
+    } else {
+        // content is different, try to find the original content in another line
+        if let Some((row, found_line)) = lines
+            .iter()
+            .enumerate()
+            .find(|(_, l)| l.starts_with(original_content))
+        {
+            // we found it, add the comment
+            let comment_added = format!("{} {}", found_line, line.content.clone());
+            lines[row] = comment_added.to_string();
+        } else {
+            // ignore comment or add it to the original line?
+            // TODO: add option for the user to decide what to do?
+        }
+    }
+}
+
+fn manage_block_comment(
+    lines: &mut Vec<String>,
+    line: &Line,
+    above_line: &Option<Line>,
+    below_line: &Option<Line>,
+) {
+    // block comment
+    // we check the line in the original content, if the content is the same and the line above and below are the same, we add the comment.
+    match (above_line, below_line) {
+        (Some(above_line), Some(below_line)) => {
+            // iterate from the start and try to find a couple of lines
+            let (trimmed_above, trimmed_below) =
+                (above_line.content.trim(), below_line.content.trim());
+            let found = lines.iter().enumerate().find(|(i, l)| {
+                lines.get(i + 1).map_or(false, |next| {
+                    l.trim().starts_with(trimmed_above) && next.trim().starts_with(trimmed_below)
+                })
+            });
+            if let Some(found) = found {
+                // add the comment in the line below
+                lines.insert(found.0 + 1, line.content.clone());
+            } else {
+                // if not found, some lines may have been inserted in between.
+                // as most usually comments are placed above the line or in the line (not usually below)
+                // we will test for the the below line
+                search_and_insert_if_found(&below_line.content, lines, &line.content);
+            }
+        }
+        (Some(above_line), None) => {
+            // most probably was the last line
+            // start searching from the end
+            let trimmed = above_line.content.trim();
+            let found = lines
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, l)| l.trim().starts_with(trimmed));
+            if let Some(found) = found {
+                // add the comment in the line below
+                lines.insert(found.0 + 1, line.content.clone());
+            }
+        }
+        (None, Some(below_line)) => {
+            // most probably was the first line
+            // start searching from the beginning
+            search_and_insert_if_found(&below_line.content, lines, &line.content);
+        }
+        (None, None) => {
+            // we have a block comment with no context, just add it to the line
+            // NOTE: potentially do nothing, this case should not happen
+            lines.insert(line.row, line.content.clone());
+        }
+    }
+}
+
+fn search_and_insert_if_found(content: &str, lines: &mut Vec<String>, comment: &str) {
+    let trimmed = content.trim();
+    let found = lines
+        .iter()
+        .enumerate()
+        .find(|(_, l)| l.trim().starts_with(trimmed));
+
+    if let Some(found) = found {
+        // add the comment in the line
+        lines.insert(found.0, comment.to_owned());
+    }
+}
+
+fn get_line_content(source: &str, byte_offset: usize) -> &str {
+    let start = source[..byte_offset].rfind('\n').map_or(0, |pos| pos + 1);
+    let end = source[byte_offset..]
+        .find('\n')
+        .map_or(source.len(), |pos| byte_offset + pos);
+    let content = &source[start..end];
+    content
+        .find('#')
+        .map_or(content, |index| content[..index].trim_end())
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -63,9 +63,10 @@ fn extract_comments_from_node(node: Node<'_>, source: &str, comments: &mut Vec<C
                         Line::new(next.start_position().row, content.to_string())
                     }),
                 },
-                |original| Comment::Inline {
+                |previous_node| Comment::Inline {
                     line: Line::new(row, comment.to_string()),
-                    original_content: source[original.start_byte()..start_byte - 1].to_string(),
+                    original_content: source[previous_node.start_byte()..start_byte - 1]
+                        .to_string(),
                 },
             );
         comments.push(final_comment);

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -25,7 +25,7 @@ pub fn prettify_yaml(content: &str) -> Result<String, ReconcileError> {
 ///
 /// The algorithm applies for the majority of the cases affecting the static analysis configuration files but has some limitations:
 ///
-/// * Repeated elements may lead to false positives if there are lines added before or between the existing content.
+/// * Repeated elements with `inline` comments may lead to false positives if there are lines added before or between the existing content.
 /// * If the original content uses a different syntax than the one emitted by the serializer, we may not be able to determine the location of those comments (e.g. dictionaries and list can be represented in an abbreviated form)
 ///  
 ///
@@ -452,6 +452,32 @@ rulesets:
       rule3:
         ignore:
           - "**"
+"#;
+
+        let result = reconcile_comments(original_content, modified, true).unwrap();
+        assert_eq!(result.trim(), expected.trim());
+    }
+
+    #[test]
+    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence() {
+        let original_content = r#"
+schema-version: v1
+rulesets:
+  - java-1 # inline comment for java-1
+"#;
+
+        let modified = r#"
+schema-version: v1
+rulesets:
+  - java-1
+  - java-2
+"#;
+
+        let expected = r#"
+schema-version: v1
+rulesets:
+  - java-1 # inline comment for java-1
+  - java-2
 "#;
 
         let result = reconcile_comments(original_content, modified, true).unwrap();

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -25,7 +25,7 @@ pub fn prettify_yaml(content: &str) -> Result<String, ReconcileError> {
 ///
 /// The algorithm applies for the majority of the cases affecting the static analysis configuration files but has some limitations:
 ///
-/// * Repeated elements with `inline` comments may lead to false positives in some edge cases (see mode inline_limitations in tests for more info)
+/// * Repeated elements with `inline` comments may lead to false positives in some edge cases (see mode `inline_limitations` in tests for more info)
 /// * If the original content uses a different syntax than the one emitted by the serializer, we may not be able to determine the location of those comments (e.g. dictionaries and list can be represented in an abbreviated form)
 ///  
 ///
@@ -75,19 +75,17 @@ fn get_related_comments<'a>(
     visited: &mut HashSet<Node<'a>>,
     comment: &mut String,
 ) -> Option<Node<'a>> {
-    if let Some(next) = next {
+    next.and_then(|next| {
         if next.kind() == "comment" {
             // get the comment
             let content = &source[next.start_byte()..next.end_byte()];
-            *comment = format!("{}\n{}", comment, content);
+            *comment = format!("{comment}\n{content}");
             visited.insert(next);
             get_related_comments(next.next_sibling(), source, visited, comment)
         } else {
             Some(next)
         }
-    } else {
-        None
-    }
+    })
 }
 
 fn extract_comments_from_node<'a>(
@@ -193,7 +191,7 @@ fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &s
         {
             // we found it, add the comment
             let comment_added = format!("{} {}", found_line, line.content.clone());
-            lines[row] = comment_added.to_string();
+            lines[row] = comment_added;
         } else {
             // ignore comment (or add it to the original line?)
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -95,10 +95,9 @@ fn extract_comments_from_node<'a>(
     visited: &mut HashSet<Node<'a>>,
 ) {
     if node.kind() == "comment" {
-        if visited.contains(&node) {
+        if !visited.insert(node) {
             return;
         }
-        visited.insert(node);
 
         let start_byte = node.start_byte();
         let end_byte = node.end_byte();

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -459,8 +459,7 @@ rulesets:
     }
 
     #[test]
-    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence2()
-    {
+    fn it_works_for_repeated_keys_with_inline_comments_if_no_additions_before_comment_occurrence() {
         let original_content = r#"
 schema-version: v1
 rulesets:

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -167,7 +167,7 @@ fn reconcile(modified: &str, comments: &[Comment]) -> String {
 
 fn starts_with_and_no_comment(text: &str, pat: &str) -> bool {
     let trimmed = text.trim();
-    trimmed.starts_with(pat) && !trimmed.contains('#')
+    trimmed.starts_with(pat) && !trimmed.contains(" #")
 }
 
 fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &str) {
@@ -275,7 +275,7 @@ fn get_line_content(source: &str, byte_offset: usize) -> &str {
         .map_or(source.len(), |pos| byte_offset + pos);
     let content = &source[start..end];
     content
-        .find('#')
+        .find(" #")
         .map_or(content, |index| content[..index].trim_end())
 }
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/comment_preserver/reconciler.rs
@@ -122,20 +122,17 @@ fn reconcile(modified: &str, comments: &[Comment]) -> String {
     let mut lines: Vec<String> = modified.lines().map(ToString::to_string).collect();
 
     for comment in comments {
-        let line = comment.get_line();
-        if line.row < lines.len() {
-            match comment {
-                Comment::Inline {
-                    line,
-                    original_content,
-                } => manage_inline_comment(&mut lines, line, original_content),
+        match comment {
+            Comment::Inline {
+                line,
+                original_content,
+            } => manage_inline_comment(&mut lines, line, original_content),
 
-                Comment::Block {
-                    line,
-                    above_line,
-                    below_line,
-                } => manage_block_comment(&mut lines, line, above_line, below_line),
-            }
+            Comment::Block {
+                line,
+                above_line,
+                below_line,
+            } => manage_block_comment(&mut lines, line, above_line, below_line),
         }
     }
     // rejoin the lines again
@@ -147,8 +144,11 @@ fn manage_inline_comment(lines: &mut [String], line: &Line, original_content: &s
     // if the content of the line is the same as the original content, we can add the comment to the end of the line.
     // if the content of the line is different, we have to look for the original content in the document, as it may have been moved
     // if we find it, we add the comment to the end of the line, if we don't find it, we add the comment to the end of the line of the original content even if the content is different.
-    let current_content = &lines[line.row];
-    if current_content.starts_with(original_content) {
+    let current_content = &lines.get(line.row);
+    if current_content
+        .filter(|c| c.starts_with(original_content))
+        .is_some()
+    {
         // line is ok, just add the comment
         let comment_added = format!("{} {}", lines[line.row], line.content.clone());
         lines[line.row] = comment_added;

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
@@ -40,7 +40,7 @@ impl<'r> Responder<'r, 'static> for ConfigFileError {
 }
 
 impl ConfigFileError {
-    pub fn code(&self) -> u16 {
+    pub const fn code(&self) -> u16 {
         match self {
             Self::Parser { .. } => 1,
             Self::Decoder { .. } => 2,

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
@@ -1,3 +1,4 @@
+use super::comment_preserver::ReconcileError;
 use rocket::{http::ContentType, response::Responder, Response};
 use serde_json::json;
 use thiserror::Error;
@@ -12,6 +13,12 @@ pub enum ConfigFileError {
     },
     #[error("Error decoding base64 string")]
     Decoder { source: anyhow::Error },
+
+    #[error("Error reconciling comments")]
+    CommentReconciler {
+        #[from]
+        source: ReconcileError,
+    },
 }
 
 impl From<anyhow::Error> for ConfigFileError {
@@ -37,6 +44,7 @@ impl ConfigFileError {
         match self {
             Self::Parser { .. } => 1,
             Self::Decoder { .. } => 2,
+            Self::CommentReconciler { .. } => 3,
         }
     }
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/mod.rs
@@ -1,3 +1,4 @@
+mod comment_preserver;
 pub mod endpoints;
 mod error;
 mod models;

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -398,11 +398,11 @@ rulesets:
             let expected = r"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1
-- ruleset2
-- a-ruleset3
+  - java-security
+  - java-1
+  - ruleset1
+  - ruleset2
+  - a-ruleset3
 ";
 
             assert_eq!(config.trim(), expected.trim());
@@ -587,21 +587,21 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-1
-- java-security
-- ruleset1:
-  rules:
-    rule2:
-      only:
-      - foo/bar
-    rule1:
-      ignore:
-      - '**'
-";
-            assert!(config.trim() == expected.trim());
+  - java-1
+  - java-security
+  - ruleset1:
+    rules:
+      rule2:
+        only:
+          - foo/bar
+      rule1:
+        ignore:
+          - "**"
+"#;
+            assert_eq!(config.trim(), expected.trim());
         }
 
         #[test]
@@ -639,19 +639,19 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1:
-  rules:
-    rule2:
-      severity: ERROR
-    rule1:
-      ignore:
-      - '**'
-";
+  - java-security
+  - java-1
+  - ruleset1:
+    rules:
+      rule2:
+        severity: ERROR
+      rule1:
+        ignore:
+          - "**"
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -287,20 +287,20 @@ rulesets:
         #[test]
         fn it_works_complex() {
             let content = to_encoded_content(
-                r"
+                r#"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1:
-  rules:
-    rule2:
+  - java-security
+  - java-1
+  - ruleset1:
+    rules:
+      rule2:
         only:
-        - foo/bar
-    rule1:
+          - foo/bar
+      rule1:
         ignore:
-        - '**'
-",
+          - "**"
+"#,
             );
             let rulesets = StaticAnalysisConfigFile::to_rulesets(content);
             assert_eq!(rulesets, vec!["java-security", "java-1", "ruleset1"]);
@@ -411,20 +411,20 @@ rulesets:
         #[test]
         fn it_works_complex() {
             let content = to_encoded_content(
-                r"
+                r#"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1:
-  rules:
-    rule2:
-      only:
-      - foo/bar
-    rule1:
-      ignore:
-      - '**'
-",
+  - java-security
+  - java-1
+  - ruleset1:
+    rules:
+      rule2:
+        only:
+          - foo/bar
+      rule1:
+        ignore:
+          - "**"
+"#,
             );
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1", "ruleset2", "a-ruleset3"],
@@ -432,22 +432,22 @@ rulesets:
             )
             .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1:
-  rules:
-    rule2:
-      only:
-      - foo/bar
-    rule1:
-      ignore:
-      - '**'
-- ruleset2
-- a-ruleset3
-";
+  - java-security
+  - java-1
+  - ruleset1:
+    rules:
+      rule2:
+        only:
+          - foo/bar
+      rule1:
+        ignore:
+          - "**"
+  - ruleset2
+  - a-ruleset3
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }
@@ -490,17 +490,17 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-1
-- java-security
-- ruleset1:
-  rules:
-    rule1:
-      ignore:
-      - '**'
-";
+  - java-1
+  - java-security
+  - ruleset1:
+    rules:
+      rule1:
+        ignore:
+          - "**"
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }
@@ -519,16 +519,17 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-1
-- java-security
-- ruleset1:
-  rules:
-    rule1:
-      ignore:
-      - '**'";
+  - java-1
+  - java-security
+  - ruleset1:
+    rules:
+      rule1:
+        ignore:
+          - "**"
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }
@@ -552,18 +553,19 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-1
-- java-security
-- ruleset1:
-  rules:
-    rule1:
-      only:
-      - foo/bar
-      ignore:
-      - '**'";
+  - java-1
+  - java-security
+  - ruleset1:
+    rules:
+      rule1:
+        only:
+          - foo/bar
+        ignore:
+          - "**"
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }
@@ -675,18 +677,18 @@ rulesets:
                 StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule2".into(), content)
                     .unwrap();
 
-            let expected = r"
+            let expected = r#"
 schema-version: v1
 rulesets:
-- java-security
-- java-1
-- ruleset1:
-  rules:
-    rule2:
-      ignore:
-      - '**'
-      severity: ERROR
-";
+  - java-security
+  - java-1
+  - ruleset1:
+    rules:
+      rule2:
+        ignore:
+          - "**"
+        severity: ERROR
+"#;
 
             assert_eq!(config.trim(), expected.trim());
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -269,7 +269,7 @@ impl StaticAnalysisConfigFile {
                 |original_content| reconcile_comments(original_content, &fixed, true),
             )
             .or_else(|e| {
-                tracing::debug!(error = ?e, "Reconciliation error: {}", e.to_string());
+                tracing::debug!(error = ?e, "Reconciliation or formatting error: {}", e.to_string());
                 Ok::<String, ConfigFileError>(fixed)
             })
     }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -179,10 +179,7 @@ impl StaticAnalysisConfigFile {
         rulesets: &[impl AsRef<str> + Debug],
         config_content_base64: Option<String>,
     ) -> Result<String, ConfigFileError> {
-        let mut original_content: Option<String> = None;
-
         let mut config = config_content_base64.map_or(Ok(Self::default()), |content| {
-            original_content = Some(content.clone());
             Self::try_from(content).map_err(|e| {
                 tracing::error!(error =?e, "Error trying to parse config file");
                 e

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -1,4 +1,4 @@
-use super::comment_preserver::reconcile_comments;
+use super::comment_preserver::{prettify_yaml, reconcile_comments};
 use super::error::ConfigFileError;
 use indexmap::IndexMap;
 use kernel::config_file::config_file_to_yaml;
@@ -250,9 +250,10 @@ impl StaticAnalysisConfigFile {
         let fixed = str.replace(": null", ":");
         // preserve the comments if the original content is provided
         if let Some(original_content) = &self.original_content {
-            reconcile_comments(original_content, &fixed).map_err(Into::into)
+            reconcile_comments(original_content, &fixed, true).map_err(Into::into)
         } else {
-            Ok(fixed)
+            // prettify the content
+            prettify_yaml(&fixed).map_err(Into::into)
         }
     }
 }
@@ -357,9 +358,9 @@ rulesets:
             let expected = r"
 schema-version: v1
 rulesets:
-- ruleset1
-- ruleset2
-- a-ruleset3
+  - ruleset1
+  - ruleset2
+  - a-ruleset3
 ";
             assert_eq!(config.trim(), expected.trim());
         }
@@ -374,7 +375,7 @@ rulesets:
             let expected = r"
 schema-version: v1
 rulesets:
-- ruleset1
+  - ruleset1
 ";
             assert_eq!(config.trim(), expected.trim());
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_name_repetitions)]
+
 mod configuration_file;
 use rocket::Route;
 

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -287,7 +287,8 @@ pub fn get_all_default_rulesets(use_staging: bool, debug: bool) -> Result<Vec<Ru
 /// we need to ensure that
 ///   1. We are scanning a Git Repository
 ///   2. We have API Keys for the user
-/// When we issue the request, we pass
+///
+///   When we issue the request, we pass
 ///   - repository url
 ///   - current sha
 ///   - current branch

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -266,6 +266,7 @@ pub fn filter_files_by_size(files: &[PathBuf], configuration: &CliConfiguration)
 ///  - directory_path is the path of the directory
 ///  - diff_aware_info is the information we got from our API about the scan to do with the list of files
 ///    and base sha
+///
 /// We return the list of files from the first arguments filtered with the list of files we should effectively
 /// scan. The returned list length must always less or equal than the initial list (first argument).
 pub fn filter_files_by_diff_aware_info(

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -14,6 +14,7 @@ derive_builder = { workspace = true }
 serde-sarif = { workspace = true }
 sha2 = { workspace = true }
 indexmap = { workspace = true }
+tree-sitter = { workspace = true }
 
 # other
 deno_core = "0.196.0"
@@ -21,7 +22,6 @@ globset = "0.4.14"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 thiserror = "1.0.59"
-tree-sitter = "0.22.6"
 
 [build-dependencies]
 cc = "1.0.97"

--- a/crates/static-analysis-kernel/src/model/analysis.rs
+++ b/crates/static-analysis-kernel/src/model/analysis.rs
@@ -26,7 +26,7 @@ impl LinesToIgnore {
     /// return if a specific rule should be ignored
     ///  - rule_name is the full rule name like rule1/rule2
     ///  - line is the line of the violation
-    /// returns true if the rule should be ignored
+    ///    returns true if the rule should be ignored
     pub fn should_filter_rule(&self, rule_name: &str, line: u32) -> bool {
         match &self.ignore_file {
             AllRules => {


### PR DESCRIPTION
## What problem are you trying to solve?

The main problem is that the comments of the configuration file are removed after modification due to the deserialization and serialization process. Some users have complained about it.

## What is your solution?

Added support for comment preservation and pretty formatting.

## Alternatives considered

## What the reviewer should know

The last commit fixes some `clippy` warnings that  were triggering when committing or pushing (via cargo-husky). I had to touch some files outside the `ide` folder. For some reason, we're using `-D warnings` locally but not in the CI. I didn't want to modify any of this but I guess it would be nice to reconcile this difference at some point.

https://github.com/user-attachments/assets/1e42b2ee-5b10-4435-a0ea-1c73580178bc

IDE-2599
