### PR TITLE
[STAL-1489] refactor: handle internal rule conversion errors more pragmatically

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -1,6 +1,5 @@
 use crate::model::analysis::{MatchNode, MatchNodeContext, TreeSitterNode};
 use crate::model::common::Language;
-use anyhow::Result;
 use common::model::position::Position;
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -68,9 +67,12 @@ pub fn get_tree(code: &str, language: &Language) -> Option<tree_sitter::Tree> {
 }
 
 // build the query from tree-sitter
-pub fn get_query(query_code: &str, language: &Language) -> Result<TSQuery> {
+pub fn get_query(
+    query_code: &str,
+    language: &Language,
+) -> Result<TSQuery, tree_sitter::QueryError> {
     let tree_sitter_language = get_tree_sitter_language(language);
-    TSQuery::try_new(&tree_sitter_language, query_code).map_err(anyhow::Error::new)
+    TSQuery::try_new(&tree_sitter_language, query_code)
 }
 
 /// A wrapper around a [`tree_sitter::Query`].
@@ -84,7 +86,7 @@ impl TSQuery {
     pub fn try_new(
         language: &tree_sitter::Language,
         source: &str,
-    ) -> std::result::Result<Self, tree_sitter::QueryError> {
+    ) -> Result<Self, tree_sitter::QueryError> {
         let query = tree_sitter::Query::new(language, source)?;
         let capture_names = Self::build_cache(&query);
         Ok(Self {

--- a/crates/static-analysis-server/src/constants.rs
+++ b/crates/static-analysis-server/src/constants.rs
@@ -1,3 +1,5 @@
+// when a rule failed to parse
+pub const ERROR_PARSING_RULE: &str = "error-parsing-rule";
 // when a rule is not base64
 pub const ERROR_DECODING_BASE64: &str = "error-decoding-base64";
 // when the code is not base64


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, our logic for parsing rules into the internal rule representation is a bit brittle when it comes to processing errors. The reason for this is we convert all errors into anyhow errors; using anyhow means we cannot easily pattern-match or check what kind of error was actually returned. The function `Rule::to_rule_internal` can return 5 different types of errors:

- when the rule type is invalid
- when the base64 string is invalid base64
- when the decoded base64 string is invalid utf8
- when the tree-sitter query is missing
- when the tree-sitter-query fails to build

Although some of these errors can be "grouped" together w.r.t. surfacing a public-facing error, it would not make sense to say, show "error-decoding-base64" when the tree-sitter query failed to build.

## What is your solution?

I've refactored the code pertaining to converting a rule to its internal representation by creating an enum that derives `thiserror::Error`, and has 5 members that each correspond to one of the potential errors mentioned above.

By doing this, we can handle errors more gracefully when we call `Rule::to_rule_internal` in `process_analysis_request`, because we can pattern match on the error and return more appropriate user-facing errors depending on the kind of error we encountered. In this specific case, I've grouped the "invalid base 64" and "invalid utf8" errors together, since that indicates a problem with the base64 string, and I've grouped the "invalid rule type", "missing tree-sitter query", and "invalid tree-sitter query" together, since they pertain to parsing and actually building the rule. A new constant has been added to represent this kind of error - `ERROR_PARSING_RULE` which has the string `"error-parsing-rule"`, and is what will be shown to users.

## Alternatives considered

## What the reviewer should know

This PR touches a bit on the code in the `tree_sitter` mod because it has to return the tree-sitter query error itself rather than an anyhow error, so that it can be mapped to the `RuleInternalError` at the call-site in `to_rule_internal`.
