### PR TITLE
[STAL-2732] feat: add SQL support

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -34,6 +34,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Markdown, &["md"]),
     (Language::Apex, &["cls"]),
     (Language::R, &["r"]),
+    (Language::SQL, &["sql"]),
 ];
 
 static FILE_EXACT_MATCH_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
@@ -704,6 +705,7 @@ mod tests {
         extensions_per_languages.insert(Language::Markdown, 1);
         extensions_per_languages.insert(Language::Apex, 1);
         extensions_per_languages.insert(Language::R, 1);
+        extensions_per_languages.insert(Language::SQL, 1);
 
         for (l, e) in extensions_per_languages {
             assert_eq!(

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -232,6 +232,15 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        TreeSitterProject {
+            name: "tree-sitter-sql".to_string(),
+            compilation_unit: "tree-sitter-sql".to_string(),
+            repository: "https://github.com/DerekStride/tree-sitter-sql".to_string(),
+            build_dir: "src".into(),
+            commit_hash: "c67ecbd37d8d12f22e4cc7138afd14bc20253e10".to_string(),
+            files: vec!["parser.c".to_string(), "scanner.c".to_string()],
+            cpp: false,
+        },
     ];
 
     // For each project:

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -77,6 +77,14 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         Language::Markdown => {
             vec!["<!--no-dd-sa", "<!--datadog-disable"]
         }
+        Language::SQL => {
+            vec![
+                "--no-dd-sa",
+                "--datadog-disable",
+                "/*no-dd-sa",
+                "/*datadog-disable",
+            ]
+        }
     };
     let mut ignore_file_all_rules: bool = false;
     let mut rules_to_ignore: Vec<String> = vec![];

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -29,6 +29,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         fn tree_sitter_markdown() -> tree_sitter::Language;
         fn tree_sitter_apex() -> tree_sitter::Language;
         fn tree_sitter_r() -> tree_sitter::Language;
+        fn tree_sitter_sql() -> tree_sitter::Language;
     }
 
     match language {
@@ -52,6 +53,7 @@ pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
         Language::Markdown => unsafe { tree_sitter_markdown() },
         Language::Apex => unsafe { tree_sitter_apex() },
         Language::R => unsafe { tree_sitter_r() },
+        Language::SQL => unsafe { tree_sitter_sql() },
     }
 }
 
@@ -632,6 +634,18 @@ x <- 1
 print("Hello, World!")
 "#;
         let t = get_tree(source_code, &Language::R);
+        assert!(t.is_some());
+        let t = t.unwrap();
+        assert!(!t.root_node().has_error());
+        assert_eq!("program", t.root_node().kind());
+    }
+
+    #[test]
+    fn test_sql_get_tree() {
+        let source_code = r#"
+SELECT * FROM table WHERE column = 'value';
+"#;
+        let t = get_tree(source_code, &Language::SQL);
         assert!(t.is_some());
         let t = t.unwrap();
         assert!(!t.root_node().has_error());

--- a/crates/static-analysis-kernel/src/model/common.rs
+++ b/crates/static-analysis-kernel/src/model/common.rs
@@ -59,6 +59,7 @@ pub enum Language {
     #[serde(rename = "APEX")]
     Apex,
     R,
+    SQL,
 }
 
 #[allow(dead_code)]
@@ -83,6 +84,7 @@ pub static ALL_LANGUAGES: &[Language] = &[
     Language::Markdown,
     Language::Apex,
     Language::R,
+    Language::SQL,
 ];
 
 impl fmt::Display for Language {
@@ -108,6 +110,7 @@ impl fmt::Display for Language {
             Self::Markdown => "markdown",
             Self::Apex => "apex",
             Self::R => "r",
+            Self::SQL => "sql",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not support SQL files. We need a way to parse and query SQL files, but we do not currently fetch and build an SQL grammar.

## What is your solution?

Add the SQL grammar to the analyzer itself, which is fetched from https://github.com/DerekStride/tree-sitter-sql. This will allow us (and customers down the line) to begin writing rules targeting SQL files.

## Alternatives considered

## What the reviewer should know

The SQL grammar repository does not generate and commit the `parser.c` file on the main branch, but rather the `gh-pages` branch, so the commit being used does not exist on the main branch - this is expected