### PR TITLE
chore(integration-tests): require minimum results to be at least 2

### DIFF
--- a/misc/integration-test-docker.sh
+++ b/misc/integration-test-docker.sh
@@ -21,7 +21,7 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
 
 echo "Found $RES errors on first run"
 
-if [ "$RES" -lt "12" ]; then
+if [ "$RES" -lt "2" ]; then
   echo "not enough errors found without the static-analysis.datadog.yml file"
   exit 1
 fi

--- a/misc/integration-test-js-ts.sh
+++ b/misc/integration-test-js-ts.sh
@@ -28,8 +28,8 @@ fi
 
 FINDINGS=`jq '.runs[0].results|length' ${REPO_DIR}/results.json`
 echo "Found $FINDINGS violations"
-if [ $FINDINGS -lt 10 ]; then
-  echo "only $FINDINGS found, expected at least 10 findings"
+if [ $FINDINGS -lt 2 ]; then
+  echo "only $FINDINGS found, expected at least 2 findings"
   exit 1
 fi
 

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -21,7 +21,7 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
 
 echo "Found $RES errors on first run"
 
-if [ "$RES" -lt "18" ]; then
+if [ "$RES" -lt "2" ]; then
   echo "not enough errors found"
   exit 1
 fi
@@ -44,7 +44,7 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
 
 echo "Found $RES errors on second run"
 
-if [ "$RES" -lt "18" ]; then
+if [ "$RES" -lt "2" ]; then
   echo "not enough errors found"
   exit 1
 fi


### PR DESCRIPTION
## What problem are you trying to solve?

As mentioned earlier, rules are subject to constant updates and changes to mitigate false positives or improve performance. Our current integration scripts check for an *exact* number of violations to be flagged, which is really brittle, as changing one rule can change this number easily if the change is mitigating false positives.

## What is your solution?

We should only check that a bare minimum number of results are detected. For example, if we're detecting around ~20, we can safely assume that we will *always* have at least 2 results. This logic was implemented in #505 with the addition of new integration tests, but we should also update the existing ones to follow this logic.

## Alternatives considered

## What the reviewer should know

The integration scripts for python, docker, and js-ts were all updated to check for a bare minimum of 2 violations, instead of the exact number of violations detected at the time the script was created.
