### PR TITLE
fix(windows): allow to compile in a windows machine

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ git2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 derive_builder = { workspace = true }
-num_cpus = { workspace = true}
+num_cpus = { workspace = true }
 serde-sarif = { workspace = true }
 sha2 = { workspace = true }
 uuid = { workspace = true }
@@ -29,7 +29,7 @@ percent-encoding = "2.3.1"
 prettytable-rs = "0.10.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 valico = "4.0.0"
-walkdir = "2.3.3"
+walkdir = "2.5.0"
 itertools = "0.12.1"
 
 [dev-dependencies]


### PR DESCRIPTION
## What problem are you trying to solve?

While trying to compile the project in my Windows 11 machine I found out I was unable to compile the project due to some issues:

1. use of unix commands in build.rs
1. walkdir dependency mismatch

## What is your solution?

1. I replaced the UNIX commands for Rust commands.
1. Updated Walkdir to 2.5.0, which is the latest version. For some reason, the version we had in Cargo.toml (2.3.3) didn't have the `follow_root_links` method that we're using in `file_utils.rs`. Not sure how, in Mac we're getting the right version (maybe through another dependency), but this is not true in Windows, so I decided to update the dependency.

## Alternatives considered

## What the reviewer should know

Tested this in a Windows 11 machine and it works.

RE #541
