### PR TITLE
feat(server): add option to save logs to a file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
           "kind": "bin"
         }
       },
-      "args": ["-p", "49159", "-e"],
+      "args": ["-p", "49159", "-e", "-l"],
       "cwd": "${workspaceFolder}"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,10 @@
           "kind": "bin"
         }
       },
-      "args": ["-p", "49159", "-e", "-l"],
+      "args": ["-p", "49159", "-e"],
+      "env": {
+        "RUST_LOG": "trace"
+      },
       "cwd": "${workspaceFolder}"
     },
     {

--- a/crates/bins/Cargo.toml
+++ b/crates/bins/Cargo.toml
@@ -59,7 +59,12 @@ getopts = "0.2.21"
 indicatif = "0.17.6"
 rayon = "1.7.0"
 rocket = { version = "=0.5.0", features = ["json"] }
-tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = [
+  "fmt",
+  "env-filter",
+  "json",
+] }
+tracing-appender = "0.2"
 thiserror = "1"
 pretty_yaml = "0.4"
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -41,7 +41,7 @@ fn get_opts() -> Options {
     opts.optopt(
         "l",
         "logs",
-        "Enables logs to a file. Usually /tmp/static-analyzer-server/logs",
+        "Enables log rotation and saves logs to a file in a system temp folder. Options: minutely, hourly, daily",
         "[minutely, hourly, daily]",
     );
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -64,7 +64,7 @@ fn get_log_dir() -> PathBuf {
                 // Fallback in case TEMP is not set
                 PathBuf::from("C:\\Temp")
             });
-        log_dir.push("static-analysis-server/logs");
+        log_dir.push(path);
         log_dir
     }
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -114,6 +114,7 @@ pub enum RocketPreparation {
 /// This function can panic or end the process in the case keep-alive is on and:
 /// -  graceful exit doesn't work (abort)
 /// -  the keep-alive channel is disconnected (exit code 70)
+///
 /// Although it should not happen frequently, it's certainly a possibility.
 pub fn prepare_rocket() -> Result<RocketPreparation, CliError> {
     let args: Vec<String> = env::args().collect();
@@ -160,10 +161,11 @@ pub fn prepare_rocket() -> Result<RocketPreparation, CliError> {
     // server state
     tracing::debug!("Preparing the server state and rocket configuration");
     let mut server_state = ServerState::new(matches.opt_str("s"), matches.opt_present("e"));
-    let mut rocket_configuration = rocket::config::Config::default();
-
-    // disable rocket colors and emojis if we're logging to a file as we will be using json format
-    rocket_configuration.cli_colors = !matches.opt_present("l");
+    let mut rocket_configuration = rocket::config::Config {
+        // disable rocket colors and emojis if we're logging to a file as we will be using json format
+        cli_colors: !matches.opt_present("l"),
+        ..Default::default()
+    };
 
     // set up the port if present
     if let Some(port_str) = matches.opt_str("p") {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
@@ -89,6 +89,7 @@ impl Fairing for KeepAlive {
             if state.is_keepalive_enabled {
                 // mutate the keep alive ms
                 if let Ok(mut x) = state.last_ping_request_timestamp_ms.try_write() {
+                    tracing::trace!("Updating the last_ping_request_timestamp_ms");
                     *x = get_current_timestamp_ms();
                 }
             }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
@@ -1,7 +1,6 @@
 use std::process;
 
 use cli::{CliError, RocketPreparation};
-use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod endpoints;
@@ -14,12 +13,9 @@ mod utils;
 ///
 /// # Panics
 ///
-/// This function will exit the process when it finds an error.
+/// This function will exit the process and panic when it finds an error.
 pub async fn start() {
-    // TODO: (ROB) we only want to instrument the server here
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    println!("Starting!!");
     // prepare the rocket based on the cli args.
     // NOTE: shared state is already managed by the rocket. No need to use `manage` again.
     // we get the state back just in case we want to add a particular fairing based on it.
@@ -30,6 +26,7 @@ pub async fn start() {
             match e {
                 CliError::Parsing(_f) => process::exit(22), // invalid argument code
                 CliError::InvalidPort(_port) => process::exit(1), // generic error code
+                CliError::InvalidAddress(_address) => process::exit(1), // generic error code
             }
         }
         Ok(RocketPreparation::NoServerInteraction) => {
@@ -39,6 +36,7 @@ pub async fn start() {
             mut rocket,
             state,
             tx_shutdown,
+            guard,
         }) => {
             // set fairings
             rocket = rocket
@@ -50,7 +48,9 @@ pub async fn start() {
             }
             // launch the rocket
             if let Err(e) = endpoints::launch_rocket_with_endpoints(rocket, tx_shutdown).await {
-                // TODO: (ROB) drop guard
+                tracing::error!("Something went wrong while trying to ignite the rocket {e:?}");
+                // flushing the pending logs by dropping the guard before panic
+                drop(guard);
                 panic!("Something went wrong while trying to ignite the rocket {e:?}");
             }
         }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
@@ -1,3 +1,6 @@
+use std::process;
+
+use cli::{CliError, RocketPreparation};
 use tracing_subscriber::EnvFilter;
 
 mod cli;
@@ -7,24 +10,49 @@ mod ide;
 mod state;
 mod utils;
 
+/// Starts the process
+///
+/// # Panics
+///
+/// This function will exit the process when it finds an error.
 pub async fn start() {
+    // TODO: (ROB) we only want to instrument the server here
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
     // prepare the rocket based on the cli args.
     // NOTE: shared state is already managed by the rocket. No need to use `manage` again.
     // we get the state back just in case we want to add a particular fairing based on it.
-    let (mut rocket, state, tx_shutdown) = cli::prepare_rocket();
-    // set fairings
-    rocket = rocket
-        .attach(fairings::Cors)
-        .attach(fairings::CustomHeaders)
-        .attach(fairings::TracingFairing);
-    if state.is_keepalive_enabled {
-        rocket = rocket.attach(fairings::KeepAlive);
-    }
-    // launch the rocket
-    if let Err(e) = endpoints::launch_rocket_with_endpoints(rocket, tx_shutdown).await {
-        panic!("Something went wrong while trying to ignite the rocket {e:?}");
+    let rocket_preparation = cli::prepare_rocket();
+    match rocket_preparation {
+        Err(e) => {
+            eprintln!("Error found: {e}");
+            match e {
+                CliError::Parsing(_f) => process::exit(22), // invalid argument code
+                CliError::InvalidPort(_port) => process::exit(1), // generic error code
+            }
+        }
+        Ok(RocketPreparation::NoServerInteraction) => {
+            // don't do anything, just exit with 0 code
+        }
+        Ok(RocketPreparation::ServerInfo {
+            mut rocket,
+            state,
+            tx_shutdown,
+        }) => {
+            // set fairings
+            rocket = rocket
+                .attach(fairings::Cors)
+                .attach(fairings::CustomHeaders)
+                .attach(fairings::TracingFairing);
+            if state.is_keepalive_enabled {
+                rocket = rocket.attach(fairings::KeepAlive);
+            }
+            // launch the rocket
+            if let Err(e) = endpoints::launch_rocket_with_endpoints(rocket, tx_shutdown).await {
+                // TODO: (ROB) drop guard
+                panic!("Something went wrong while trying to ignite the rocket {e:?}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

We have been observing several issues when using the server in the IDE:
- intelliJ reports having multiple instances of the server that won't be automatically shutdown
- a user in VS Code reported a case where multiple processes where present at the same time after leaving his computer idle all the night (unable to reproduce on our side)

## What is your solution?

In order to better understand what's going on it would be nice to have the generated logs of the server saved into a file.

This PR adds a new option in the CLI to roll all the logs to a file. The user can decide the cadence: minutely, hourly or daily. These logs will be using JSON format for easy parsing.

These logs are saved into the `/tmp` folder in UNIX and will default to the `TEMP` env var in windows, which is usually pointing to `C:\Users\<user_name>\AppData\Local\Temp`. If not present, for whatever reason, then it will fallback to `c:\Temp`.

The idea is to leverage this option to enable a setting in the IDEs that will allow users and the dev team to enable this feature in the binary and then easily debug the static analysis server processes. 

## Alternatives considered

## What the reviewer should know

Tested it on Windows 11 and it works, thought the compilation process didn't work out of the box due to some UNIX commands being used in the kernel build.rs file and a wrong dependency version. I managed to fix all that. I'll prepare another PR for that.


IDE-3768