### PR TITLE
[STAL-2617] Add Windows Support

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,6 +13,7 @@ num_cpus,https://github.com/seanmonstar/num_cpus,MIT, Copyright (c) 2015 Sean Mc
 percent-encoding,https://github.com/servo/rust-url/,MIT, Copyright (c) 2013-2022 The rust-url developers
 prettytable-rs,https://github.com/phsym/prettytable-rs/,BSD-3-Clause,Copyright (c) 2022 Pierre-Henri Symoneaux
 rayon,https://crates.io/crates/rayon,MIT,Copyright (c) 2010 The Rust Project Developers
+path_slash,https://github.com/rhysd/path-slash,MIT,Copyright (c) 2018 rhysd
 pretty_yaml,https://github.com/g-plane/pretty_yaml,MIT,Copyright (c) 2024-present Pig Fang
 rocket,https://github.com/SergioBenitez/Rocket,Apache-2.0,Copyright 2016 Sergio Benitez
 tree-sitter,https://github.com/tree-sitter/tree-sitter,MIT,2014 Max Brunsfeld

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { workspace = true }
 uuid = { workspace = true }
 # other
 csv = "1.3.0"
-
+path-slash = "0.2.1"
 percent-encoding = "2.3.1"
 prettytable-rs = "0.10.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }


### PR DESCRIPTION
## What problem are you trying to solve?

We want to make sure that when running on Windows, the SARIF files are correctly created and validated. Today, the path are using `\` which breaks the file validation.

Example of file

<img width="1262" alt="Screenshot 2024-08-03 at 11 27 27 AM" src="https://github.com/user-attachments/assets/4ecfad59-516f-4e8b-bf69-5fad385b7b16">

Running `datadog-ci` against this file.

<img width="752" alt="Screenshot 2024-08-03 at 11 37 17 AM" src="https://github.com/user-attachments/assets/5e11969e-98c8-4741-95cc-823c86cfb61e">


## What is your solution?

In `sarif_utils.rs`, ensure that we convert the filenames to using slash. We are using the [path_slash](https://docs.rs/path-slash/latest/path_slash/) rust module for this.

Closes #476 

## Tested

Tested on a Windows machine.

Example of file after modifications

<img width="1265" alt="Screenshot 2024-08-03 at 11 27 35 AM" src="https://github.com/user-attachments/assets/6424de05-147b-4ff9-bdc6-56d5ec3ade0e">


Running `datadog-ci` against this file.

<img width="726" alt="Screenshot 2024-08-03 at 11 37 27 AM" src="https://github.com/user-attachments/assets/e8da0757-fc6b-4b8f-a252-41a6d0cc5e34">

