### PR TITLE
Add support for mjs/cjs extensions

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -25,7 +25,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Rust, &["rs"]),
     (Language::Swift, &["swift"]),
     (Language::Terraform, &["tf"]),
-    (Language::TypeScript, &["ts", "tsx"]),
+    (Language::TypeScript, &["ts", "tsx", "mts", "cts"]),
     (Language::Yaml, &["yml", "yaml"]),
     (Language::Starlark, &["bzl"]),
     (Language::Bash, &["sh", "bash"]),
@@ -742,7 +742,7 @@ mod tests {
         extensions_per_languages.insert(Language::Kotlin, 2);
         extensions_per_languages.insert(Language::Python, 2);
         extensions_per_languages.insert(Language::Rust, 1);
-        extensions_per_languages.insert(Language::TypeScript, 2);
+        extensions_per_languages.insert(Language::TypeScript, 4);
         extensions_per_languages.insert(Language::Dockerfile, 2);
         extensions_per_languages.insert(Language::Yaml, 2);
         extensions_per_languages.insert(Language::Starlark, 1);
@@ -800,6 +800,22 @@ mod tests {
                     PathBuf::from("path").join(PathBuf::from("foo/bar/baz.kjs"))
                 ],
                 &Language::JavaScript
+            )
+            .len()
+        );
+    }
+
+    #[test]
+    fn test_javascript_mts_cts_support() {
+        assert_eq!(
+            2,
+            filter_files_for_language(
+                &[
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.cts")),
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.mts")),
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.kts"))
+                ],
+                &Language::TypeScript
             )
             .len()
         );

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -18,7 +18,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Dockerfile, &["docker", "dockerfile"]),
     (Language::Go, &["go"]),
     (Language::Java, &["java"]),
-    (Language::JavaScript, &["js", "jsx"]),
+    (Language::JavaScript, &["js", "jsx", "mjs", "cjs"]),
     (Language::Kotlin, &["kt", "kts"]),
     (Language::Python, &["py", "py3"]),
     (Language::Ruby, &["rb"]),
@@ -738,7 +738,7 @@ mod tests {
     #[test]
     fn get_extensions_for_language_all_languages() {
         let mut extensions_per_languages: HashMap<Language, usize> = HashMap::new();
-        extensions_per_languages.insert(Language::JavaScript, 2);
+        extensions_per_languages.insert(Language::JavaScript, 4);
         extensions_per_languages.insert(Language::Kotlin, 2);
         extensions_per_languages.insert(Language::Python, 2);
         extensions_per_languages.insert(Language::Rust, 1);
@@ -784,6 +784,22 @@ mod tests {
             filter_files_for_language(
                 &[PathBuf::from("path").join(PathBuf::from("foobar.Dockerfile"))],
                 &Language::Dockerfile
+            )
+            .len()
+        );
+    }
+
+    #[test]
+    fn test_javascript_mjs_cjs_support() {
+        assert_eq!(
+            2,
+            filter_files_for_language(
+                &[
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.mjs")),
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.cjs")),
+                    PathBuf::from("path").join(PathBuf::from("foo/bar/baz.kjs"))
+                ],
+                &Language::JavaScript
             )
             .len()
         );


### PR DESCRIPTION
## What problem are you trying to solve?

Support `.cjs` and `.mjs` file extensions.

## What is your solution?

Add support for the extensions and treat these files as JavaScript files.

## What the reviewer should know

Closes #529 