### PR TITLE
feat: add R support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -33,6 +33,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::PHP, &["php"]),
     (Language::Markdown, &["md"]),
     (Language::Apex, &["cls"]),
+    (Language::R, &["r"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -702,6 +703,7 @@ mod tests {
         extensions_per_languages.insert(Language::PHP, 1);
         extensions_per_languages.insert(Language::Markdown, 1);
         extensions_per_languages.insert(Language::Apex, 1);
+        extensions_per_languages.insert(Language::R, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -228,7 +228,7 @@ fn main() {
             compilation_unit: "tree-sitter-r".to_string(),
             repository: "https://github.com/r-lib/tree-sitter-r".to_string(),
             build_dir: "src".into(),
-            commit_hash: "b1e211f52ad8f8e1e182bbbcc16dcd5e3688eb7d".to_string(),
+            commit_hash: "369d20ff5d9fced274d3065b792951b23981b63d".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -223,6 +223,15 @@ fn main() {
             files: vec!["parser.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-r".to_string(),
+            compilation_unit: "tree-sitter-r".to_string(),
+            repository: "https://github.com/r-lib/tree-sitter-r".to_string(),
+            build_dir: "src".into(),
+            commit_hash: "b1e211f52ad8f8e1e182bbbcc16dcd5e3688eb7d".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -41,7 +41,8 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         | Language::Ruby
         | Language::Terraform
         | Language::Yaml
-        | Language::Bash => {
+        | Language::Bash
+        | Language::R => {
             vec!["#no-dd-sa", "#datadog-disable"]
         }
         Language::JavaScript | Language::TypeScript | Language::Apex => {

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -28,6 +28,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_php() -> tree_sitter::Language;
         fn tree_sitter_markdown() -> tree_sitter::Language;
         fn tree_sitter_apex() -> tree_sitter::Language;
+        fn tree_sitter_r() -> tree_sitter::Language;
     }
 
     match language {
@@ -50,6 +51,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::PHP => unsafe { tree_sitter_php() },
         Language::Markdown => unsafe { tree_sitter_markdown() },
         Language::Apex => unsafe { tree_sitter_apex() },
+        Language::R => unsafe { tree_sitter_r() },
     }
 }
 
@@ -621,6 +623,19 @@ public class HelloWorld {
         let t = t.unwrap();
         assert!(!t.root_node().has_error());
         assert_eq!("parser_output", t.root_node().kind());
+    }
+
+    #[test]
+    fn test_r_get_tree() {
+        let source_code = r#"
+x <- 1
+print("Hello, World!")
+"#;
+        let t = get_tree(source_code, &Language::R);
+        assert!(t.is_some());
+        let t = t.unwrap();
+        assert!(!t.root_node().has_error());
+        assert_eq!("program", t.root_node().kind());
     }
 
     // test the number of node we should retrieve when executing a rule

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -58,6 +58,7 @@ pub enum Language {
     Markdown,
     #[serde(rename = "APEX")]
     Apex,
+    R,
 }
 
 #[allow(dead_code)]
@@ -81,6 +82,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::PHP,
     Language::Markdown,
     Language::Apex,
+    Language::R,
 ];
 
 impl fmt::Display for Language {
@@ -105,6 +107,7 @@ impl fmt::Display for Language {
             Self::PHP => "php",
             Self::Markdown => "markdown",
             Self::Apex => "apex",
+            Self::R => "r",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support R files. We need a way to parse and query R files, but we do not currently fetch and build an R grammar.

## What is your solution?

Add the R grammar to the analyzer itself, which is fetched from https://github.com/r-lib/tree-sitter-r. This will allow us (and customers down the line) to begin writing rules targeting R files.

## Alternatives considered

## What the reviewer should know
