### PR TITLE
Pin workflow to @actions/core@1.10.1

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -4,7 +4,7 @@
   "main": "check-regressions.js",
   "type": "module",
   "dependencies": {
-    "@actions/core": "^1.10.1",
+    "@actions/core": "1.10.1",
     "@actions/github": "^6.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## What problem are you trying to solve?
Our regression check JavaScript script [specifies](https://github.com/DataDog/datadog-static-analyzer/blob/f3f1dcb4983b0a0b05ea7849bc909f453d342015/.github/scripts/package.json#L7) `@actions/core@^1.10.6` as a dependency. Two days ago, v1.11.0 was released, and this breaks our workflow with the following error:

<img width="748" alt="image" src="https://github.com/user-attachments/assets/078599e9-a7fe-4294-bbbd-90963f4972ca">

(I artificially introduced this regression -- [job here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/11186357324/job/31101218604))

The upstream issue of note is https://github.com/actions/toolkit/issues/1841. It seems upgrading to Node 20 would also solve this for us, but pinning seems more prudent at the moment.

## What is your solution?

Pin to exactly `1.10.6`.

Re-running the job shows it now works:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/080a383a-af6f-4adf-8b38-f48bf1a6ef7c">


## Alternatives considered

## What the reviewer should know
* This is triggered only when there is a detection regression in a PR.