### PR TITLE
[STAL-3002] Only use `latest` tag on ghcr for stable releases

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -41,6 +41,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease && github.event_name == 'release' }}
+            type=ref,event=tag
+            type=sha
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
## What problem are you trying to solve?
Currently, when a pre-release is published, it is marked with the `latest` tag on GHCR:

> <img width="791" alt="image" src="https://github.com/user-attachments/assets/6b7b8063-2280-4272-adf7-0b6b75e0fffc">

> <img width="519" alt="image" src="https://github.com/user-attachments/assets/b322c968-9428-4db7-9370-9173272e374b">

Pre-release is intended for us to be able to test an image internally before publishing, so this behavior is unexpected.

## What is your solution?
* Only assign the `latest` tag when the release is _not_ a pre-release.
* Additionally, add a commit SHA tag to the image.

> <img width="753" alt="image" src="https://github.com/user-attachments/assets/0e9c0176-43d0-4665-a93e-4917bbd68408">

> <img width="573" alt="image" src="https://github.com/user-attachments/assets/e7b30a6b-7ff1-47ec-89a8-b5b5fa028a53">


## Alternatives considered

## What the reviewer should know
* The git tag is still used as one of the docker image tags, so our current method of tagging with a number like `0.3.5` will continue to function the same.