### PR TITLE
[STAL-2831] Add YAML + configuration method

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -222,11 +222,9 @@ fn main() -> Result<()> {
     let configuration_file_and_method = get_config(directory_to_analyze.as_str(), use_debug);
 
     let (configuration_file, configuration_method): (Option<ConfigFile>, Option<ConfigMethod>) =
-        match &configuration_file_and_method {
+        match configuration_file_and_method {
             Ok(cfg) => match cfg {
-                Some((config_file, config_method)) => {
-                    (Some(config_file.clone()), Some(config_method.clone()))
-                }
+                Some((config_file, config_method)) => (Some(config_file), Some(config_method)),
                 _ => (None, None),
             },
             Err(err) => {

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -38,7 +38,7 @@ use kernel::analysis::generated_content::DEFAULT_IGNORED_GLOBS;
 use kernel::constants::{CARGO_VERSION, VERSION};
 use kernel::model::analysis::ERROR_RULE_TIMEOUT;
 use kernel::model::common::OutputFormat;
-use kernel::model::config_file::{ConfigFile, PathConfig};
+use kernel::model::config_file::{ConfigFile, ConfigMethod, PathConfig};
 use kernel::model::rule::{Rule, RuleInternal, RuleResult, RuleSeverity};
 use kernel::rule_config::RuleConfigProvider;
 use secrets::model::secret_result::SecretResult;
@@ -55,7 +55,6 @@ fn main() -> Result<()> {
     let program = args[0].clone();
     let mut opts = Options::new();
     #[allow(unused_assignments)]
-    let mut use_configuration_file = false;
     let mut ignore_gitignore = false;
     let mut max_file_size_kb = DEFAULT_MAX_FILE_SIZE_KB;
     let mut ignore_generated_files = true;
@@ -220,9 +219,16 @@ fn main() -> Result<()> {
         exit(1)
     }
 
-    let configuration_file: Option<ConfigFile> =
-        match get_config(directory_to_analyze.as_str(), use_debug) {
-            Ok(cfg) => cfg,
+    let configuration_file_and_method = get_config(directory_to_analyze.as_str(), use_debug);
+
+    let (configuration_file, configuration_method): (Option<ConfigFile>, Option<ConfigMethod>) =
+        match &configuration_file_and_method {
+            Ok(cfg) => match cfg {
+                Some((config_file, config_method)) => {
+                    (Some(config_file.clone()), Some(config_method.clone()))
+                }
+                _ => (None, None),
+            },
             Err(err) => {
                 eprintln!(
                     "Error reading configuration file from {}:\n  {}",
@@ -245,7 +251,6 @@ fn main() -> Result<()> {
     // if there is a configuration file, we load the rules from it. But it means
     // we cannot have the rule parameter given.
     if let Some(conf) = configuration_file {
-        use_configuration_file = true;
         ignore_gitignore = conf.ignore_gitignore.unwrap_or(false);
         if rules_file.is_some() {
             eprintln!("a rule file cannot be specified when a configuration file is present.");
@@ -265,7 +270,6 @@ fn main() -> Result<()> {
         max_file_size_kb = conf.max_file_size_kb.unwrap_or(DEFAULT_MAX_FILE_SIZE_KB);
         ignore_generated_files = conf.ignore_generated_files.unwrap_or(true);
     } else {
-        use_configuration_file = false;
         // if there is no config file, we take the default rules from our APIs.
         if rules_file.is_none() {
             println!("WARNING: no configuration file detected, getting the default rules from the Datadog API");
@@ -336,7 +340,7 @@ fn main() -> Result<()> {
     // build the configuration object that contains how the CLI should behave.
     let configuration = CliConfiguration {
         use_debug,
-        use_configuration_file,
+        configuration_method,
         ignore_gitignore,
         source_directory: directory_to_analyze.clone(),
         source_subdirectories: subdirectories_to_analyze.clone(),

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -222,11 +222,9 @@ fn main() -> Result<()> {
     let configuration_file_and_method = get_config(directory_to_analyze.as_str(), use_debug);
 
     let (configuration_file, configuration_method): (Option<ConfigFile>, Option<ConfigMethod>) =
-        match &configuration_file_and_method {
+        match configuration_file_and_method {
             Ok(cfg) => match cfg {
-                Some((config_file, config_method)) => {
-                    (Some(config_file.clone()), Some(config_method.clone()))
-                }
+                Some((config_file, config_method)) => (Some(config_file), Some(config_method)),
                 _ => (None, None),
             },
             Err(err) => {

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -3,7 +3,7 @@ use crate::datadog_utils::{get_remote_configuration, should_use_datadog_backend}
 use crate::git_utils::get_repository_url;
 use anyhow::{anyhow, Context, Result};
 use kernel::config_file::parse_config_file;
-use kernel::model::config_file::ConfigFile;
+use kernel::model::config_file::{ConfigFile, ConfigMethod};
 use kernel::utils::{decode_base64_string, encode_base64_string};
 use std::fs::File;
 use std::io::Read;
@@ -76,7 +76,7 @@ pub fn read_config_file_in_base64(path: &str) -> Result<Option<String>> {
 /// - If the user is a Datadog user (e.g. with API keys), we fetch the remote configuration
 ///   and merge it
 /// - If not, we just return the configuration
-pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
+pub fn get_config(path: &str, debug: bool) -> Result<Option<(ConfigFile, ConfigMethod)>> {
     let config_file = read_config_file(path);
     let repository_url_opt = get_repository_url(path);
 
@@ -103,11 +103,13 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
                     let remote_config_string =
                         decode_base64_string(rc).expect("error when decoding base64");
                     match parse_config_file(remote_config_string.as_str()) {
-                        Ok(remote_config) => Some(remote_config),
+                        Ok(remote_config) => {
+                            Some((remote_config, ConfigMethod::RemoteConfiguration))
+                        }
                         Err(e) => {
                             eprintln!("Error when parsing remote config: {:?}", e);
                             eprintln!("Proceeding with local config");
-                            cf
+                            cf.map(|c| (c, ConfigMethod::File))
                         }
                     }
                 }
@@ -116,14 +118,14 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<ConfigFile>> {
                         eprintln!("Error when attempting to fetch the remote config: {:?}", e);
                         eprintln!("Falling back to the local configuration, if any")
                     }
-                    cf
+                    cf.map(|c| (c, ConfigMethod::File))
                 }
             }
         } else {
             if debug {
                 eprintln!("not attempting to use remote configuration");
             }
-            cf
+            cf.map(|c| (c, ConfigMethod::File))
         }
     })
 }

--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -115,8 +115,11 @@ pub fn get_config(path: &str, debug: bool) -> Result<Option<(ConfigFile, ConfigM
                             Some((remote_config, config_method))
                         }
                         Err(e) => {
-                            eprintln!("Error when parsing remote config: {:?}", e);
-                            eprintln!("Proceeding with local config");
+                            if debug {
+                                eprintln!("Error when parsing remote config: {:?}", e);
+                                eprintln!("Proceeding with local config");
+                            }
+
                             cf.map(|c| (c, ConfigMethod::File))
                         }
                     }

--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -35,6 +35,7 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "RUBY",
     "TYPESCRIPT",
     "PHP",
+    "YAML",
 ];
 
 // Get secrets rules from the static analysis API

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -492,7 +492,7 @@ mod tests {
         files1.push(d);
         let cli_configuration = CliConfiguration {
             use_debug: true,
-            use_configuration_file: true,
+            configuration_method: None,
             ignore_gitignore: true,
             source_directory: "bla".to_string(),
             source_subdirectories: vec![],

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use common::model::diff_aware::DiffAware;
 use git2::Repository;
 use kernel::model::common::OutputFormat;
-use kernel::model::config_file::PathConfig;
+use kernel::model::config_file::{ConfigMethod, PathConfig};
 use kernel::rule_config::RuleConfigProvider;
 use sha2::{Digest, Sha256};
 
@@ -15,7 +15,7 @@ use secrets::model::secret_rule::SecretRule;
 #[derive(Clone)]
 pub struct CliConfiguration {
     pub use_debug: bool,
-    pub use_configuration_file: bool,
+    pub configuration_method: Option<ConfigMethod>,
     pub ignore_gitignore: bool,
     pub source_directory: String,
     pub source_subdirectories: Vec<String>,
@@ -142,7 +142,7 @@ mod tests {
     fn test_generate_diff_aware_hash() {
         let cli_configuration = CliConfiguration {
             use_debug: true,
-            use_configuration_file: true,
+            configuration_method: None,
             ignore_gitignore: true,
             source_directory: "bla".to_string(),
             source_subdirectories: vec![],
@@ -203,7 +203,7 @@ mod tests {
 
         let cli_configuration_base = CliConfiguration {
             use_debug: true,
-            use_configuration_file: true,
+            configuration_method: None,
             ignore_gitignore: true,
             source_directory: "bla".to_string(),
             source_subdirectories: vec![],

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -30,6 +30,7 @@ pub fn print_configuration(configuration: &CliConfiguration) {
     let configuration_method = match configuration.configuration_method {
         None => "none (no local file and no remote configuration)",
         Some(ConfigMethod::RemoteConfiguration) => "remote configuration",
+        Some(ConfigMethod::RemoteConfigurationWithFile) => "remote configuration + local file",
         Some(ConfigMethod::File) => "local config file (static-analysis.datadog.[yml|yaml])",
     };
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,9 +1,9 @@
-use kernel::constants::{CARGO_VERSION, VERSION};
-use kernel::model::common::OutputFormat;
-
 use crate::constants::DEFAULT_MAX_CPUS;
 use crate::model::cli_configuration::CliConfiguration;
 use crate::rule_utils::get_languages_for_rules;
+use kernel::constants::{CARGO_VERSION, VERSION};
+use kernel::model::common::OutputFormat;
+use kernel::model::config_file::ConfigMethod;
 
 /// Returns the user's requested core count, clamped to the number of logical cores on the system.
 /// If unspecified, up to [DEFAULT_MAX_CPUS] CPUs will be used.
@@ -27,10 +27,10 @@ pub fn get_num_threads_to_use(configuration: &CliConfiguration) -> usize {
 }
 
 pub fn print_configuration(configuration: &CliConfiguration) {
-    let configuration_method = if configuration.use_configuration_file {
-        "config file (static-analysis.datadog.[yml|yaml])"
-    } else {
-        "rule file"
+    let configuration_method = match configuration.configuration_method {
+        None => "none (no local file and no remote configuration)",
+        Some(ConfigMethod::RemoteConfiguration) => "remote configuration",
+        Some(ConfigMethod::File) => "local config file (static-analysis.datadog.[yml|yaml])",
     };
 
     let output_format_str = match configuration.output_format {
@@ -84,10 +84,6 @@ pub fn print_configuration(configuration: &CliConfiguration) {
     println!(
         "ignore gitignore       : {}",
         configuration.ignore_gitignore
-    );
-    println!(
-        "use config file        : {}",
-        configuration.use_configuration_file
     );
     println!("use debug              : {}", configuration.use_debug);
     println!("use staging            : {}", configuration.use_staging);

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -94,6 +94,7 @@ pub struct RulesetConfig {
 pub enum ConfigMethod {
     File,
     RemoteConfiguration,
+    RemoteConfigurationWithFile,
 }
 
 // The parsed configuration file without any legacy fields.

--- a/crates/static-analysis-kernel/src/model/config_file.rs
+++ b/crates/static-analysis-kernel/src/model/config_file.rs
@@ -90,6 +90,12 @@ pub struct RulesetConfig {
     pub rules: IndexMap<String, RuleConfig>,
 }
 
+#[derive(Debug, Clone)]
+pub enum ConfigMethod {
+    File,
+    RemoteConfiguration,
+}
+
 // The parsed configuration file without any legacy fields.
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct ConfigFile {


### PR DESCRIPTION
## What problems are you trying to solve?

1. Default YAML rules are not being pulled
2. We do not show how the analyzer is configured when using remote configuration.

## What is your solution?

1. Add a `ConfigMethod` that indicates how the analyzer is configured (file, remote or nothing)
2. Add YAML in the list of default languages


## Testing

With no remote config or file

```
Configuration
=============
version                : 0.4.2
revision               : development
config method          : none (no local file and no remote configuration)
cores available        : 10
cores used             : 8
#static analysis rules : 880
source directory       : /Users/julien.delange/git/tree-sitter-xml
subdirectories         :
output file            : /Users/julien.delange/test.sarif
secrets enabled        : false
output format          : sarif
ignore paths           : Cargo.lock,target/,build/,prebuilds/,node_modules/,.build/,Package.resolved,go.sum,_obj/,.venv/,dist/,*.egg-info,*.whl,*.a,*.so,*.so.*,*.dylib,*.dll,*.pc,/examples/*/,dsl.d.ts,*.wasm,*.obj,*.o,**/node_modules/**/*,**/jspm_packages/**/*,**/.next/**/*,**/.vuepress/**/*,**/venv/**/*,**/__pycache__/**/*,**/_vendor/bundle/ruby/**/*,**/.vendor/bundle/ruby/**/*,**/.bundle/**/*,**/.gradle/**/*
only paths             : all paths
ignore gitignore       : false
use debug              : false
use staging            : true
ignore gen files       : true
rules languages        : ruby,python,dockerfile,go,yaml,c#,php,javascript,java,typescript
max file size          : 200 kb
```


With remote config

```
Configuration
=============
version                : 0.4.2
revision               : development
config method          : remote configuration
cores available        : 10
cores used             : 8
#static analysis rules : 98
source directory       : /Users/julien.delange/git/datadog-static-analyzer
subdirectories         :
output file            : /Users/julien.delange/test.sarif
secrets enabled        : false
output format          : sarif
ignore paths           : debug/,target/,Cargo.lock,**/*.rs.bk,*.pdb,*~,crates/static-analysis-kernel/.vendor/,.idea,venv,**/node_modules/**/*,**/jspm_packages/**/*,**/.next/**/*,**/.vuepress/**/*,**/venv/**/*,**/__pycache__/**/*,**/_vendor/bundle/ruby/**/*,**/.vendor/bundle/ruby/**/*,**/.bundle/**/*,**/.gradle/**/*
only paths             : all paths
ignore gitignore       : false
use debug              : false
use staging            : true
ignore gen files       : true
rules languages        : go,python
max file size          : 200 kb
Analyzing 2 Python files using 59 rules
```


With local config

```
Configuration
=============
version                : 0.4.2
revision               : development
config method          : local config file (static-analysis.datadog.[yml|yaml])
cores available        : 10
cores used             : 8
#static analysis rules : 59
source directory       : /Users/julien.delange/git/tree-sitter-xml
subdirectories         :
output file            : /Users/julien.delange/test.sarif
secrets enabled        : false
output format          : sarif
ignore paths           : Cargo.lock,target/,build/,prebuilds/,node_modules/,.build/,Package.resolved,go.sum,_obj/,.venv/,dist/,*.egg-info,*.whl,*.a,*.so,*.so.*,*.dylib,*.dll,*.pc,/examples/*/,dsl.d.ts,*.wasm,*.obj,*.o,**/node_modules/**/*,**/jspm_packages/**/*,**/.next/**/*,**/.vuepress/**/*,**/venv/**/*,**/__pycache__/**/*,**/_vendor/bundle/ruby/**/*,**/.vendor/bundle/ruby/**/*,**/.bundle/**/*,**/.gradle/**/*
only paths             : all paths
ignore gitignore       : false
use debug              : false
use staging            : true
ignore gen files       : true
rules languages        : python
max file size          : 200 kb

```