### PR TITLE
ci: enable static CPUs for build and test job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ test-and-build-arm64:
   variables:
     KUBERNETES_MEMORY_REQUEST: 6Gi
     KUBERNETES_MEMORY_LIMIT: 12Gi
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: $CI_PROJECT_NAME
     DD_SITE: datadoghq.com
   tags:
     - arch:arm64
@@ -49,7 +48,6 @@ test-and-build-amd64:
   variables:
     KUBERNETES_MEMORY_REQUEST: 6Gi
     KUBERNETES_MEMORY_LIMIT: 12Gi
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: $CI_PROJECT_NAME
     DD_SITE: datadoghq.com
   tags:
     - arch:amd64
@@ -64,7 +62,6 @@ trigger_internal_image:
     strategy: depend
   variables:
     DD_IMAGES_BRANCH: master
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: images
     IMAGE_VERSION: current
     IMAGE_NAME: datadog-static-analyzer
     RELEASE_TAG: ${CI_COMMIT_SHORT_SHA}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,26 @@ stages:
   - test
   - release
 
+.jobs-resource-allocation:
+  variables:
+    # Sized resources using https://app.datadoghq.com/dashboard/xff-wqx-4a2/ci-reliability-kubernetes-runner-sizing-and-diagnotic
+    KUBERNETES_CPU_REQUEST: "6"
+    KUBERNETES_CPU_LIMIT: "6"
+    KUBERNETES_MEMORY_REQUEST: "12Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    # Using non-integer CPU requests/limits to avoid the static CPU policy to be set on the helper container.
+    # Static CPU policy reserves full CPU cores for containers with integer requests. It is used to isolate
+    # CI job containers from each other and prevent noisy ones to starve resources on a CI node.
+    # By using non-integer CPU request and limits for the helper container, responsible for cloning,
+    # we can leverage multi-cores to speed-up git clones while preserving isolation for the build container.
+    KUBERNETES_HELPER_CPU_REQUEST: "200m"
+    KUBERNETES_HELPER_CPU_LIMIT: "200m"
+    KUBERNETES_HELPER_MEMORY_REQUEST: "1Gi"
+    KUBERNETES_HELPER_MEMORY_LIMIT: "1Gi"
+
 test-and-build-arm64:
+  extends:
+    - .jobs-resource-allocation
   stage: test
   script:
     - apt-get update
@@ -22,13 +41,13 @@ test-and-build-arm64:
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l csharp
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l python
   variables:
-    KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 12Gi
     DD_SITE: datadoghq.com
   tags:
     - arch:arm64
 
 test-and-build-amd64:
+  extends:
+    - .jobs-resource-allocation
   stage: test
   script:
     - apt-get update
@@ -46,8 +65,6 @@ test-and-build-amd64:
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l csharp
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l python
   variables:
-    KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 12Gi
     DD_SITE: datadoghq.com
   tags:
     - arch:amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ubuntu:22.04
+image: registry.ddbuild.io/ubuntu:22.04
 
 stages:
   - test


### PR DESCRIPTION
## What problem are you trying to solve?

Containerization has been an industry standard for many years now, but many of the build tools we use have no awareness of it, and instead set defaults for concurrent processing based on the CPU count of the container host, causing failures in CI.

## What is your solution?

[Dedicated Cores for CI jobs by default](https://docs.google.com/document/d/1YKCRHk2hcs7iaheQF6ZHxzJz9VE4sXbBEuGr9IlGZno/edit?tab=t.0#heading=h.k4f2rhz10zak) will grant the job consistent CPU resources. Which results in increased reliability and predictability.
The values were chosen based on our [diagnostic and sizing dashboard](https://app.datadoghq.com/dashboard/xff-wqx-4a2/ci-reliability-kubernetes-runner-sizing-and-diagnotic?fromUser=false&refresh_mode=sliding&tpl_var_container_name%5B0%5D=build&tpl_var_job_name%5B0%5D=test-and-build-arm64&tpl_var_repository%5B0%5D=datadog-static-analyzer&from_ts=1730209630201&to_ts=1730818030201&live=true).

## Alternatives considered

We could let the build container burst but pinning the CPU cores should help with the memory consumption. The idea of the PR is to look if the duration of the job is negatively affected by pinning it to 4 cores.

## What the reviewer should know

I am not familiar with neither the Rust build toolings nor the repository CI so please correct any wrong assumption I made.

PS: I also took the occasion to remove legacy settings for the CI (service account overwrite and ECR).