### PR TITLE
chore(github): updated the team owning ide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 **/*                                                              @DataDog/static-analysis-core
-/crates/bins/src/bin/datadog_static_analyzer_server/ide/**/*      @DataDog/ide-integration
+/crates/bins/src/bin/datadog_static_analyzer_server/ide/**/*      @DataDog/ide-integration-static-analysis-server


### PR DESCRIPTION
## What problem are you trying to solve?

Before the whole IDE integrations team was a code owner of the IDE folder. As we wanted to enable the auto assignation of reviewers for this repo, we had to enable it for the IDE integrations team. This was causing a problem for the Jetbrains sub-team which uses the IDE Integrations team for their repo. Members of the VS and VS Code team were assigned to their PRs as reviewers.

## What is your solution?

As they don't want to create a sub team for their repo and they don't want to use the reviewer auto assignation feature, the solution was to create a new subteam specific for this repo.

## Alternatives considered

## What the reviewer should know
