### PR TITLE
[STAL-2707] feat: add Apex support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -32,6 +32,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Bash, &["sh", "bash"]),
     (Language::PHP, &["php"]),
     (Language::Markdown, &["md"]),
+    (Language::Apex, &["cls"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -700,6 +701,7 @@ mod tests {
         extensions_per_languages.insert(Language::Bash, 2);
         extensions_per_languages.insert(Language::PHP, 1);
         extensions_per_languages.insert(Language::Markdown, 1);
+        extensions_per_languages.insert(Language::Apex, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -214,6 +214,15 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-apex".to_string(),
+            compilation_unit: "tree-sitter-apex".to_string(),
+            repository: "https://github.com/aheber/tree-sitter-sfapex".to_string(),
+            build_dir: "apex/src".into(),
+            commit_hash: "9fe5d1fbfd75c11ba48a32db27ac0ed5da57ec78".to_string(),
+            files: vec!["parser.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -44,7 +44,7 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         | Language::Bash => {
             vec!["#no-dd-sa", "#datadog-disable"]
         }
-        Language::JavaScript | Language::TypeScript => {
+        Language::JavaScript | Language::TypeScript | Language::Apex => {
             vec![
                 "//no-dd-sa",
                 "/*no-dd-sa",

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -27,6 +27,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_bash() -> tree_sitter::Language;
         fn tree_sitter_php() -> tree_sitter::Language;
         fn tree_sitter_markdown() -> tree_sitter::Language;
+        fn tree_sitter_apex() -> tree_sitter::Language;
     }
 
     match language {
@@ -48,6 +49,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::Bash => unsafe { tree_sitter_bash() },
         Language::PHP => unsafe { tree_sitter_php() },
         Language::Markdown => unsafe { tree_sitter_markdown() },
+        Language::Apex => unsafe { tree_sitter_apex() },
     }
 }
 
@@ -604,6 +606,21 @@ This is some text
         let t = t.unwrap();
         assert!(!t.root_node().has_error());
         assert_eq!("document", t.root_node().kind());
+    }
+
+    #[test]
+    fn test_apex_get_tree() {
+        let source_code = r#"
+public class HelloWorld {
+    public static void main() {
+        System.out.println('Hello, World');
+    }
+}"#;
+        let t = get_tree(source_code, &Language::Apex);
+        assert!(t.is_some());
+        let t = t.unwrap();
+        assert!(!t.root_node().has_error());
+        assert_eq!("parser_output", t.root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -56,6 +56,8 @@ pub enum Language {
     PHP,
     #[serde(rename = "MARKDOWN")]
     Markdown,
+    #[serde(rename = "APEX")]
+    Apex,
 }
 
 #[allow(dead_code)]
@@ -78,6 +80,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::Bash,
     Language::PHP,
     Language::Markdown,
+    Language::Apex,
 ];
 
 impl fmt::Display for Language {
@@ -101,6 +104,7 @@ impl fmt::Display for Language {
             Self::Bash => "bash",
             Self::PHP => "php",
             Self::Markdown => "markdown",
+            Self::Apex => "apex",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support Apex files. We need a way to parse and query Apex files, but we do not currently fetch and build an Apex grammar.

## What is your solution?

Add the Apex grammar to the analyzer itself, which is fetched from https://github.com/aheber/tree-sitter-sfapex. This will allow us (and customers down the line) to begin writing rules targeting Apex files.

## Alternatives considered

## What the reviewer should know
