### PR TITLE
[STAL-3119] Fix folder structure for Windows release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,11 @@ jobs:
       - name: Zip Rust binaries (Windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          7z a datadog-static-analyzer-${{ matrix.target }}.zip target/${{ matrix.target }}/release/datadog-static-analyzer.exe
-          7z a datadog-static-analyzer-git-hook-${{ matrix.target }}.zip target/${{ matrix.target }}/release/datadog-static-analyzer-git-hook.exe
-          7z a datadog-static-analyzer-server-${{ matrix.target }}.zip target/${{ matrix.target }}/release/datadog-static-analyzer-server.exe
+          cd target\${{ matrix.target }}\release
+          7z a datadog-static-analyzer-${{ matrix.target }}.zip datadog-static-analyzer.exe
+          7z a datadog-static-analyzer-git-hook-${{ matrix.target }}.zip datadog-static-analyzer-git-hook.exe
+          7z a datadog-static-analyzer-server-${{ matrix.target }}.zip datadog-static-analyzer-server.exe
+          move *.zip ..\..\..\
 
       - name: Upload assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What problem are you trying to solve?
With https://github.com/DataDog/datadog-static-analyzer/pull/534, we changed the action steps that performed the release, and in doing so, inadvertently changed the folder structure of the zip for Windows.

For example, it's now:
```
.
└── target
    └── x86_64-pc-windows-msvc
        └── release
            └── datadog-static-analyzer.exe
```

Whereas before, it was:
```
.
└── datadog-static-analyzer.exe
```


## What is your solution?
Fix the invocation of `7z` so it creates the archive with the exe at the root level.

You can see a successful run of this (and download the binaries and confirm a root level exe here: https://github.com/DataDog/datadog-static-analyzer/releases/tag/pre-release-110424-2) 

## Alternatives considered

## What the reviewer should know
* https://github.com/DataDog/datadog-static-analyzer/commit/d73cdbc375df1c002d536e192be39cf2488069a1 triggered a pre-release to test this only for Windows. It will be force-pushed away before merging.
