### PR TITLE
[STAL-3112] Bump GitLab runner memory limit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ test-and-build-arm64:
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l python
   variables:
     KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_MEMORY_LIMIT: 12Gi
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: $CI_PROJECT_NAME
     DD_SITE: datadoghq.com
   tags:
@@ -48,7 +48,7 @@ test-and-build-amd64:
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l python
   variables:
     KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_MEMORY_LIMIT: 12Gi
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: $CI_PROJECT_NAME
     DD_SITE: datadoghq.com
   tags:


### PR DESCRIPTION
## What problem are you trying to solve?
Our GitLab builds are failing on arm64 with an oom kill after the introduction of (3) new dependencies in #541. It seems like these break the camel's back during LTO.

✅ Before 541:
<img width="473" alt="image" src="https://github.com/user-attachments/assets/c3646b35-dd0a-4730-ac80-320e265f083b">

❌ After 541:
<img width="470" alt="image" src="https://github.com/user-attachments/assets/c4b9d3f2-3e12-43c1-a342-da8c80f8e4d1">

## What is your solution?

Increase the limit from 8Gi to 12Gi.

✅ Now:
<img width="472" alt="image" src="https://github.com/user-attachments/assets/96b6a234-83fc-4984-a63d-4828c576dccb">

## Alternatives considered

## What the reviewer should know
