### PR TITLE
[STAL-2703] feat: add Markdown support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -31,6 +31,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Starlark, &["bzl"]),
     (Language::Bash, &["sh", "bash"]),
     (Language::PHP, &["php"]),
+    (Language::Markdown, &["md"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -698,6 +699,7 @@ mod tests {
         extensions_per_languages.insert(Language::Starlark, 1);
         extensions_per_languages.insert(Language::Bash, 2);
         extensions_per_languages.insert(Language::PHP, 1);
+        extensions_per_languages.insert(Language::Markdown, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -205,6 +205,15 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-markdown".to_string(),
+            compilation_unit: "tree-sitter-markdown".to_string(),
+            repository: "https://github.com/tree-sitter-grammars/tree-sitter-markdown".to_string(),
+            build_dir: "tree-sitter-markdown/src".into(),
+            commit_hash: "7fe453beacecf02c86f7736439f238f5bb8b5c9b".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -73,6 +73,9 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
                 "#datadog-disable",
             ]
         }
+        Language::Markdown => {
+            vec!["<!--no-dd-sa", "<!--datadog-disable"]
+        }
     };
     let mut ignore_file_all_rules: bool = false;
     let mut rules_to_ignore: Vec<String> = vec![];

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -26,6 +26,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_starlark() -> tree_sitter::Language;
         fn tree_sitter_bash() -> tree_sitter::Language;
         fn tree_sitter_php() -> tree_sitter::Language;
+        fn tree_sitter_markdown() -> tree_sitter::Language;
     }
 
     match language {
@@ -46,6 +47,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::Starlark => unsafe { tree_sitter_starlark() },
         Language::Bash => unsafe { tree_sitter_bash() },
         Language::PHP => unsafe { tree_sitter_php() },
+        Language::Markdown => unsafe { tree_sitter_markdown() },
     }
 }
 
@@ -589,6 +591,19 @@ echo "Hello, World!";
         let t = t.unwrap();
         assert!(!t.root_node().has_error());
         assert_eq!("program", t.root_node().kind());
+    }
+
+    #[test]
+    fn test_markdown_get_tree() {
+        let source_code = r#"
+# Hello, World!
+This is some text
+"#;
+        let t = get_tree(source_code, &Language::Markdown);
+        assert!(t.is_some());
+        let t = t.unwrap();
+        assert!(!t.root_node().has_error());
+        assert_eq!("document", t.root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -54,6 +54,8 @@ pub enum Language {
     #[serde(rename = "BASH")]
     Bash,
     PHP,
+    #[serde(rename = "MARKDOWN")]
+    Markdown,
 }
 
 #[allow(dead_code)]
@@ -75,6 +77,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::Starlark,
     Language::Bash,
     Language::PHP,
+    Language::Markdown,
 ];
 
 impl fmt::Display for Language {
@@ -97,6 +100,7 @@ impl fmt::Display for Language {
             Self::Starlark => "starlark",
             Self::Bash => "bash",
             Self::PHP => "php",
+            Self::Markdown => "markdown",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support Markdown files. We need a way to parse and query Markdown files, but we do not currently fetch and build a Markdown grammar.

## What is your solution?

Add the Markdown grammar to the analyzer itself, which is fetched from https://github.com/tree-sitter-grammars/tree-sitter-markdown. This will allow us (and customers down the line) to begin writing rules targeting Markdown files.

## Alternatives considered

## What the reviewer should know
