### PR TITLE
[STAL-2820] feat: add end-to-end testing for R, Rust, and SQL

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,6 +21,9 @@ jobs:
           - { file: './misc/integration-test-js-ts.sh', gha_alias: 'JavaScript/TypeScript' }
           - { file: './misc/integration-test-filter-rules.sh', gha_alias: 'Per-Path Rule Filtering' }
           - { file: './misc/integration-git-hooks.sh', gha_alias: 'Git Hooks' }
+          - { file: './misc/integration-test-r.sh', gha_alias: 'R' }
+          - { file: './misc/integration-test-rust.sh', gha_alias: 'Rust' }
+          - { file: './misc/integration-test-sql.sh', gha_alias: 'SQL' }
     name: Run integration test - ${{ matrix.scripts.gha_alias }}
     steps:
       - uses: actions/checkout@v4

--- a/misc/integration-test-r.sh
+++ b/misc/integration-test-r.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cargo build --profile release-dev --bin datadog-static-analyzer
+
+## An R repository
+echo "Checking stuart-lab/signac"
+REPO_DIR=$(mktemp -d)
+export REPO_DIR
+git clone --depth=1 https://github.com/stuart-lab/signac.git "${REPO_DIR}"
+
+echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - r-code-style" >> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - r-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
+
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "failed to analyze stuart-lab/signac"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+
+echo "Found $RES errors on second run"
+
+if [ "$RES" -lt "2" ]; then
+  echo "not enough errors found"
+  exit 1
+fi
+
+# Test that --fail-on-any-violation returns a non-zero return code
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
+
+if [ $? -eq 0 ]; then
+  echo "static analyzer reports 0 when it should not"
+  exit 1
+fi
+
+echo "All tests passed"
+
+exit 0

--- a/misc/integration-test-rust.sh
+++ b/misc/integration-test-rust.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cargo build --profile release-dev --bin datadog-static-analyzer
+
+## An R repository
+echo "Checking tokio-rs/tokio"
+REPO_DIR=$(mktemp -d)
+export REPO_DIR
+git clone --depth=1 https://github.com/tokio-rs/tokio.git "${REPO_DIR}"
+
+echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - rust-code-style" >> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - rust-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
+
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "failed to analyze tokio-rs/tokio"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+
+echo "Found $RES errors on second run"
+
+if [ "$RES" -lt "2" ]; then
+  echo "not enough errors found"
+  exit 1
+fi
+
+# Test that --fail-on-any-violation returns a non-zero return code
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
+
+if [ $? -eq 0 ]; then
+  echo "static analyzer reports 0 when it should not"
+  exit 1
+fi
+
+echo "All tests passed"
+
+exit 0

--- a/misc/integration-test-sql.sh
+++ b/misc/integration-test-sql.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cargo build --profile release-dev --bin datadog-static-analyzer
+
+## An R repository
+echo "Checking cisagov/cset"
+REPO_DIR=$(mktemp -d)
+export REPO_DIR
+git clone --depth=1 https://github.com/SparkhoundSQL/sql-server-toolbox.git "${REPO_DIR}"
+
+echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - sql-code-style" >> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - sql-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
+
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "failed to analyze cisagov/cset"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+
+echo "Found $RES errors on second run"
+
+if [ "$RES" -lt "2" ]; then
+  echo "not enough errors found"
+  exit 1
+fi
+
+# Test that --fail-on-any-violation returns a non-zero return code
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
+
+if [ $? -eq 0 ]; then
+  echo "static analyzer reports 0 when it should not"
+  exit 1
+fi
+
+echo "All tests passed"
+
+exit 0


### PR DESCRIPTION
## What problem are you trying to solve?

We've added support for several new languages in the analyzer, but we haven't added proper end-to-end testing to ensure that we can write rules in the rule editor for these languages, retrieve them from the backend, run them in the analyzer, and get some number of results back.

## What is your solution?

This PR adds 3 integration test files, named `integration-test-{lang}.sh` which incorporate the same logic as the other currently existing integration scripts. It downloads a repository that is a project written mostly in the target language, writes a config file to use the `{lang}-inclusive` and `{lang}-code-style` rulesets in the cloned path, and executes the analyzer in this path. Each language has a `function-name-min-length` and `comments` rule which are in the `code-style` and `inclusive` rulesets for each language. We expect to get at *least* two results in each case; currently the R repo has 10 results, the Rust one 9, and the SQL one 27. While there might be slight variation in the number of results over time as the repository changes, we're not likely to see this number go below 2.

These three integration test scripts have been added to the `integration-tests` GitHub CI job as well to check for any regressions/issues.

## Alternatives considered

## What the reviewer should know