### PR TITLE
[STAL-2736] feat!: switch upstream Kotlin parser

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -697,6 +697,7 @@ mod tests {
     fn get_extensions_for_language_all_languages() {
         let mut extensions_per_languages: HashMap<Language, usize> = HashMap::new();
         extensions_per_languages.insert(Language::JavaScript, 2);
+        extensions_per_languages.insert(Language::Kotlin, 2);
         extensions_per_languages.insert(Language::Python, 2);
         extensions_per_languages.insert(Language::Rust, 1);
         extensions_per_languages.insert(Language::TypeScript, 2);

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -92,7 +92,7 @@ fn main() {
             compilation_unit: "tree-sitter-kotlin".to_string(),
             repository: "https://github.com/tree-sitter-grammars/tree-sitter-kotlin.git"
                 .to_string(),
-            commit_hash: "b67a9cfe21b09868bd6bf1d7e812130bface9b79".to_string(),
+            commit_hash: "33c8fa9913e5518724b1e4b3bce6ed69b8117ee7".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -90,8 +90,9 @@ fn main() {
         TreeSitterProject {
             name: "tree-sitter-kotlin".to_string(),
             compilation_unit: "tree-sitter-kotlin".to_string(),
-            repository: "https://github.com/fwcd/tree-sitter-kotlin.git".to_string(),
-            commit_hash: "4e909d6cc9ac96b4eaecb3fb538eaca48e9e9ee9".to_string(),
+            repository: "https://github.com/tree-sitter-grammars/tree-sitter-kotlin.git"
+                .to_string(),
+            commit_hash: "b67a9cfe21b09868bd6bf1d7e812130bface9b79".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -45,7 +45,7 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
         | Language::R => {
             vec!["#no-dd-sa", "#datadog-disable"]
         }
-        Language::JavaScript | Language::TypeScript | Language::Apex => {
+        Language::JavaScript | Language::TypeScript | Language::Kotlin | Language::Apex => {
             vec![
                 "//no-dd-sa",
                 "/*no-dd-sa",
@@ -53,12 +53,7 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
                 "/*datadog-disable",
             ]
         }
-        Language::Go
-        | Language::Rust
-        | Language::Csharp
-        | Language::Java
-        | Language::Kotlin
-        | Language::Swift => {
+        Language::Go | Language::Rust | Language::Csharp | Language::Java | Language::Swift => {
             vec!["//no-dd-sa", "//datadog-disable"]
         }
         Language::Json => {


### PR DESCRIPTION
## What problem are you trying to solve?

Currently the Kotlin grammar we use is from a third-party repository, and there are some [open issues](https://github.com/fwcd/tree-sitter-kotlin/issues) w.r.t parsing. Not only that, but certain queries take a *very* long time; the lag while typing in the rule editor is very noticeable.

## What is your solution?

The new grammar I wrote that lives in the `tree-sitter-grammars` org parses Kotlin more correctly and is easier to query since the parse tree is simpler. It also removes the noticeable lag when editing with the old Kotlin grammar, and is also an actively maintained grammar with support from tree-sitter & neovim contributors.

## Alternatives considered

## What the reviewer should know

Kotlin supports block comments, so I moved the match arm in `get_lines_to_ignore` to be with JS/TS which checks for two slashes and a slash + asterisk, instead of just two slashes.