### PR TITLE
[STAL-2781] Build release Linux binary on Ubuntu 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@ jobs:
           # Ubuntu
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            image: ubuntu:20.04
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            image: ubuntu:20.04
           # Mac OS
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -35,7 +37,22 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.image || '' }}
+      options: --privileged
     steps:
+      - name: Configure container
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          apt-get update
+          apt-get --no-install-recommends install -y build-essential ca-certificates curl git jq wget zip
+          mkdir -p -m 755 /etc/apt/keyrings
+          wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          apt-get update
+          apt-get install gh -y
+          git config --global --add safe.directory $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       - name: Install Stable + Rustfmt + Clippy
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## What problem are you trying to solve?
We currently compile our Linux release binaries on GitHub's `ubuntu-latest` runner, which resolves to ubuntu 24.04. Because 24.04 uses a newer version of glibc, it compiles binaries that expect more recent versions of glibc (currently, v8 expects `pthread_getattr_np@GLIBC_2.32`). This leads to an error when trying to run the binary on older versions of Linux (specifically Ubuntu 20.04, which ships with glibc 2.31)

<img width="727" alt="Image of a failed attempt to execute the binary on Ubuntu 20.04" src="https://github.com/user-attachments/assets/830ceec3-8e5e-4778-a65f-f4f417dc6d10">

## What is your solution?
Building on Ubuntu 20.04 generates a binary that now expects glibc 2.2.5:
```sh
❯ greadelf -a datadog-static-analyzer-server | grep pthread_getattr_np
000003efe688  011700000006 R_X86_64_GLOB_DAT 0000000000000000 pthread_getattr_np@GLIBC_2.2.5 + 0
```

And thus the binaries now work on Ubuntu 20.04.

You can confirm that this modification to the release workflow functions correctly by looking at [a pre-release](https://github.com/DataDog/datadog-static-analyzer/releases/tag/vSTAL-2781) that I just generated to test it:
<img width="466" alt="image" src="https://github.com/user-attachments/assets/f4cea864-f214-4218-8980-9c73dbffc168">
<img width="364" alt="image" src="https://github.com/user-attachments/assets/9894225b-0bfc-4961-8fd3-f5fae4e97eba">

We need to add an extra step to set up the container, as the base image is missing the packages that GitHub installs by default on a non-containerized runner (curl, gh, etc).

## Alternatives considered

## What the reviewer should know
* I only modified the release.yml to build on Ubuntu 20.04 -- all of the integration tests will still build/run on `ubuntu-latest` (currently 24.04). Assuming glibc doesn't have forward-compatibility issues, this setup is fine.
* glibc has backwards compatibility for the APIs we're using, so this runs on 22.04 (glibc 2.35), 24.04 (glibc 2.39)