### PR TITLE
Add git-hook and server into GHCR release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
 COPY . /app
 WORKDIR /app
 RUN cargo build --release --bin datadog-static-analyzer
+RUN cargo build --release --bin datadog-static-analyzer-git-hook
+RUN cargo build --release --bin datadog-static-analyzer-server
 
 FROM base
 
 COPY --from=build /app/target/release/datadog-static-analyzer /usr/bin/datadog-static-analyzer
+COPY --from=build /app/target/release/datadog-static-analyzer-server /usr/bin/datadog-static-analyzer-server
+COPY --from=build /app/target/release/datadog-static-analyzer-git-hook /usr/bin/datadog-static-analyzer-git-hook
 COPY --from=build /app/misc/github-action.sh /usr/bin/github-action.sh
 
 RUN apt update && apt install -y curl git \


### PR DESCRIPTION
## What problem are you trying to solve?

We want to release more tools (git hook and server) into our GHCR image.

## What is your solution?

Build and add them to the image