### PR TITLE
Do not follow symlinks while scanning the repo for files to analyze

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -128,7 +128,10 @@ pub fn get_files(
     };
 
     for directory_to_walk in directories_to_walk {
-        for entry in WalkDir::new(directory_to_walk.as_str()) {
+        for entry in WalkDir::new(directory_to_walk.as_str())
+            .follow_links(false)
+            .follow_root_links(true)
+        {
             let dir_entry = entry?;
             let entry = dir_entry.path();
 


### PR DESCRIPTION
## What problem are you trying to solve?
We want to be able to tell, just by inspecting the code, that the scanner is not following symlinks.

## What is your solution?
Set the configuration values, even if they are the defaults, to make it explicit.

## Alternatives considered

## What the reviewer should know
