### PR TITLE
[STAL-2687] Fetch remote config

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use cli::config_file::read_config_file;
+use cli::config_file::{get_config, read_config_file};
 use cli::constants::{DEFAULT_MAX_CPUS, DEFAULT_MAX_FILE_SIZE_KB};
 use cli::datadog_utils::{get_all_default_rulesets, get_rules_from_rulesets, get_secrets_rules};
 use cli::file_utils::{
@@ -221,7 +221,7 @@ fn main() -> Result<()> {
     }
 
     let configuration_file: Option<ConfigFile> =
-        match read_config_file(directory_to_analyze.as_str()) {
+        match get_config(directory_to_analyze.as_str(), use_debug) {
             Ok(cfg) => cfg,
             Err(err) => {
                 eprintln!(

--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use cli::config_file::{get_config, read_config_file};
+use cli::config_file::get_config;
 use cli::constants::{DEFAULT_MAX_CPUS, DEFAULT_MAX_FILE_SIZE_KB};
 use cli::datadog_utils::{get_all_default_rulesets, get_rules_from_rulesets, get_secrets_rules};
 use cli::file_utils::{

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -233,7 +233,7 @@ fn main() -> Result<()> {
         };
 
     if configuration_file.is_none() && use_debug {
-        eprintln!("INFO: no configuration detected (either local or remote)")
+        eprintln!("INFO: no configuration detected locally or remotely")
     }
 
     let rule_config_provider = configuration_file

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use std::{env, fs};
 
-use cli::config_file::read_config_file;
+use cli::config_file::get_config;
 use cli::constants::{DEFAULT_MAX_CPUS, DEFAULT_MAX_FILE_SIZE_KB};
 use cli::csv;
 use cli::datadog_utils::{
@@ -221,7 +221,7 @@ fn main() -> Result<()> {
     }
 
     let configuration_file: Option<ConfigFile> =
-        match read_config_file(directory_to_analyze.as_str()) {
+        match get_config(directory_to_analyze.as_str(), use_debug) {
             Ok(cfg) => cfg,
             Err(err) => {
                 eprintln!(
@@ -231,6 +231,11 @@ fn main() -> Result<()> {
                 exit(1)
             }
         };
+
+    if configuration_file.is_none() && use_debug {
+        eprintln!("INFO: no configuration detected (either local or remote)")
+    }
+
     let rule_config_provider = configuration_file
         .as_ref()
         .map(RuleConfigProvider::from_config)

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -50,7 +50,7 @@ pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
                 if size_read == 0 {
                     return Err(anyhow!("the config file is empty"));
                 }
-                parse_config_file(&contents).map(|c| Some(c))
+                parse_config_file(&contents).map(Some)
             } else {
                 Ok(None)
             }

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -39,45 +39,35 @@ fn get_config_file(path: &str) -> Result<Option<File>> {
 // If the file does not exist, we return a Ok(None).
 // If there is an error reading the file, we return a failure
 pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
-    match get_config_file(path) {
-        Ok(file_opt) => {
-            if let Some(mut file) = file_opt {
-                let mut contents = String::new();
+    if let Some(mut file) = get_config_file(path)? {
+        let mut contents = String::new();
 
-                let size_read = file
-                    .read_to_string(&mut contents)
-                    .context("error when reading the configration file")?;
-                if size_read == 0 {
-                    return Err(anyhow!("the config file is empty"));
-                }
-                parse_config_file(&contents).map(Some)
-            } else {
-                Ok(None)
-            }
+        let size_read = file
+            .read_to_string(&mut contents)
+            .context("error when reading the configration file")?;
+        if size_read == 0 {
+            return Err(anyhow!("the config file is empty"));
         }
-        Err(e) => Err(e),
+        parse_config_file(&contents).map(Some)
+    } else {
+        Ok(None)
     }
 }
 
 // Read the config file in base64
 pub fn read_config_file_in_base64(path: &str) -> Result<Option<String>> {
-    match get_config_file(path) {
-        Ok(file_opt) => {
-            if let Some(mut file) = file_opt {
-                let mut contents = String::new();
+    if let Some(mut file) = get_config_file(path)? {
+        let mut contents = String::new();
 
-                let size_read = file
-                    .read_to_string(&mut contents)
-                    .context("error when reading the configration file")?;
-                if size_read == 0 {
-                    return Err(anyhow!("the config file is empty"));
-                }
-                Ok(Some(encode_base64_string(contents)))
-            } else {
-                Ok(None)
-            }
+        let size_read = file
+            .read_to_string(&mut contents)
+            .context("error when reading the configration file")?;
+        if size_read == 0 {
+            return Err(anyhow!("the config file is empty"));
         }
-        Err(e) => Err(e),
+        Ok(Some(encode_base64_string(contents)))
+    } else {
+        Ok(None)
     }
 }
 

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -50,9 +50,7 @@ pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
                 if size_read == 0 {
                     return Err(anyhow!("the config file is empty"));
                 }
-                match parse_config_file(&contents) {
-                    Ok(c) => Ok(Some(c)),
-                    Err(e) => Err(e),
+                parse_config_file(&contents).map(|c| Some(c))
                 }
             }
             None => Ok(None),
@@ -120,8 +118,8 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
                 }
                 Err(e) => {
                     if debug {
-                        eprintln!("error when trying to get remote config: {:?}", e);
-                        eprintln!("will use the local configuration if any")
+                        eprintln!("Error when attempting to fetch the remote config: {:?}", e);
+                        eprintln!("Falling back to the local configuration, if any")
                     }
                     cf
                 }

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -1,17 +1,15 @@
+use crate::constants;
+use crate::datadog_utils::{get_remote_configuration, should_use_datadog_backend};
+use crate::git_utils::get_repository_url;
 use anyhow::{anyhow, Context, Result};
 use kernel::config_file::parse_config_file;
 use kernel::model::config_file::ConfigFile;
+use kernel::utils::{decode_base64_string, encode_base64_string};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use crate::constants;
-
-// We first try to read static-analysis.datadog.yml
-// If it fails, we try to read static-analysis.datadog.yaml
-// If the file does not exist, we return a Ok(None).
-// If there is an error reading the file, we return a failure
-pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
+fn get_config_file(path: &str) -> Result<Option<File>> {
     let yml_file_path = Path::new(path).join(format!(
         "{}.yml",
         constants::DATADOG_CONFIG_FILE_WITHOUT_PREFIX
@@ -22,26 +20,117 @@ pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
     ));
 
     // first, static-analysis.datadog.yml
-    let mut file = match File::open(yml_file_path) {
-        Ok(f) => f,
+    match File::open(yml_file_path) {
+        Ok(f) => Ok(Some(f)),
         Err(e1) if e1.kind() == std::io::ErrorKind::NotFound => {
             // second, static-analysis.datadog.yaml
             match File::open(yaml_file_path) {
-                Ok(f) => f,
-                Err(e2) if e2.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-                otherwise => otherwise?,
+                Ok(f) => Ok(Some(f)),
+                Err(e2) if e2.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                _ => Err(anyhow!("cannot open config file")),
             }
         }
-        otherwise => otherwise?,
-    };
-    let mut contents = String::new();
-
-    let size_read = file
-        .read_to_string(&mut contents)
-        .context("error when reading the configration file")?;
-    if size_read == 0 {
-        return Err(anyhow!("the config file is empty"));
+        _ => Err(anyhow!("cannot open config file")),
     }
+}
 
-    Ok(Some(parse_config_file(&contents)?))
+// We first try to read static-analysis.datadog.yml
+// If it fails, we try to read static-analysis.datadog.yaml
+// If the file does not exist, we return a Ok(None).
+// If there is an error reading the file, we return a failure
+pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
+    match get_config_file(path) {
+        Ok(file_opt) => match file_opt {
+            Some(mut file) => {
+                let mut contents = String::new();
+
+                let size_read = file
+                    .read_to_string(&mut contents)
+                    .context("error when reading the configration file")?;
+                if size_read == 0 {
+                    return Err(anyhow!("the config file is empty"));
+                }
+                match parse_config_file(&contents) {
+                    Ok(c) => Ok(Some(c)),
+                    Err(e) => Err(e),
+                }
+            }
+            None => Ok(None),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+// Read the config file in base64
+pub fn read_config_file_in_base64(path: &str) -> Result<Option<String>> {
+    match get_config_file(path) {
+        Ok(file_opt) => match file_opt {
+            Some(mut file) => {
+                let mut contents = String::new();
+
+                let size_read = file
+                    .read_to_string(&mut contents)
+                    .context("error when reading the configration file")?;
+                if size_read == 0 {
+                    return Err(anyhow!("the config file is empty"));
+                }
+                Ok(Some(encode_base64_string(contents)))
+            }
+            None => Ok(None),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+/// Get the final configuration for the analyzer
+/// First, try to get the configuration from the file
+/// - If the user is a Datadog user (e.g. with API keys), we fetch the remote configuration
+///   and merge it
+/// - If not, we just return the configuration
+pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
+    let config_file = read_config_file(path);
+    let repository_url_opt = get_repository_url(path);
+
+    config_file.map(|cf| {
+        if should_use_datadog_backend() && repository_url_opt.is_ok() {
+            let existing_config_file_base64 =
+                read_config_file_in_base64(path).expect("cannot get the config file in base64");
+            let remote_config = get_remote_configuration(
+                repository_url_opt.expect("repository URL should exist"),
+                existing_config_file_base64,
+                debug,
+            );
+
+            match remote_config {
+                Ok(rc) => {
+                    if debug {
+                        eprintln!("Remote config (base64): {:?}", rc);
+                    }
+
+                    let remote_config_base64 =
+                        decode_base64_string(rc).expect("error when decoding base64");
+                    match parse_config_file(remote_config_base64.as_str()) {
+                        Ok(remote_config) => Some(remote_config),
+                        Err(e) => {
+                            eprintln!("Error when parsing remote config: {:?}", e);
+                            eprintln!("Proceeding with local config");
+                            cf
+                        }
+                    }
+                }
+                Err(e) => {
+                    if debug {
+                        eprintln!("error when trying to get remote config: {:?}", e);
+                        eprintln!("will use the local configuration if any")
+                    }
+                    cf
+                }
+            }
+        } else {
+            if debug {
+                eprintln!("not attempting to use remote configuration");
+            }
+            cf
+        }
+    })
 }

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -40,8 +40,8 @@ fn get_config_file(path: &str) -> Result<Option<File>> {
 // If there is an error reading the file, we return a failure
 pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
     match get_config_file(path) {
-        Ok(file_opt) => match file_opt {
-            Some(mut file) => {
+        Ok(file_opt) => {
+            if let Some(mut file) = file_opt {
                 let mut contents = String::new();
 
                 let size_read = file
@@ -51,10 +51,10 @@ pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
                     return Err(anyhow!("the config file is empty"));
                 }
                 parse_config_file(&contents).map(|c| Some(c))
-                }
+            } else {
+                Ok(None)
             }
-            None => Ok(None),
-        },
+        }
         Err(e) => Err(e),
     }
 }
@@ -62,8 +62,8 @@ pub fn read_config_file(path: &str) -> Result<Option<ConfigFile>> {
 // Read the config file in base64
 pub fn read_config_file_in_base64(path: &str) -> Result<Option<String>> {
     match get_config_file(path) {
-        Ok(file_opt) => match file_opt {
-            Some(mut file) => {
+        Ok(file_opt) => {
+            if let Some(mut file) = file_opt {
                 let mut contents = String::new();
 
                 let size_read = file
@@ -73,9 +73,10 @@ pub fn read_config_file_in_base64(path: &str) -> Result<Option<String>> {
                     return Err(anyhow!("the config file is empty"));
                 }
                 Ok(Some(encode_base64_string(contents)))
+            } else {
+                Ok(None)
             }
-            None => Ok(None),
-        },
+        }
         Err(e) => Err(e),
     }
 }

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -80,7 +80,9 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
     let config_file = read_config_file(path);
     let repository_url_opt = get_repository_url(path);
 
+    // Get the config file
     config_file.map(|cf| {
+        // if we need to fetch the remote config
         if should_use_datadog_backend() && repository_url_opt.is_ok() {
             let existing_config_file_base64 =
                 read_config_file_in_base64(path).expect("cannot get the config file in base64");
@@ -90,15 +92,17 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
                 debug,
             );
 
+            // if we get the remote config, we parse it. If we succeed, we use the remote config
+            // otherwise, we use the file config.
             match remote_config {
                 Ok(rc) => {
                     if debug {
                         eprintln!("Remote config (base64): {:?}", rc);
                     }
 
-                    let remote_config_base64 =
+                    let remote_config_string =
                         decode_base64_string(rc).expect("error when decoding base64");
-                    match parse_config_file(remote_config_base64.as_str()) {
+                    match parse_config_file(remote_config_string.as_str()) {
                         Ok(remote_config) => Some(remote_config),
                         Err(e) => {
                             eprintln!("Error when parsing remote config: {:?}", e);

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -374,7 +374,7 @@ pub fn get_remote_configuration(
 
     let api_response = serde_json::from_str::<ConfigResponse>(response_text);
 
-    if !&status_code.is_success() {
+    if !status_code.is_success() {
         return Err(anyhow!("server returned error {}", status_code.as_u16()));
     }
 

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -375,7 +375,7 @@ pub fn get_remote_configuration(
     let api_response = serde_json::from_str::<ConfigResponse>(response_text);
 
     if !&status_code.is_success() {
-        return Err(anyhow!("server returned error {}", &status_code.as_u16()));
+        return Err(anyhow!("server returned error {}", status_code.as_u16()));
     }
 
     match api_response {

--- a/crates/cli/src/git_utils.rs
+++ b/crates/cli/src/git_utils.rs
@@ -103,6 +103,18 @@ fn get_changed_files(diff: &Diff) -> anyhow::Result<HashMap<PathBuf, Vec<u32>>> 
     Ok(res)
 }
 
+pub fn get_repository_url(path: &str) -> anyhow::Result<String> {
+    let repository_opt = Repository::init(path);
+    match repository_opt {
+        Ok(repository) => Ok(repository
+            .find_remote("origin")?
+            .url()
+            .ok_or(anyhow!("cannot get the repository origin URL"))?
+            .to_string()),
+        Err(_) => Err(anyhow!("cannot get the repo")),
+    }
+}
+
 /// Get the list of changed files for the repository between the latest commit the repository
 /// is at and the default branch pointed by [default_branch].
 /// The [repository] object is the repository built by git2.

--- a/crates/cli/src/git_utils.rs
+++ b/crates/cli/src/git_utils.rs
@@ -9,6 +9,7 @@ use crate::constants::{GITLAB_ENVIRONMENT_VARIABLE_COMMIT_BRANCH, GIT_HEAD};
 /// The string to reference the head on the remote (hopefully pointing to the default branch)
 const REMOTE_HEAD_REF: &str = "refs/remotes/origin/HEAD";
 const ORIGIN_PREFIX: &str = "origin/";
+pub const ORIGIN: &str = "origin";
 
 /// Try to get the branch running. We first try to get the branch from the repository. When
 /// it fails, we attempt to get the branch from the CI provider when the analyzer
@@ -107,7 +108,7 @@ pub fn get_repository_url(path: &str) -> anyhow::Result<String> {
     let repository_opt = Repository::init(path);
     match repository_opt {
         Ok(repository) => Ok(repository
-            .find_remote("origin")?
+            .find_remote(ORIGIN)?
             .url()
             .ok_or(anyhow!("cannot get the repository origin URL"))?
             .to_string()),

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -1,4 +1,4 @@
-use crate::git_utils::get_branch;
+use crate::git_utils::{get_branch, ORIGIN};
 use anyhow::anyhow;
 use common::model::diff_aware::DiffAware;
 use git2::Repository;
@@ -101,7 +101,7 @@ impl CliConfiguration {
         let repository = repository_opt?;
 
         let repository_url = repository
-            .find_remote("origin")?
+            .find_remote(ORIGIN)?
             .url()
             .ok_or(anyhow!("cannot get the repository origin URL"))?
             .to_string();

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -12,6 +12,7 @@ pub struct DiffAwareResponseDataAttributes {
     #[serde(rename = "base_sha")]
     pub base_sha: String,
 }
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiffAwareResponseData {
     #[serde(rename = "id")]
@@ -24,6 +25,26 @@ pub struct DiffAwareResponseData {
 pub struct DiffAwareResponse {
     #[serde(rename = "data")]
     pub data: DiffAwareResponseData,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigResponseDataAttributes {
+    #[serde(rename = "config_base64")]
+    pub config_base64: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigResponseData {
+    #[serde(rename = "id")]
+    pub id: String,
+    #[serde(rename = "attributes")]
+    pub attributes: ConfigResponseDataAttributes,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigResponse {
+    #[serde(rename = "data")]
+    pub data: ConfigResponseData,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -54,6 +75,28 @@ pub struct DiffAwareRequestData {
 pub struct DiffAwareRequest {
     #[serde(rename = "data")]
     pub data: DiffAwareRequestData,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigRequestDataAttributes {
+    #[serde(rename = "repository")]
+    pub repository: String,
+    #[serde(rename = "config_base64")]
+    pub config_base64: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigRequestData {
+    #[serde(rename = "type")]
+    pub request_type: String,
+    #[serde(rename = "attributes")]
+    pub attributes: ConfigRequestDataAttributes,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConfigRequest {
+    #[serde(rename = "data")]
+    pub data: ConfigRequestData,
 }
 
 /// Data structure to get all attributes and argument for the request.


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to fetch the configuration remotely.

## Solution

We attempt to read the configuration file

1. If there is a configuration file, we attempt to get the remote configuration by passing the existing config file and the backend returns the final config
2. If there is no config, we retrieve the remote configuration by passing a `null` configuration to the API

## Notes

1. We fetch the remote configuration ONLY if we have some API keys defined. Otherwise, we do not even try
2. We added a lot of debug information so that customer will be able to troubleshoot

## Testing

Tested locally, existing tests should pass


```
cargo run --bin datadog-static-analyzer -- --staging --directory /Users/julien.delange/git/datadog-ci --format sarif --output ~/plop.json  --debug yes 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/datadog-static-analyzer --staging --directory /Users/julien.delange/git/datadog-ci --format sarif --output /Users/julien.delange/plop.json --debug yes`
Remote config (base64): "cnVsZXNldHM6CiAgLSBvcmctcnVsZXNldAogIC0ga2Rza2xmanNsZGYK"
Error: ruleset org-ruleset not found
Error: error when reading rules from API

Caused by:
    Error: ruleset org-ruleset not found
```

