### PR TITLE
[STAL-2577] feat: pin rust toolchain to 1.80.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.80.1"


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we do not pin the Rust toolchain to a specific version when building and deploying the analyzer. This is not ideal since we'd like our builds to be reproducible across different machines that might have different default toolchain versions set.

## What is your solution?

Adding a [`rust-toolchain.toml`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) file will allow us to pin the version used to build the analyzer, meaning that no matter what machine or OS version we build it on, it will always use this version.

## Alternatives considered

## What the reviewer should know
