### PR TITLE
[STAL-2635] Add JavaScript `Digraph`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,6 +6,7 @@ csv,https://github.com/BurntSushi/rust-csv,MIT,Copyright (c) 2015 Andrew Gallant
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 globset,https://crates.io/crates/globset,MIT,Copyright (c) 2015 Andrew Gallant
+graphviz-rust,https://github.com/besok/graphviz-rust,MIT,Copyright (c) 2013 Boris Zhguchev
 indexmap,https://github.com/indexmap-rs/indexmap,MIT and Apache-2.0,Copyright (c) 2016-2017 bluss
 indicatif,https://crates.io/crates/indicatif,MIT,Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
 itertools,https://github.com/rust-itertools/itertools,MIT,Copyright 2015 itertools Developers

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -19,6 +19,7 @@ tree-sitter = { workspace = true }
 # other
 deno_core = "0.196.0"
 globset = "0.4.14"
+graphviz-rust = "0.9.0"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 thiserror = "1.0.59"

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/extension.rs
@@ -28,6 +28,7 @@ deno_core::extension!(
         ("ext:ddsa_lib/ddsa", "ddsa.js"),
         ("ext:ddsa_lib/edit", "edit.js"),
         ("ext:ddsa_lib/fix", "fix.js"),
+        ("ext:ddsa_lib/flow/graph", "flow/graph.js"),
         ("ext:ddsa_lib/query_match", "query_match.js"),
         ("ext:ddsa_lib/query_match_compat", "query_match_compat.js"),
         ("ext:ddsa_lib/stella_compat", "stella_compat.js"),

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js.rs
@@ -26,6 +26,7 @@ mod edit;
 pub(crate) use edit::*;
 mod fix;
 pub(crate) use fix::*;
+pub(crate) mod flow;
 mod query_match;
 pub(crate) use query_match::*;
 mod query_match_compat;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/__bootstrap.js
@@ -6,6 +6,7 @@
 
 import {DDSA} from "ext:ddsa_lib/ddsa";
 import {DDSA_Console} from "ext:ddsa_lib/utility";
+import {Digraph} from "ext:ddsa_lib/flow/graph";
 import {FileContext} from "ext:ddsa_lib/context_file";
 import {FileContextGo} from "ext:ddsa_lib/context_file_go";
 import {FileContextTerraform, TerraformResource} from "ext:ddsa_lib/context_file_tf";
@@ -20,6 +21,7 @@ import {TsLanguageContext} from "ext:ddsa_lib/context_ts_lang";
 //           these should be hidden inside another object, not `globalThis`.
 globalThis.DDSA_Console = DDSA_Console;
 globalThis.DDSA = DDSA;
+globalThis.Digraph = Digraph;
 globalThis.FileContext = FileContext;
 globalThis.FileContextGo = FileContextGo;
 globalThis.FileContextJavaScript = FileContextJavaScript;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow.rs
@@ -1,0 +1,5 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+pub(crate) mod graph;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/graph.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/graph.js
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+/**
+ * A directed graph.
+ */
+export class Digraph {
+    constructor() {
+        /**
+         * The adjacency list representation of this digraph.
+         * @type {AdjacencyList}
+         */
+        this.adjacencyList = new Map();
+    }
+
+    /**
+     * Adds a typed, directed edge from a source {@link VertexId} to a target `VertexId`.
+     * @param {VertexId} from
+     * @param {VertexId} to
+     * @param {EdgeKind} kind
+     */
+    addTypedEdge(from, to, kind) {
+        _addTypedEdge(this.adjacencyList, from, to, kind);
+    }
+}
+
+/**
+ * @typedef {number & { _brand: "Edge" }} Edge
+ * A typed edge in a {@link Digraph} storing a target {@link VertexId} and an {@link EdgeKind}.
+ *
+ * Internally, this is a bit-packed integer:
+ * ```text
+ *            49 bits           4 bits
+ * |---------------------------|----|
+ *         targetVertexId       kind
+ * ```
+ *
+ * This serialization format stores the same information as an object with the shape:
+ * ```js
+ * const edge = {
+ *     targetVertexId: targetVertexId,
+ *     kind: kind,
+ * };
+ * ```
+ */
+
+/**
+ * @typedef {Map<VertexId, Array<Edge>>} AdjacencyList
+ * An adjacency list represented as a Map.
+ */
+
+/**
+ * @typedef {TreeSitterNode} Vertex
+ * A vertex in a {@link Digraph}.
+ */
+
+/**
+ * @typedef {number & { _brand: "VertexId" }} VertexId
+ * An id of {@link Vertex}.
+ */
+
+/**
+ * Adds a typed, directed edge from a source {@link VertexId} to a target `VertexId`.
+ * @param {AdjacencyList} adjacencyList
+ * @param {VertexId} from
+ * @param {VertexId} to
+ * @param {EdgeKind} kind
+ */
+function _addTypedEdge(adjacencyList, from, to, kind) {
+    if (from === to) {
+        return;
+    }
+    let existingEdges = adjacencyList.get(from);
+    if (existingEdges === undefined) {
+        const sources = [];
+        adjacencyList.set(from, sources);
+        existingEdges = sources;
+    }
+    const edge = makeEdge(to, kind);
+    existingEdges.push(edge);
+}
+
+
+/**
+ * @typedef {0 | 1 | 2} EdgeKind
+ * A typed edge in a {@link Digraph}, represented as a 4-bit integer. Possible values:
+ * * {@link EDGE_UNTYPED}
+ * * {@link EDGE_ASSIGNMENT}
+ * * {@link EDGE_DEPENDENCE}
+ */
+
+/** @type {0} */
+export const EDGE_UNTYPED = 0;
+/** @type {1} */
+export const EDGE_ASSIGNMENT = 1;
+/** @type {2} */
+export const EDGE_DEPENDENCE = 2;
+
+/**
+ * @constant
+ * @type {number}
+ * The number of bits used to represent an {@link EdgeKind} integer.
+ */
+const EDGE_KIND_BITS = 4;
+
+/**
+ * @constant
+ * @type {number}
+ * A bitmask to retrieve the {@link EdgeKind} of a {@link Edge}.
+ */
+const EDGE_KIND_MASK = (1 << EDGE_KIND_BITS) - 1;
+
+/**
+ * Creates a typed `Edge`.
+ * @param {VertexId} target
+ * @param {EdgeKind} kind
+ * @returns Edge
+ */
+export function makeEdge(target, kind) {
+    // (See `Edge` for documentation about this serialization).
+    return /** @type {Edge} */ ((target << EDGE_KIND_BITS) | kind);
+}
+
+/**
+ * Returns the `VertexId` of the edge's target.
+ * @param {Edge} edge
+ * @returns {VertexId}
+ */
+export function getEdgeTarget(edge) {
+    // (See `Edge` for documentation about this deserialization).
+    return /** @type {VertexId} */ (edge >> EDGE_KIND_BITS);
+}
+
+/**
+ * Returns the type of the provided `Edge`.
+ * @param {Edge} edge
+ * @returns {EdgeKind}
+ */
+export function getEdgeKind(edge) {
+    // (See `Edge` for documentation about this deserialization).
+    return /** @type {EdgeKind} */ (edge & EDGE_KIND_MASK);
+}

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/graph.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/graph.rs
@@ -1,0 +1,602 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use deno_core::v8;
+use graphviz_rust::dot_structures;
+use std::borrow::{Borrow, Cow};
+use std::collections::{HashMap, HashSet};
+
+/// A wrapper around a [`graphviz_rust::Graph::DiGraph`]. This is only used in unit tests to specify
+/// and assert on the structure of a graph.
+#[derive(Debug, Clone)]
+pub struct Digraph(dot_structures::Graph);
+
+impl Digraph {
+    /// Constructs a [`Self`] from the provided `input`.
+    /// # Panics
+    /// * Panics if `input` is not a strict digraph.
+    /// * Panics if any [`dot_structures::Stmt`] in `input` isn't a node or an edge.
+    pub fn new(input: dot_structures::Graph) -> Self {
+        use dot_structures::*;
+        let Graph::DiGraph { strict, stmts, .. } = &input else {
+            panic!("graph should be a digraph");
+        };
+        assert!(strict, "should be \"strict\"");
+        let all_valid_stmts = stmts
+            .iter()
+            .all(|stmt| matches!(stmt, Stmt::Node(..) | Stmt::Edge(..)));
+        assert!(all_valid_stmts, "should only contain `node`s and `edge`s");
+        Self(input)
+    }
+
+    /// Returns `true` if this graph is a subgraph of the provided `other`. A graph is considered
+    /// a subgraph if the `other` has identical nodes and edges as this graph.
+    pub fn is_subgraph_of(&self, other: impl Borrow<Self>) -> bool {
+        self.difference(other).is_empty()
+    }
+
+    /// Returns the nodes and edges that are in `self`, but not in `other`.
+    pub fn difference(&self, other: impl Borrow<Self>) -> Vec<dot_structures::Stmt> {
+        use dot_structures::*;
+
+        /// Returns a hash map of nodes and edges, using an arbitrary (but stable) key.
+        fn normalize_stmts(graph: &Graph) -> HashMap<String, &Stmt> {
+            fn attr_string(attributes: &[Attribute]) -> String {
+                let mut attrs = attributes
+                    .iter()
+                    .map(|attr| format!("{}={}", attr.0, attr.1))
+                    .collect::<Vec<_>>();
+                attrs.sort();
+                format!("[{}]", attrs.join(","))
+            }
+
+            digraph_stmts(graph)
+                .iter()
+                .map(|stmt| match stmt {
+                    Stmt::Node(node) => (
+                        format!("{}{}", node.id.0, attr_string(&node.attributes)),
+                        stmt,
+                    ),
+                    Stmt::Edge(edge) => {
+                        let EdgeTy::Pair(Vertex::N(src), Vertex::N(target)) = &edge.ty else {
+                            unreachable!()
+                        };
+                        let (src, target, attrs) =
+                            (&src.0, &target.0, attr_string(&edge.attributes));
+                        (format!("{src}->{target}{attrs}"), stmt)
+                    }
+                    _ => unreachable!(),
+                })
+                .collect::<HashMap<_, _>>()
+        }
+
+        let self_stmts = normalize_stmts(&self.0);
+        let other_stmts = normalize_stmts(&other.borrow().0);
+
+        let mut diff = Vec::<Stmt>::new();
+        for (key, &value) in &self_stmts {
+            if !other_stmts.contains_key(key) {
+                diff.push(value.clone());
+            }
+        }
+        diff
+    }
+
+    /// Returns this graph in DOT form. Note that the nodes and edges are displayed in construction-order,
+    /// which does not hold semantic meaning. Two [`Digraph`] can have a different `to_dot` output
+    /// but represent the same graph.
+    pub fn to_dot(&self) -> String {
+        use graphviz_rust::printer::DotPrinter;
+        self.0.print(&mut Default::default())
+    }
+}
+
+impl PartialEq for Digraph {
+    fn eq(&self, other: &Self) -> bool {
+        self.difference(other).is_empty() && other.difference(self).is_empty()
+    }
+}
+
+/// Returns the [`Stmt`](dot_structures::Stmt)s in a [`dot_structures::Graph::DiGraph`].
+fn digraph_stmts(graph: &dot_structures::Graph) -> &[dot_structures::Stmt] {
+    let dot_structures::Graph::DiGraph { stmts, .. } = graph else {
+        panic!("graph should be a digraph");
+    };
+    stmts
+}
+
+// DOT attribute keys
+const KIND: &str = "kind";
+
+/// A graph edge storing a target [`VertexId`] and an [`EdgeKind`].
+///
+/// Internally, this is a bit-packed integer [`v8::Number`]:
+/// ```text
+///            49 bits           4 bits
+/// |---------------------------|----|
+///         targetVertexId       kind
+/// ```
+struct Edge(u32);
+
+impl Edge {
+    /// The number of bits used to represent the uint form of this enum.
+    const KIND_BITS: u32 = 4;
+    /// A bitmask to extract an `EdgeKind` from the bit-packed edge.
+    const KIND_BIT_MASK: u32 = (1 << Self::KIND_BITS) - 1;
+
+    /// Returns the target of this edge.
+    pub fn target(&self) -> VertexId {
+        VertexId(self.0 >> Self::KIND_BITS)
+    }
+
+    /// The type of edge this is.
+    pub fn kind(&self) -> EdgeKind {
+        EdgeKind::try_from_id((self.0 & Self::KIND_BIT_MASK) as usize)
+            .expect("js should serialize PackedEdge correctly")
+    }
+}
+
+/// The type of edge between two nodes in the [`Digraph`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum EdgeKind {
+    Untyped = 0,
+    Assignment,
+    Dependence,
+}
+
+impl std::fmt::Display for EdgeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EdgeKind::Untyped => write!(f, "untyped"),
+            EdgeKind::Assignment => write!(f, "assignment"),
+            EdgeKind::Dependence => write!(f, "dependence"),
+        }
+    }
+}
+
+impl TryFrom<&str> for EdgeKind {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "untyped" => Ok(Self::Untyped),
+            "assignment" => Ok(Self::Assignment),
+            "dependence" => Ok(Self::Dependence),
+            _ => Err(format!("invalid edge type `{value}`")),
+        }
+    }
+}
+
+impl EdgeKind {
+    /// Creates a new `EdgeKind` if the provided `id` is valid.
+    pub(crate) fn try_from_id(id: usize) -> Result<Self, String> {
+        match id {
+            i if i == EdgeKind::Untyped as usize => Ok(EdgeKind::Untyped),
+            i if i == EdgeKind::Assignment as usize => Ok(EdgeKind::Assignment),
+            i if i == EdgeKind::Dependence as usize => Ok(EdgeKind::Dependence),
+            _ => Err(format!("invalid id {id}")),
+        }
+    }
+}
+
+/// A [`v8::Number`] used to store an id of a vertex in a [`Digraph`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+struct VertexId(u32);
+
+impl std::fmt::Display for VertexId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+/// Returns the string form of a `dot_structures::Id`.
+fn id_str(id: &dot_structures::Id) -> Cow<str> {
+    use dot_structures::Id;
+    match id {
+        Id::Html(s) | Id::Plain(s) | Id::Anonymous(s) => Cow::Borrowed(s),
+        Id::Escaped(s) => {
+            let sans_quotes = &s[1..s.len() - 1];
+            let mut chars = sans_quotes.chars();
+            let mut unescaped = String::new();
+
+            while let Some(ch) = chars.next() {
+                unescaped.push(match ch {
+                    '\\' => chars.next().expect("string should never end on `\\`"),
+                    _ => ch,
+                });
+            }
+            Cow::Owned(unescaped)
+        }
+    }
+}
+
+/// A [`dot_structures::Graph`] directly deserialized from v8, containing only the vertex and
+/// edge information present in the v8 representation.
+pub(crate) struct V8DotGraph {
+    vertices: Vec<dot_structures::Node>,
+    edges: Vec<dot_structures::Edge>,
+}
+
+impl V8DotGraph {
+    /// Creates a new `V8DotGraph` from the provided `v8::Map`.
+    /// # Panics
+    /// Panics if deserialization is unsuccessful.
+    pub fn new(scope: &mut v8::HandleScope, map: v8::Local<v8::Map>) -> Self {
+        use dot_structures::*;
+        use graphviz_rust::dot_generator::*;
+
+        let mut vertices: Vec<Node> = vec![];
+        let mut edges: Vec<Edge> = vec![];
+
+        // VertexIds we discovered as the source of an edge.
+        let mut known_sources = HashSet::<VertexId>::new();
+        // VertexIds we discovered as the target of an edge.
+        let mut known_targets = HashSet::<VertexId>::new();
+
+        let map_arr = map.as_array(scope);
+        let len = map_arr.length();
+        for i in (0..len).step_by(2) {
+            let key_idx = i;
+            let val_idx = key_idx + 1;
+            let source_vid = map_arr.get_index(scope, key_idx).unwrap();
+            assert!(source_vid.is_number());
+            let source_vid = source_vid.uint32_value(scope).unwrap();
+            known_sources.insert(VertexId(source_vid));
+            let adj_list =
+                v8::Local::<v8::Array>::try_from(map_arr.get_index(scope, val_idx).unwrap())
+                    .unwrap();
+            vertices.push(node!(source_vid));
+
+            let adj_len = adj_list.length();
+            for j in 0..adj_len {
+                let v8_packed_edge = adj_list.get_index(scope, j).unwrap();
+                assert!(v8_packed_edge.is_number());
+                let v8_packed_edge = v8_packed_edge.uint32_value(scope).unwrap();
+                let packed_edge = Edge(v8_packed_edge);
+                let target_vid = packed_edge.target();
+                known_targets.insert(target_vid);
+
+                let edge = edge!(node_id!(source_vid) => node_id!(target_vid), vec![attr![KIND, packed_edge.kind()]]);
+                edges.push(edge);
+            }
+        }
+
+        // Targets with no outgoing edges are sinks (and will not have been inserted as nodes yet).
+        for &sink_vid in known_targets.difference(&known_sources) {
+            vertices.push(node!(sink_vid));
+        }
+
+        Self { vertices, edges }
+    }
+
+    /// Converts this graph into a [`dot_structures::Graph`].
+    #[rustfmt::skip]
+    pub fn to_dot<T>(&self, name: impl Into<String>, vertex_transformer: T) -> dot_structures::Graph
+    where
+        for<'a> T: Fn(&'a dot_structures::Node) -> dot_structures::Node,
+    {
+        use dot_structures::*;
+        // A cache storing the result of `vertex_transformer`'s mutation of a `dot_structures::NodeId`.
+        let mut vertex_id_map = HashMap::<String, NodeId>::new();
+        let vertices = self
+            .vertices
+            .iter()
+            .map(|node| {
+                let before_id = id_str(&node.id.0).to_string();
+                let transformed = vertex_transformer(node);
+                let after_id = transformed.id.clone();
+                vertex_id_map.insert(before_id, after_id);
+                transformed
+            })
+            .map(Stmt::Node)
+            .collect::<Vec<_>>();
+        let edges = self
+            .edges
+            .iter()
+            .map(|edge| {
+                // Edges remain the same, except the vertex ids they reference are updated to their transformed form.
+                let mut cloned = edge.clone();
+                let EdgeTy::Pair(Vertex::N(source), Vertex::N(target)) = &mut cloned.ty else { unreachable!(); };
+                let new_source_id = vertex_id_map.get(id_str(&source.0).as_ref()).expect("edge should refer to known id").clone();
+                let _ = std::mem::replace(source, new_source_id);
+                let new_target_id = vertex_id_map.get(id_str(&target.0).as_ref()).expect("edge should refer to known id").clone();
+                let _ = std::mem::replace(target, new_target_id);
+                cloned
+            })
+            .map(Stmt::Edge)
+            .collect::<Vec<_>>();
+
+        Graph::DiGraph {
+            id: Id::Plain(name.into()),
+            strict: true,
+            stmts: [vertices, edges].concat(),
+        }
+    }
+}
+
+/// Encodes the input as either a [`Plain`](dot_structures::Id::Plain) or [`Escaped`](dot_structures::Id::Escaped) id.
+fn encode_id(input: impl AsRef<str>) -> dot_structures::Id {
+    let input = input.as_ref();
+
+    // (The char ranges below are from the official DOT language grammar spec)
+    let needs_escape = input
+        .chars()
+        .any(|ch| !matches!(ch, '0'..='9' | 'a'..='z' | 'A'..='Z' | '_' ));
+    if needs_escape {
+        dot_structures::Id::Escaped(format!("\"{}\"", input.replace(r#"""#, r#"\""#)))
+    } else {
+        dot_structures::Id::Plain(input.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::analysis::ddsa_lib::common::compile_script;
+    use crate::analysis::ddsa_lib::js::flow::graph::{
+        id_str, Digraph, Edge, EdgeKind, V8DotGraph, VertexId, KIND,
+    };
+    use crate::analysis::ddsa_lib::test_utils::{cfg_test_runtime, try_execute};
+    use crate::analysis::ddsa_lib::JsRuntime;
+    use deno_core::v8;
+    use graphviz_rust::dot_structures;
+
+    /// A newtype wrapper around a string vertex id.
+    struct TestVertex(String);
+
+    impl TestVertex {
+        /// A mapping from a string name to an assigned id.
+        /// It is used to specify human-friendly string vertex ids and have them transparently
+        /// translated to and from a JavaScript numeric `VertexId`.
+        /// (This is a hardcoded mapping for simplicity).
+        const ID_MAPPING: &'static [(&'static str, VertexId)] = &[
+            // Generic CST node vertices:
+            ("v_1", VertexId(1)),
+            ("v_2", VertexId(2)),
+            ("v_3", VertexId(3)),
+        ];
+
+        /// Creates a new `TestVertex` from a DOT-specified id with the string format:
+        /// ```text
+        /// v_1  // Generic CST node vertex
+        /// ```
+        /// Panics if the vertex id is not pre-defined in [`Self::ID_MAPPING`].
+        fn from_dot(dot_vertex_id: &str) -> Self {
+            let is_known = Self::ID_MAPPING
+                .iter()
+                .any(|&(str_id, _)| str_id == dot_vertex_id);
+            assert!(is_known, "vertex id `{dot_vertex_id}` must be predefined");
+            Self(dot_vertex_id.to_string())
+        }
+
+        /// Converts this to a `dot_structures::Node`. A round-trip from [`Self::from_dot`] to this
+        /// function will not lose any fundamental information.
+        fn to_dot(&self) -> dot_structures::Node {
+            use dot_structures::*;
+            use graphviz_rust::dot_generator::*;
+            // Reconstitute the string id.
+            let &(str_id, _) = Self::ID_MAPPING
+                .iter()
+                .find(|(str_id, _)| str_id == &self.0)
+                .unwrap();
+            node!(str_id)
+        }
+
+        /// Returns the vertex id used by JavaScript.
+        fn to_js_id(&self) -> VertexId {
+            Self::ID_MAPPING
+                .iter()
+                .find(|&(str_id, _)| str_id == &self.0)
+                .map(|(_, vid)| *vid)
+                .unwrap()
+        }
+
+        /// Constructs a `Self` from a JavaScript vertex id.
+        fn from_js_id(vertex_id: u32) -> Self {
+            Self::ID_MAPPING
+                .iter()
+                .find(|&(_, vid)| VertexId(vertex_id) == *vid)
+                .map(|(str_id, _)| Self(str_id.to_string()))
+                .unwrap()
+        }
+    }
+
+    /// Generates a snippet of JavaScript code that will construct a JavaScript `Digraph` based on the
+    /// provided [`dot_structures::Graph`] and return the adjacency list.
+    fn generate_graph_creation_js(graph: &dot_structures::Graph) -> String {
+        use dot_structures::*;
+        let Graph::DiGraph { stmts, .. } = graph else {
+            unreachable!();
+        };
+        let add_edges = stmts
+            .iter()
+            .filter_map(|stmt| match stmt {
+                Stmt::Edge(edge) => {
+                    let EdgeTy::Pair(Vertex::N(source), Vertex::N(target)) = &edge.ty else {
+                        unreachable!()
+                    };
+                    let source_vertex = TestVertex::from_dot(&id_str(&source.0));
+                    let target_vertex = TestVertex::from_dot(&id_str(&target.0));
+                    let edge_kind = edge
+                        .attributes
+                        .iter()
+                        .find(|&attr| id_str(&attr.0) == KIND)
+                        .map(|attr| EdgeKind::try_from(&*id_str(&attr.1)).unwrap())
+                        .unwrap();
+                    Some(format!(
+                        // language=javascript
+                        "graph.addTypedEdge({}, {}, {});",
+                        source_vertex.to_js_id(),
+                        target_vertex.to_js_id(),
+                        edge_kind as u32
+                    ))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        // language=javascript
+        format!(
+            "\
+const graph = new Digraph();
+{}
+graph.adjacencyList;
+",
+            add_edges.join("\n")
+        )
+    }
+
+    /// Deserialized `Digraph`s created from JavaScript adjacency lists.
+    struct JsGraphs {
+        /// The entire graph with all nodes.
+        pub full: Digraph,
+    }
+
+    /// Builds a JavaScript `Digraph` from the provided `reference` and then deserializes it to
+    /// a [`Digraph`] so it can be inspected.
+    fn construct_js_graphs(reference: &str) -> JsGraphs {
+        let mut rt = JsRuntime::try_new().unwrap();
+        let reference_graph = graphviz_rust::parse(reference).unwrap();
+        let js_script = generate_graph_creation_js(&reference_graph);
+        let js_script = compile_script(&mut rt.v8_handle_scope(), &js_script).unwrap();
+
+        let vertex_transformer = |node: &dot_structures::Node| -> dot_structures::Node {
+            let vid = id_str(&node.id.0).parse::<u32>().unwrap();
+            let vertex = TestVertex::from_js_id(vid);
+            vertex.to_dot()
+        };
+
+        let full = rt
+            .scoped_execute(
+                &js_script,
+                |sc, val| {
+                    let full = v8::Local::<v8::Map>::try_from(val).unwrap();
+                    let full = V8DotGraph::new(sc, full);
+                    full.to_dot("full", vertex_transformer)
+                },
+                None,
+            )
+            .unwrap();
+
+        let full = Digraph::new(full);
+        JsGraphs { full }
+    }
+
+    /// Constructs a [`dot_structures::Graph`] and casts it to a `Digraph`.
+    fn dot_graph(specification: &str) -> Digraph {
+        let dot = graphviz_rust::parse(specification).unwrap();
+        Digraph::new(dot)
+    }
+
+    /// The [`EdgeKind`] enum numbering should be consistent between Rust and JavaScript.
+    #[test]
+    fn edge_kind_js_synchronization() {
+        let tests = [
+            EdgeKind::Untyped,
+            EdgeKind::Assignment,
+            EdgeKind::Dependence,
+        ];
+        let mut rt = cfg_test_runtime();
+        let scope = &mut rt.handle_scope();
+        for rust_kind in tests {
+            // (The name of the const exported from `graph.js`)
+            let js_const = match rust_kind {
+                EdgeKind::Untyped => "EDGE_UNTYPED",
+                EdgeKind::Assignment => "EDGE_ASSIGNMENT",
+                EdgeKind::Dependence => "EDGE_DEPENDENCE",
+            };
+            let js_value = try_execute(scope, &format!("{};", js_const)).unwrap();
+            assert!(js_value.is_number());
+            assert_eq!(rust_kind as u32, js_value.uint32_value(scope).unwrap());
+        }
+    }
+
+    /// The Rust logic for unpacking an "Edge" JavaScript number is in sync with JavaScript.
+    #[test]
+    fn js_edge_rust_deserialize() {
+        let mut rt = cfg_test_runtime();
+        let sc = &mut rt.handle_scope();
+        // language=javascript
+        let js_code = "makeEdge(1234, EDGE_DEPENDENCE);";
+        let packed_uint = try_execute(sc, js_code).unwrap();
+        assert!(packed_uint.is_number());
+        let packed_edge = Edge(packed_uint.uint32_value(sc).unwrap());
+        assert_eq!(packed_edge.target(), VertexId(1234));
+        assert_eq!(packed_edge.kind(), EdgeKind::Dependence);
+    }
+
+    /// The JavaScript logic for serializing and deserializing an "Edge" is correct.
+    #[test]
+    fn js_edge_js_ser_des() {
+        let mut rt = cfg_test_runtime();
+        let sc = &mut rt.handle_scope();
+        // language=javascript
+        let js_code = "\
+const packed = makeEdge(1234, EDGE_DEPENDENCE);
+`${getEdgeTarget(packed)}, ${getEdgeKind(packed)}`;
+";
+        let deserialized = try_execute(sc, js_code).unwrap().to_rust_string_lossy(sc);
+        assert_eq!(deserialized, "1234, 2");
+    }
+
+    /// A vertex may not point to itself.
+    #[test]
+    fn graph_construction_assignment_identity() {
+        // language=dot
+        let attempted_graph = r#"
+strict digraph {
+    v_1
+    v_2
+
+    v_1 -> v_1 [kind=assignment]
+    v_2 -> v_2 [kind=dependence]
+}
+        "#;
+        // language=dot
+        let expected_graph = r#"
+strict digraph { }
+        "#;
+
+        let JsGraphs { full } = construct_js_graphs(attempted_graph);
+        assert_eq!(full, dot_graph(expected_graph));
+    }
+
+    /// Graph edges are typed.
+    #[test]
+    fn graph_typed_edges() {
+        // language=dot
+        let original_graph = r#"
+strict digraph {
+    v_1
+    v_2
+    v_3
+
+    v_2 -> v_3 [kind=dependence]
+    v_1 -> v_2 [kind=assignment]
+}
+        "#;
+        let expected_graph = original_graph;
+
+        let JsGraphs { full } = construct_js_graphs(original_graph);
+        assert_eq!(full, dot_graph(expected_graph));
+    }
+
+    /// Graph cycles are allowed.
+    #[test]
+    fn graph_cyclic_dependency() {
+        // language=dot
+        let original_graph = r#"
+strict digraph {
+    v_1
+    v_2
+
+    v_2 -> v_1 [kind=dependence]
+    v_1 -> v_2  [kind=dependence]
+}
+        "#;
+        let expected_graph = original_graph;
+
+        let JsGraphs { full } = construct_js_graphs(original_graph);
+        assert_eq!(full, dot_graph(expected_graph));
+    }
+}


### PR DESCRIPTION
## What problem are you trying to solve?
To support more sophisticated analysis techniques, we want to be able to construct arbitrary graphs from the source code we're analyzing.

We're initially iterating on the construction and traversal logic in JavaScript for iteration speed. These can be ported up to Rust if/when it makes sense.

This PR has two main goals:
1. Implement the graph data structure.
2. Establish a pattern to write unit tests against an expected graph structure.

## What is your solution?

### JavaScript-based Digraph
We'll initially be implementing taint analysis, and so our initial graph will be stored as an adjacency list containing directed edges that indicate the flow of tainted values from sources to targets. We need to be able to type the edges to distinguish between various semantics (for now: "assignment" and "dependence")

Thus, in pseudo-code, an edge looks like

```rs
type VertexId = u16;
#[repr(u8)]
enum EdgeKind {
    Assignment,
    Dependence,
}
#[derive(Copy)]
struct Edge {
    target: VertexId,
    kind: EdgeKind,
}
type Adjacencies = Vec<EdgeKind>;
```

Defining and parsing edges as structs makes sense in Rust, as LLVM can optimize these into registers.

The straightforward JavaScript equivalent of this would be an object:
```js
const edge1 = {
    target: 123,
    kind: EdgeKind_DEPENDENCE,
};
const adjacencies = [edge1, /* edge2, edge3, ... */];
```

However, this isn't ideal because:
* Equality checking (e.g. to traverse and/or detect cycles) requires additional complexity (`number` equality is simply by-value, whereas [`object` equality is by-reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality#comparison_of_objects))
* Objects always perform a heap allocation for each edge, as v8 cannot optimize in a similar manner, and we expect to create a lot of edges.

Instead, we use [bit packing](https://github.com/DataDog/datadog-static-analyzer/blob/1e9bcb9997f25012c9dedede3c52b666667c9f79/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/graph.rs#L112-L120) to represent the edge as a number (specifically: integer).

I believe this ends up being a more simple and more maintainable solution in the long-run, particularly because we will eventually be introducing vertex types, so were we to use an object here, we'd have to write something like:
```js
const edge1 = {
    target: {
        id: 123,
        kind: VertexKind_CST,
    },
    kind: EdgeKind_DEPENDENCE,
};
```
We'd then need a way to represent this as an adjacency list. We can't easily do `Map<Vertex, Edge[]>` because objects are by-reference, not by-value, so we would need to come up with some one-off serialization of `Vertex` into a number/string map key. At that point, it's more simple just to have everything use the same serialization to number.

### Unit Tests
We'll be building more complex graphs that are specific to the semantics of each programming language. We need to be able to easily read (and write) unit tests that make assertions about the structure of a graph generated from source code. To that end, this PR introduces the following pattern:

* Expected graphs are specified using [DOT Language](https://graphviz.org/doc/info/lang.html).
* Unit tests specify a transformer function to map a manually-written graph to an algorithmically generated one.

To illustrate: while not implemented in _this_ PR, a future PR will use this pattern to implement a DSL that can specify CST nodes as graph nodes and edges as taint flow. For example, for the given Java code:
```java
String value = request.getHeader("abc");
System.out.println(value);
```
A test writer will be able to specify that they expect at line 1, "`value` is dependent on `request`, and that the `println` function is a sink for that value by simply writing:

```dot
digraph expected {
    value1 [text=value,line=1]
    value2 [text=value,line=2]
    request [line=1]
    println [line=2]

    value1 -> request [kind=dependence]  
    value2 -> value1 [kind=dependence]
    println -> value2 [kind=dependence]
}
```

## Alternatives considered

## What the reviewer should know
* New third party dependency `graphviz-rust` is used to parse (and eventually generate) DOT language graphs used in unit tests.