### PR TITLE
[STAL-2964] Validate and export validation status in SARIF

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,6 +4,7 @@ base64,https://github.com/marshallpierce/rust-base64,Apache-2.0,Copyright (c) 20
 bstr,https://github.com/BurntSushi/bstr,MIT,Copyright (c) 2018-2019 Andrew Gallant
 csv,https://github.com/BurntSushi/rust-csv,MIT,Copyright (c) 2015 Andrew Gallant
 deno-core,https://github.com/denoland/deno,MIT,Copyright 2018-2023 the Deno authors
+futures,https://rust-lang.github.io/futures-rs/,MIT,Copyright (c) 2017 The Tokio Authors
 git2,https://crates.io/crates/git2,MIT,Copyright (c) 2014 Alex Crichton
 globset,https://crates.io/crates/globset,MIT,Copyright (c) 2015 Andrew Gallant
 graphviz-rust,https://github.com/besok/graphviz-rust,MIT,Copyright (c) 2013 Boris Zhguchev

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -9,10 +9,10 @@ use walkdir::WalkDir;
 
 use kernel::model::common::Language;
 use kernel::model::config_file::PathConfig;
-use kernel::model::violation::Violation;
 
 use crate::model::cli_configuration::CliConfiguration;
 use crate::model::datadog_api::DiffAwareData;
+use crate::sarif::sarif_utils::SarifViolation;
 
 static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Csharp, &["cs"]),
@@ -304,7 +304,7 @@ pub fn filter_files_by_diff_aware_info(
 ///  SHA2(<file-location-in-repository> - <characters-in-directory> - <content-of-start-line> - <number of characters in start line>)
 pub fn get_fingerprint_for_violation(
     rule_name: String,
-    violation: &Violation,
+    violation: &SarifViolation,
     repository_root: &Path,
     file: &Path,
     use_debug: bool,
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn get_fingerprint_for_violation_success_single_region() {
         let d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let violation = Violation {
+        let violation = SarifViolation {
             start: Position { line: 10, col: 1 },
             end: Position { line: 12, col: 1 },
             message: "something bad happened".to_string(),
@@ -402,6 +402,7 @@ mod tests {
             category: RuleCategory::Performance,
             fixes: vec![],
             taint_flow: None,
+            validation_status: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
@@ -438,7 +439,7 @@ mod tests {
             end: Position { line: 5, col: 30 },
         };
         let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let violation = Violation {
+        let violation = SarifViolation {
             start: region0.start,
             end: region0.end,
             message: "flow violation".to_string(),
@@ -446,6 +447,7 @@ mod tests {
             category: RuleCategory::Security,
             fixes: vec![],
             taint_flow: Some(vec![region0, region1]),
+            validation_status: None,
         };
         let fingerprint = get_fingerprint_for_violation(
             "taint_flow_rule".to_string(),
@@ -468,7 +470,7 @@ mod tests {
         let d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let path = "resources/test/gitignore/test1";
 
-        let violation = Violation {
+        let violation = SarifViolation {
             start: Position { line: 10, col: 1 },
             end: Position { line: 12, col: 1 },
             message: "something bad happened".to_string(),
@@ -476,6 +478,7 @@ mod tests {
             category: RuleCategory::Performance,
             fixes: vec![],
             taint_flow: None,
+            validation_status: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
 

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -7,12 +7,11 @@ use anyhow::Result;
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
-use kernel::model::common::Language;
-use kernel::model::config_file::PathConfig;
-
 use crate::model::cli_configuration::CliConfiguration;
 use crate::model::datadog_api::DiffAwareData;
-use crate::sarif::sarif_utils::SarifViolation;
+use kernel::model::common::Language;
+use kernel::model::config_file::PathConfig;
+use kernel::model::violation::Violation;
 
 static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Csharp, &["cs"]),
@@ -304,7 +303,7 @@ pub fn filter_files_by_diff_aware_info(
 ///  SHA2(<file-location-in-repository> - <characters-in-directory> - <content-of-start-line> - <number of characters in start line>)
 pub fn get_fingerprint_for_violation(
     rule_name: String,
-    violation: &SarifViolation,
+    violation: &Violation,
     repository_root: &Path,
     file: &Path,
     use_debug: bool,
@@ -394,7 +393,7 @@ mod tests {
     #[test]
     fn get_fingerprint_for_violation_success_single_region() {
         let d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let violation = SarifViolation {
+        let violation = Violation {
             start: Position { line: 10, col: 1 },
             end: Position { line: 12, col: 1 },
             message: "something bad happened".to_string(),
@@ -402,7 +401,6 @@ mod tests {
             category: RuleCategory::Performance,
             fixes: vec![],
             taint_flow: None,
-            validation_status: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
@@ -439,7 +437,7 @@ mod tests {
             end: Position { line: 5, col: 30 },
         };
         let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let violation = SarifViolation {
+        let violation = Violation {
             start: region0.start,
             end: region0.end,
             message: "flow violation".to_string(),
@@ -447,7 +445,6 @@ mod tests {
             category: RuleCategory::Security,
             fixes: vec![],
             taint_flow: Some(vec![region0, region1]),
-            validation_status: None,
         };
         let fingerprint = get_fingerprint_for_violation(
             "taint_flow_rule".to_string(),
@@ -470,7 +467,7 @@ mod tests {
         let d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let path = "resources/test/gitignore/test1";
 
-        let violation = SarifViolation {
+        let violation = Violation {
             start: Position { line: 10, col: 1 },
             end: Position { line: 12, col: 1 },
             message: "something bad happened".to_string(),
@@ -478,7 +475,6 @@ mod tests {
             category: RuleCategory::Performance,
             fixes: vec![],
             taint_flow: None,
-            validation_status: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -5,12 +5,12 @@ use std::rc::Rc;
 use crate::constants::{SARIF_PROPERTY_DATADOG_FINGERPRINT, SARIF_PROPERTY_SHA};
 use anyhow::Result;
 use base64::Engine;
+use common::model::position::Position;
 use common::model::position::PositionBuilder;
-use common::model::position::{Position, Region};
 use git2::{BlameOptions, Repository};
 use kernel::constants::CARGO_VERSION;
 use kernel::model::rule::{RuleCategory, RuleSeverity};
-use kernel::model::violation::{Fix, Violation};
+use kernel::model::violation::Violation;
 use kernel::model::{
     rule::{Rule, RuleResult},
     violation::{Edit, EditType},
@@ -19,7 +19,6 @@ use path_slash::PathExt;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use secrets::model::secret_result::{SecretResult, SecretValidationStatus};
 use secrets::model::secret_rule::SecretRule;
-use serde::{Deserialize, Serialize};
 use serde_sarif::sarif::{
     self, ArtifactChangeBuilder, ArtifactLocationBuilder, FixBuilder, LocationBuilder,
     MessageBuilder, PhysicalLocationBuilder, PropertyBagBuilder, RegionBuilder, Replacement,
@@ -711,7 +710,7 @@ fn generate_results(
 
                     let fingerprint_option = get_fingerprint_for_violation(
                         rule_result.rule_name().to_string(),
-                        &violation,
+                        violation,
                         Path::new(options.repository_directory.as_str()),
                         Path::new(rule_result.file_path().as_str()),
                         options.debug,

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -11,7 +11,7 @@ use derive_builder::Builder;
 use git2::{BlameOptions, Repository};
 use kernel::constants::CARGO_VERSION;
 use kernel::model::rule::{RuleCategory, RuleSeverity};
-use kernel::model::violation::{Fix, Violation};
+use kernel::model::violation::{Fix};
 use kernel::model::{
     rule::{Rule, RuleResult},
     violation::{Edit, EditType},

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -11,7 +11,7 @@ use derive_builder::Builder;
 use git2::{BlameOptions, Repository};
 use kernel::constants::CARGO_VERSION;
 use kernel::model::rule::{RuleCategory, RuleSeverity};
-use kernel::model::violation::{Fix};
+use kernel::model::violation::Fix;
 use kernel::model::{
     rule::{Rule, RuleResult},
     violation::{Edit, EditType},
@@ -870,10 +870,9 @@ pub fn generate_sarif_file(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sarif::sarif_utils::SarifRule::SecretRule;
     use assert_json_diff::assert_json_eq;
     use common::model::position::{Position, PositionBuilder, Region};
-    use kernel::model::violation::Fix;
+    use kernel::model::violation::{Fix, Violation};
     use kernel::model::{
         common::Language,
         rule::{RuleBuilder, RuleCategory, RuleResultBuilder, RuleSeverity, RuleType},

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -11,6 +11,7 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+futures = "0.3"
 lazy_static = "1.5.0"
 
 # remote

--- a/crates/secrets/src/model/secret_result.rs
+++ b/crates/secrets/src/model/secret_result.rs
@@ -6,7 +6,7 @@ use common::model::position::Position;
 use sds::MatchStatus;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
 pub enum SecretValidationStatus {
     NotValidated,
     Valid,

--- a/crates/secrets/src/model/secret_result.rs
+++ b/crates/secrets/src/model/secret_result.rs
@@ -3,12 +3,35 @@
 // Copyright 2024 Datadog, Inc.
 
 use common::model::position::Position;
+use sds::MatchStatus;
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
+pub enum SecretValidationStatus {
+    NotValidated,
+    Valid,
+    Invalid,
+    ValidationError,
+    NotAvailable,
+}
+
+impl From<&MatchStatus> for SecretValidationStatus {
+    fn from(value: &MatchStatus) -> Self {
+        match value {
+            MatchStatus::NotChecked => SecretValidationStatus::NotValidated,
+            MatchStatus::Valid => SecretValidationStatus::Valid,
+            MatchStatus::Invalid => SecretValidationStatus::Invalid,
+            MatchStatus::Error(_) => SecretValidationStatus::ValidationError,
+            MatchStatus::NotAvailable => SecretValidationStatus::NotAvailable,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash, Eq)]
 pub struct SecretResultMatch {
     pub start: Position,
     pub end: Position,
+    pub validation_status: SecretValidationStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash, Eq)]

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -44,6 +44,10 @@ pub fn find_secrets(
     let mut codemut = code.to_owned();
     let mut matches = scanner.scan(&mut codemut, vec![]);
 
+    if matches.is_empty() {
+        return vec![];
+    }
+
     let matches_validation = futures::executor::block_on(scanner.validate_matches(&mut matches));
 
     if matches_validation.is_err() && options.use_debug {

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::model::secret_result::{SecretResult, SecretResultMatch};
+use crate::model::secret_result::{SecretResult, SecretResultMatch, SecretValidationStatus};
 use crate::model::secret_rule::SecretRule;
 use anyhow::Error;
 use common::analysis_options::AnalysisOptions;
@@ -32,16 +32,23 @@ pub fn find_secrets(
     sds_rules: &[SecretRule],
     filename: &str,
     code: &str,
-    _options: &AnalysisOptions,
+    options: &AnalysisOptions,
 ) -> Vec<SecretResult> {
     struct Result {
         rule_index: usize,
         start: Position,
         end: Position,
+        validation_status: SecretValidationStatus,
     }
 
     let mut codemut = code.to_owned();
-    let matches = scanner.scan(&mut codemut, vec![]);
+    let mut matches = scanner.scan(&mut codemut, vec![]);
+
+    let matches_validation = futures::executor::block_on(scanner.validate_matches(&mut matches));
+
+    if matches_validation.is_err() && options.use_debug {
+        eprintln!("error when validating secrets for filename {}", filename)
+    }
 
     matches
         .iter()
@@ -53,6 +60,7 @@ pub fn find_secrets(
                 rule_index: sds_match.rule_index,
                 start,
                 end,
+                validation_status: SecretValidationStatus::from(&sds_match.match_status),
             })
         })
         .group_by(|v| v.rule_index)
@@ -66,6 +74,7 @@ pub fn find_secrets(
                 .map(|v| SecretResultMatch {
                     start: v.start,
                     end: v.end,
+                    validation_status: v.validation_status,
                 })
                 .collect(),
         })

--- a/misc/integration-test-secrets.sh
+++ b/misc/integration-test-secrets.sh
@@ -26,6 +26,20 @@ if [ "$RES" -ne "2" ]; then
   exit 1
 fi
 
+status1=`jq '.runs[0].results[0].properties.tags[1]' "${REPO_DIR}/results1.json"`
+
+if [ "$status1" != "\"DATADOG_SECRET_VALIDATION_STATUS:NOT_AVAILABLE\"" ]; then
+  echo "did not find DATADOG_SECRET_VALIDATION_STATUS:NOT_AVAILABLE in properties, found $status1"
+  exit 1
+fi
+
+status2=`jq '.runs[0].results[1].properties.tags[1]' "${REPO_DIR}/results1.json"`
+
+if [ "$status2" != "\"DATADOG_SECRET_VALIDATION_STATUS:NOT_AVAILABLE\"" ]; then
+  echo "did not find DATADOG_SECRET_VALIDATION_STATUS:NOT_AVAILABLE in properties, found $status2"
+  exit 1
+fi
+
 echo "All tests passed"
 
 exit 0


### PR DESCRIPTION
## What problems are you trying to solve?

1. Validate the secrets
2. Show the validation status in SARIF

## What is your solution?

1. Run the validation when we find matches
2. Export the validation status in SARIF using a property
3. Adapt the severity of the rule based on the validation status

## What the reviewer should know

In order to export the validation status in SARIF, we introduce a struct called `SarifViolation`. The goal is to avoid introducing any secret-specific data in the `static-analysis-kernel` crate and keep it agnostic of the secret aspects.
