### PR TITLE
[STAL-2698] Handle effectively infallible v8 call failures

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/query_match.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/query_match.rs
@@ -4,7 +4,7 @@
 
 use crate::analysis;
 use crate::analysis::ddsa_lib::common::{
-    load_function, v8_interned, Class, DDSAJsRuntimeError, Instance, NodeId, StellaCompat,
+    load_function, swallow_v8_error, v8_interned, Class, DDSAJsRuntimeError, NodeId, StellaCompat,
 };
 use crate::analysis::ddsa_lib::js::capture::{MultiCaptureTemplate, SingleCaptureTemplate};
 use crate::analysis::ddsa_lib::js::TreeSitterNodeFn;
@@ -51,7 +51,7 @@ rust_converter!(
         self.class
             .open(scope)
             .new_instance(scope, &args[..])
-            .expect("class constructor should not throw")
+            .unwrap_or_else(|| swallow_v8_error(|| v8::Object::new(scope)))
             .into()
     }
 );

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/query_match_compat.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/query_match_compat.rs
@@ -3,7 +3,7 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::ddsa_lib::common::{
-    load_function, Class, DDSAJsRuntimeError, NodeId, StellaCompat,
+    load_function, swallow_v8_error, Class, DDSAJsRuntimeError, NodeId, StellaCompat,
 };
 use crate::analysis::ddsa_lib::js::QueryMatch;
 use crate::analysis::ddsa_lib::v8_ds::RustConverter;
@@ -27,7 +27,7 @@ rust_converter!(
         self.class
             .open(scope)
             .new_instance(scope, &args[..])
-            .expect("class constructor should not throw")
+            .unwrap_or_else(|| swallow_v8_error(|| v8::Object::new(scope)))
             .into()
     }
 );

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
@@ -3,7 +3,7 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::ddsa_lib::common::{
-    load_function, v8_uint, Class, DDSAJsRuntimeError, Instance, NodeId,
+    load_function, swallow_v8_error, v8_uint, Class, DDSAJsRuntimeError, Instance, NodeId,
 };
 use deno_core::v8;
 use deno_core::v8::HandleScope;
@@ -82,7 +82,7 @@ impl TreeSitterNodeFn<Class> {
         self.0
             .open(scope)
             .new_instance(scope, &args[..])
-            .expect("class constructor should not throw")
+            .unwrap_or_else(|| swallow_v8_error(|| v8::Object::new(scope)))
     }
 }
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/ops.rs
@@ -104,8 +104,7 @@ pub fn op_ts_node_named_children<'s>(
         None
     } else {
         let ids_buf = v8::ArrayBuffer::new(scope, 4 * count * 2);
-        let uint_array = v8::Uint32Array::new(scope, ids_buf, 0, count * 2)
-            .expect("v8 Uint32Array should be able to be created");
+        let uint_array = v8::Uint32Array::new(scope, ids_buf, 0, count * 2)?;
         let mut bridge_ref = ts_node_bridge.borrow_mut();
 
         let mut cursor = ts_node.walk();


### PR DESCRIPTION
## What problem are you trying to solve?
We currently assume that because we can guarantee valid input to certain v8 functions, that those functions are infallible, and so we unwrap the returned Option ([example 1](https://github.com/DataDog/datadog-static-analyzer/blob/139add50679acb6205e47516e415bae3f5c86711/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs#L85), [example 2](https://github.com/DataDog/datadog-static-analyzer/blob/139add50679acb6205e47516e415bae3f5c86711/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs#L153)).

However, this isn't always the case. In particular, there is a race condition where:
1. JavaScript is executing and calls into Rust via a `deno_core` op
2. The execution thread enters the deno op.
3. The [watchdog thread](https://github.com/DataDog/datadog-static-analyzer/blob/139add50679acb6205e47516e415bae3f5c86711/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs#L437) sends [`terminate_execution`](https://docs.rs/rusty_v8/0.32.1/rusty_v8/struct.IsolateHandle.html#method.terminate_execution) to the v8 isolate, causing further calls to that isolate to fail until [`cancel_terminate_execution`](https://docs.rs/rusty_v8/0.32.1/rusty_v8/struct.IsolateHandle.html#method.cancel_terminate_execution) is called.
4. The op makes a fallible call to v8.

## What is your solution?
Instead of unwrapping the Option for fallible v8 calls, we either ignore the failure or substitute it with an uninitialized value (null, an empty object, etc). This is done via an explicit function: [swallow_v8_error](https://github.com/DataDog/datadog-static-analyzer/blob/4ff4f29b5d4d2271c4ecd69794bc8ef2924f535c/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs#L354-L376) (see for in-depth documentation).

# Before
I ran the analyzer on a monorepo with over 20k files using a timeout duration of `1 ms`. About 3 seconds (~100 rule executions) into analysis, the race condition triggered, causing an panic:
<img width="837" alt="image" src="https://github.com/user-attachments/assets/db26c1b4-5e02-4ec4-803c-c2f886c29cff">

# After
I ran the analyzer on the same monorepo with the same timeout duration and logged the number of timeouts.
<img width="436" alt="image" src="https://github.com/user-attachments/assets/7f79d940-9d4e-4242-bd9c-5451ad2d363d">
This PR shows a 100% success rate in timing out v8 without panics: (over 57k timed out rule executions in this case)

## Alternatives considered

## What the reviewer should know
* There are still some places we unwrap v8 calls -- [for example here](https://github.com/DataDog/datadog-static-analyzer/blob/4ff4f29b5d4d2271c4ecd69794bc8ef2924f535c/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/context_root.rs#L40). This is because calls like this are performed only _once_ upon the runtime initialization, and all future JavaScript rule executions depend on that call not failing.