### PR TITLE
Clean up serialization of violations on the server.

### DIFF
--- a/crates/static-analysis-kernel/src/model/violation.rs
+++ b/crates/static-analysis-kernel/src/model/violation.rs
@@ -18,7 +18,6 @@ pub enum EditType {
 pub struct Edit {
     pub start: Position,
     pub end: Option<Position>,
-    #[serde(rename = "editType")]
     pub edit_type: EditType,
     pub content: Option<String>,
 }

--- a/crates/static-analysis-server/src/model/violation.rs
+++ b/crates/static-analysis-server/src/model/violation.rs
@@ -1,67 +1,19 @@
-use common::model::position::Position;
-use kernel::model::rule::{RuleCategory, RuleSeverity};
-
-use derive_builder::Builder;
-use kernel::model::violation::{Edit, EditType, Fix, Violation};
+use kernel::model::violation::Violation;
 use serde::{Deserialize, Serialize};
 
-/// because of our naming conventions that mix camelCase in the JS code
-/// and other parts of rosie adn the snake_case that got adopted for our
-/// API, we need to have a model for the server that exposes only
-/// snake_case data.
-///
-/// Therefore, for each data type from the model in the kernel, we duplicate
-/// the classes and make sure the casing follows what is expected.
-#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
-pub struct ServerEdit {
-    pub start: Position,
-    pub end: Option<Position>,
-    pub edit_type: EditType,
-    pub content: Option<String>,
-}
+/// A newtype [`Violation`] that provides a custom serialization for the server.
+#[derive(Deserialize, Debug, Serialize, Clone)]
+#[serde(transparent)]
+pub struct ServerViolation(pub Violation);
 
-#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
-pub struct ServerFix {
-    pub description: String,
-    pub edits: Vec<ServerEdit>,
-}
-
-#[derive(Deserialize, Debug, Serialize, Clone, Builder)]
-pub struct ServerViolation {
-    pub start: Position,
-    pub end: Position,
-    pub message: String,
-    pub severity: RuleSeverity,
-    pub category: RuleCategory,
-    pub fixes: Vec<ServerFix>,
-}
-
-/// Transform an edit from the kernel into an edit that is surfaced by the server.
-pub fn edit_to_server(edit: &Edit) -> ServerEdit {
-    ServerEdit {
-        start: edit.start,
-        end: edit.end,
-        edit_type: edit.edit_type,
-        content: edit.content.clone(),
+impl From<Violation> for ServerViolation {
+    fn from(value: Violation) -> Self {
+        Self(value)
     }
 }
 
-/// Transform a fix from the kernel data model into a fix that is surfaced by the server.
-pub fn fix_to_server(fix: &Fix) -> ServerFix {
-    ServerFix {
-        description: fix.description.clone(),
-        edits: fix.edits.iter().map(edit_to_server).collect(),
-    }
-}
-
-/// Transform a violation from the kernel data model into what is surfaced by the server.
-pub fn violation_to_server(violation: &Violation) -> ServerViolation {
-    ServerViolation {
-        start: violation.start,
-        end: violation.end,
-        message: violation.message.clone(),
-        severity: violation.severity,
-        category: violation.category,
-        fixes: violation.fixes.iter().map(fix_to_server).collect(),
+impl<'a> From<&'a Violation> for ServerViolation {
+    fn from(value: &'a Violation) -> Self {
+        Self(value.clone())
     }
 }

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -5,7 +5,7 @@ use crate::constants::{
 };
 use crate::model::analysis_request::{AnalysisRequest, ServerRule};
 use crate::model::analysis_response::{AnalysisResponse, RuleResponse};
-use crate::model::violation::violation_to_server;
+use crate::model::violation::ServerViolation;
 use common::analysis_options::AnalysisOptions;
 use kernel::analysis::analyze::{analyze, DEFAULT_JS_RUNTIME};
 use kernel::config_file::parse_config_file;
@@ -210,7 +210,7 @@ pub fn process_analysis_request(request: AnalysisRequest) -> AnalysisResponse {
         .iter()
         .map(|rr| RuleResponse {
             identifier: rr.rule_name.clone(),
-            violations: rr.violations.iter().map(violation_to_server).collect(),
+            violations: rr.violations.iter().map(ServerViolation::from).collect(),
             errors: rr.errors.clone(),
             execution_error: rr.execution_error.clone(),
             output: rr.output.clone(),
@@ -700,6 +700,7 @@ function visit(node, filename, code) {
         assert_eq!(1, response.rule_responses.len());
         assert_eq!(1, response.rule_responses[0].violations.len());
         assert!(response.rule_responses[0].violations[0]
+            .0
             .message
             .contains("argument = 101"));
     }
@@ -745,11 +746,11 @@ function visit(node, filename, code) {
         assert_eq!(1, response.rule_responses[0].violations.len());
         assert_eq!(
             RuleCategory::BestPractices,
-            response.rule_responses[0].violations[0].category
+            response.rule_responses[0].violations[0].0.category
         );
         assert_eq!(
             RuleSeverity::Warning,
-            response.rule_responses[0].violations[0].severity
+            response.rule_responses[0].violations[0].0.severity
         );
 
         // Override severity and category.
@@ -773,11 +774,11 @@ rulesets:
         assert_eq!(1, response.rule_responses[0].violations.len());
         assert_eq!(
             RuleCategory::CodeStyle,
-            response.rule_responses[0].violations[0].category
+            response.rule_responses[0].violations[0].0.category
         );
         assert_eq!(
             RuleSeverity::Error,
-            response.rule_responses[0].violations[0].severity
+            response.rule_responses[0].violations[0].0.severity
         );
 
         // Per-path severity override.
@@ -805,11 +806,11 @@ rulesets:
         assert_eq!(1, response.rule_responses[0].violations.len());
         assert_eq!(
             RuleCategory::CodeStyle,
-            response.rule_responses[0].violations[0].category
+            response.rule_responses[0].violations[0].0.category
         );
         assert_eq!(
             RuleSeverity::Notice,
-            response.rule_responses[0].violations[0].severity
+            response.rule_responses[0].violations[0].0.severity
         );
     }
 


### PR DESCRIPTION
## What problem are you trying to solve?
For our taint analysis implementation, we need to refactor the [`Violation`](https://github.com/DataDog/datadog-static-analyzer/blob/53912808d8fabfa1e6870f4753921d4cd070f43b/crates/static-analysis-kernel/src/model/violation.rs#L33) struct to be able to represent both single region (what we support currently) violations as well as "code flow" violations.

While doing so, I noticed that `ServerViolation` is a manual copy of Violation, created so we  can serialize the values differently on the server. This is no longer necessary, so we might as well clean it up.

## What is your solution?
`ServerViolation` was introduced because we needed the `edit_type` serialization to remain snake_case, but the kernel needed it to be camelCase so `serde_v8` could [parse stella violations](https://github.com/DataDog/datadog-static-analyzer/blob/0fd7ca4ebb379706267e8da68598e1d557e73836/crates/static-analysis-kernel/src/analysis/javascript.rs#L241).

This was made unnecessary by https://github.com/DataDog/datadog-static-analyzer/pull/382, which [changed the naming away from "editType"](https://github.com/DataDog/datadog-static-analyzer/pull/382/files#diff-96846e03f040296c97f5e8eb6e120ac71ebbfc500a147f36fa9b41bd8de25351L30).

## Alternatives considered

## What the reviewer should know
* There is no change to serialization behavior. This is just a code clean-up.
* Rather than remove "ServerViolation" altogether, we'll need a transition period where we maintain the old API for accessing "start" and "end".