### PR TITLE
Add GitHub action env variable deprecation warning

### DIFF
--- a/misc/github-action.sh
+++ b/misc/github-action.sh
@@ -13,6 +13,14 @@ if [ -z "$DD_APP_KEY" ]; then
 	exit 1
 fi
 
+if [ -n "$DD_ENV" ]; then
+	echo "::warning title=Deprecated environment variable::DD_ENV has been set, but it is no longer functional. This warning will be removed in a future update."
+fi
+
+if [ -n "$DD_SERVICE" ]; then
+	echo "::warning title=Deprecated environment variable::DD_SERVICE has been set, but it is no longer functional. This warning will be removed in a future update."
+fi
+
 if [ -z "$CPU_COUNT" ]; then
 	# the default CPU count is 2
 	CPU_COUNT=2


### PR DESCRIPTION
## What problem are you trying to solve?
In https://github.com/DataDog/datadog-static-analyzer/pull/545, we removed support for the `DD_SERVICE` and `DD_ENV` environment variables in the GitHub action.

Users may still be passing these environment variables in through the use of our official [GitHub action](https://github.com/DataDog/datadog-static-analyzer-github-action) as a part of their workflows, but they will have no effect.

## What is your solution?
Warn the user that the environment variable has no effect using GitHub's special "[warning message](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message)".

## Alternatives considered

## What the reviewer should know
