### PR TITLE
[STAL-2713] Add taint propagation within string collections

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.js
@@ -1870,6 +1870,12 @@ function findFieldIndex(children, start, fieldName) {
 const PROPAGATORS = [
     // java.util.List<String>
     { simpleClassName: "List<String>", instanceMethods: ["add", "addAll", "set"] },
+    // java.lang.StringBuilder
+    { simpleClassName: "StringBuilder", instanceMethods: ["append", "insert", "replace"] },
+    // java.lang.StringBuffer
+    { simpleClassName: "StringBuffer", instanceMethods: ["append", "insert", "replace"] },
+    // java.lang.StringJoiner
+    { simpleClassName: "StringJoiner", instanceMethods: ["add", "merge"] },
 ];
 
 /**

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.rs
@@ -1032,9 +1032,11 @@ void method() {
     /// Common types that either build a string or collection of strings propagate taint and redefine the identifier.
     #[test]
     fn string_collection_types_redefinition() {
-        #[rustfmt::skip]
         let cases = &[
             ("java.util.List<String>", "ArrayList<String>()", "add"),
+            ("java.lang.StringBuilder", "StringBuilder()", "append"),
+            ("java.lang.StringBuffer", "StringBuffer()", "append"),
+            ("java.util.StringJoiner", "StringJoiner(\":\")", "add"),
         ];
         for (class_name, constructor, method) in cases {
             let java_code = format!(


### PR DESCRIPTION
## What problem are you trying to solve?
Taint can propagate via the use of a tainted string within a string collection. For example:
```java
StringBuilder y = new StringBuilder("https://api.example.com/?param=");
y.append(userInput);
// Here, y should be considered tainted.
```

## What is your solution?
Model taint propagation via mutable variables.

This is implemented as a [generic abstraction](https://github.com/DataDog/datadog-static-analyzer/blob/bf4930313e957d28f9c19615b084b1bee4c47378/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.js#L2046-L2056), and a class and its taint-propagating methods need to be specified.

This PR adds handlers for:
* `java.util.List<String>`
* `java.lang.StringBuilder`
* `java.lang.StringBuffer`
* `java.lang.StringJoiner`

## Alternatives considered

## What the reviewer should know
