### PR TITLE
[STAL-2846] feat: add a timeout flag, and use it in the rule execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ sha2 = "0.10.7"
 num_cpus = "1.15.0"
 tracing = "0.1.40"
 uuid = { version = "1.6.1", features = ["v4"] }
-tree-sitter = "0.22.6"
+tree-sitter = "0.24.4"

--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -159,6 +159,12 @@ fn main() -> Result<()> {
     opts.optflag("t", "include-testing-rules", "include testing rules");
     opts.optflag("", "secrets", "enable secrets detection (BETA)");
     opts.optflag("", "static-analysis", "enable static-analysis");
+    opts.optopt(
+        "",
+        "rule-timeout-ms",
+        "how long a rule can run before being killed, in milliseconds",
+        "1000",
+    );
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -329,10 +335,19 @@ fn main() -> Result<()> {
         print_configuration(&configuration);
     }
 
+    let timeout = matches
+        .opt_str("rule-timeout-ms")
+        .map(|val| {
+            val.parse::<u64>()
+                .context("unable to parse `rule-timeout-ms` flag as integer")
+        })
+        .transpose()?;
+
     let analysis_options = AnalysisOptions {
         log_output: true,
         use_debug,
         ignore_generated_files,
+        timeout,
     };
 
     if should_verify_checksum {

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -25,6 +25,7 @@ fn test_rule(rule: &Rule, test: &RuleTest) -> Result<String> {
         log_output: true,
         use_debug: true,
         ignore_generated_files: false,
+        timeout: None,
     };
     let rules = vec![rule_internal];
     let analyze_result = analyze(

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -131,6 +131,12 @@ fn main() -> Result<()> {
     );
     // TODO (JF): Remove this when releasing 0.3.8
     opts.optflag("", "ddsa-runtime", "(deprecated)");
+    opts.optopt(
+        "",
+        "rule-timeout-ms",
+        "how long a rule can run before being killed, in milliseconds",
+        "1000",
+    );
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -368,10 +374,19 @@ fn main() -> Result<()> {
     if matches.opt_present("ddsa-runtime") {
         println!("[WARNING] the --ddsa-runtime flag is deprecated and will be removed in the next version");
     }
+    let timeout = matches
+        .opt_str("rule-timeout-ms")
+        .map(|val| {
+            val.parse::<u64>()
+                .context("unable to parse `rule-timeout-ms` flag as integer")
+        })
+        .transpose()?;
+
     let analysis_options = AnalysisOptions {
         log_output: true,
         use_debug,
         ignore_generated_files,
+        timeout,
     };
 
     if should_verify_checksum {

--- a/crates/common/src/analysis_options.rs
+++ b/crates/common/src/analysis_options.rs
@@ -6,6 +6,7 @@ pub struct AnalysisOptions {
     pub log_output: bool,
     pub use_debug: bool,
     pub ignore_generated_files: bool,
+    pub timeout: Option<u64>,
 }
 
 impl Default for AnalysisOptions {
@@ -14,6 +15,7 @@ impl Default for AnalysisOptions {
             log_output: false,
             use_debug: false,
             ignore_generated_files: true,
+            timeout: None,
         }
     }
 }

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -22,6 +22,7 @@ globset = "0.4.14"
 graphviz-rust = "0.9.0"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
+streaming-iterator = "0.1.9"
 thiserror = "1.0.59"
 
 [build-dependencies]

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/bridge/query_match.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/bridge/query_match.rs
@@ -126,7 +126,7 @@ const ghi = 'hello' + ' world';
         let query = TSQuery::try_new(&tree.language(), query).unwrap();
         let matches = query
             .cursor()
-            .matches(tree.root_node(), text)
+            .matches(tree.root_node(), text, None)
             .collect::<Vec<_>>();
         assert!(query_match_bridge.is_empty());
         assert!(ts_node_bridge.is_empty());
@@ -152,7 +152,7 @@ const alpha = 'bravo';
         let tree = get_tree(text, &Language::JavaScript).unwrap();
         let matches = query
             .cursor()
-            .matches(tree.root_node(), text)
+            .matches(tree.root_node(), text, None)
             .collect::<Vec<_>>();
         query_match_bridge.set_data(scope, matches, &mut ts_node_bridge);
         assert_eq!(get_node_id_at_idx(&query_match_bridge, 0), 3);

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/common.rs
@@ -15,6 +15,8 @@ pub type NodeId = u32;
 pub enum DDSAJsRuntimeError {
     #[error("{error}")]
     Execution { error: JsError },
+    #[error("Tree-sitter query execution timeout")]
+    TreeSitterTimeout { timeout: Duration },
     #[error("JavaScript execution timeout")]
     JavaScriptTimeout { timeout: Duration },
     #[error("expected `{name}` to exist within the v8 context")]

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_go.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_go.rs
@@ -8,6 +8,7 @@ use crate::analysis::tree_sitter::get_tree_sitter_language;
 use crate::model::common::Language;
 use deno_core::v8;
 use deno_core::v8::HandleScope;
+use streaming_iterator::StreamingIterator;
 
 /// Structure for the file context that is specific to Go.
 #[derive(Debug)]
@@ -44,8 +45,9 @@ impl FileContextGo {
         // the second capture is the name of the package.
 
         let mut query_cursor = tree_sitter::QueryCursor::new();
-        let query_result = query_cursor.matches(&self.ts_query, tree.root_node(), code.as_bytes());
-        for query_match in query_result {
+        let mut query_result =
+            query_cursor.matches(&self.ts_query, tree.root_node(), code.as_bytes());
+        while let Some(query_match) = query_result.next() {
             let mut package_name: Option<&str> = None;
             let mut package_alias: Option<&str> = None;
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_js.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_js.rs
@@ -4,6 +4,7 @@
 
 use deno_core::v8;
 use deno_core::v8::HandleScope;
+use streaming_iterator::StreamingIterator;
 
 use crate::analysis::ddsa_lib::common::{Class, DDSAJsRuntimeError};
 use crate::analysis::ddsa_lib::js::JSPackageImport;
@@ -165,8 +166,7 @@ impl FileContextJavaScript {
 
         let query_result = query_cursor.matches(&self.query, tree.root_node(), code.as_bytes());
         let imports = query_result
-            .into_iter()
-            .filter_map(|query_match| {
+            .filter_map_deref(|query_match| {
                 let mut name = None;
                 let mut imported_from = None;
                 let mut has_default = false;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
@@ -3,6 +3,7 @@
 // Copyright 2024 Datadog, Inc.
 
 use deno_core::v8::{self, HandleScope};
+use streaming_iterator::StreamingIterator;
 
 use crate::analysis::ddsa_lib::common::{Class, DDSAJsRuntimeError};
 use crate::analysis::ddsa_lib::js;
@@ -55,8 +56,7 @@ impl FileContextTerraform {
         let query_result = query_cursor.matches(&self.query, tree.root_node(), code.as_bytes());
 
         let resources = query_result
-            .into_iter()
-            .map(|query_match| {
+            .map_deref(|query_match| {
                 let mut resource_type = None;
                 let mut resource_name = None;
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/root.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/root.rs
@@ -118,7 +118,10 @@ impl RootContext {
         /////
 
         let mut depth = 0;
-        while let Some(child) = current_node.child_containing_descendant(node) {
+        while let Some(child) = current_node.child_with_descendant(node) {
+            if child == node {
+                break;
+            }
             // Cache the relationship discovered as a side effect of traversing down from the root.
             // Note that because the `child_containing_descendant` API filter its output, we
             // only end up caching the path directly from the root to this node.

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
@@ -106,6 +106,7 @@ mod tests {
     use crate::model::common::Language;
     use deno_core::v8;
     use std::marker::PhantomData;
+    use streaming_iterator::StreamingIterator;
 
     #[test]
     fn js_properties_canary() {

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -4,6 +4,7 @@ use common::model::position::Position;
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::sync::Arc;
+use streaming_iterator::StreamingIterator;
 use tree_sitter::CaptureQuantifier;
 
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
@@ -176,7 +177,7 @@ impl<'a, 'tree> TSQueryCursor<'a, 'tree> {
             MaybeOwnedMut::Owned(cursor) => cursor,
         };
         let matches = cursor.matches(self.query, node, text.as_bytes());
-        matches.map(|q_match| {
+        matches.map_deref(|q_match| {
             for capture in q_match.captures {
                 self.captures_scratch
                     .entry(capture.index)


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, we have no way to halt the analyzer during tree-sitter query execution. This is problematic because a customer or internal user could write a rule that has a query that is very slow (suffers from combinatorial explosion).

## What is your solution?

Upgrading to tree-sitter `0.24` allows us to set a timeout on query execution. This upgrade does bring in some other breaking changes that we have to adapt, including using `streaming-iterator` to iterate over the query cursor's matches or captures, which avoids UB upstream since the iterators are stateful. Another change with the upgrade is that `Node::child_containing_descendant` was deprecated in favor of `Node::child_with_descendant`, which is almost the same, except that it can return the `self` node. So, we add a check in the loop to ensure we don't process the `self` node.

With this upgrade, we add a `timeout` option to the CLI (analyzer and git hook) which takes in a number that sets the timeout for rule execution in milliseconds. This timeout applies to both tree-sitter query execution **AND** rule execution. After tree-sitter query execution finished, the timeout is subtracted by the time it took to execute the query, and this remaining duration for the timeout is passed into the rule execution. If the remainder is zero, that means we timed out executing the tree-sitter query, and we return this error, canceling the rule execution.

A test has been added that tests this timeout, by executing a quadratic query on a piece of code that is the same JavaScript function repeated 1000 times. The query wants to find two functions following one another, and given that we have 1000 of them, every single combination of these functions has to be checked during query execution, which will take a long time. As such, if we pass in a timeout of 1 second, we can observe that the tree-sitter timeout was reached, our program doesn't hang, and we get an error letting us know the query timed out. 

## Alternatives considered

## What the reviewer should know
