### PR TITLE
[STAL-2713] Handle taint propagation in Java for-each loop statement.

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/flow/java.rs
@@ -716,6 +716,38 @@ strict digraph full {
     ///////////////////////////////////////////////////////////////////////////
 
     #[test]
+    fn enhanced_for_stmt() {
+        // A dependence edge is drawn from the newly-defined item variable to the array it is
+        // derived from.
+        assert_digraph!(
+            // language=java
+            "\
+void method() {
+    char[] y = {'a', 'b', 'c'};
+    for (char z : y) {
+        z;
+    }
+}
+",
+            // language=dot
+            r#"
+strict digraph full {
+    y0 [text=y,line=2]
+    y1 [text=y,line=3]
+    z0 [text=z,line=3]
+    z1 [text=z,line=4]
+    arrayInitializer [text="*",cstkind=array_initializer]
+
+    y0 -> arrayInitializer [kind=assignment]
+    y1 -> y0 [kind=dependence]
+    z0 -> y1 [kind=dependence]
+    z1 -> z0 [kind=dependence]
+}
+"#
+        );
+    }
+
+    #[test]
     fn if_statement_cfg_exhaustive_non_exhaustive() {
         assert_digraph!(
             // language=java


### PR DESCRIPTION
_This is a commit from early September that was unintentionally omitted when slicing the larger taint analysis implementation into smaller PRs._

---

## What problem are you trying to solve?
Taint isn't propagated between the "item" and "array" of a for-each loop statement:

```java
void method() {
    String[] strings = {\"a\", \"b\", \"c\"};
    String query = \"\";
    for (String s: strings) {
        // `strings` taints `s`, which then taints `query`,
        query += s;
    }
    System.out.println(query);
}
```
<img width="618" alt="image" src="https://github.com/user-attachments/assets/80f6a480-a55a-4293-95fc-ab8c61384138">

## What is your solution?
Add handler for `enhanced_for_statement` CST nodes.
<img width="438" alt="image" src="https://github.com/user-attachments/assets/e74dab53-b670-4eb6-8638-7c52e2e9c0f1">


## Alternatives considered

## What the reviewer should know
