### PR TITLE
docs: add license info for `streaming-iterator`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -25,6 +25,7 @@ serde,https://github.com/serde-rs/serde,Apache-2.0,2015 David Tolnay and Serde c
 serde_json,https://github.com/serde-rs/json,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0,2016 David Tolnay
 sha2,https://crates.io/crates/sha2,Apache-2.0,Copyright (c) 2006-2009 Graydon Hoare 2009-2013 Mozilla Foundation 2016 Artyom Pavlov
+streaming-iterator,https://crates.io/crates/streaming-iterator,MIT or Apache-2.0,Copyright (c) 2016 Steven Fackler
 tempfile,https://crates.io/crates/tempfile,Apache-2.0,Copyright (c) 2015 Steven Allen
 terminal-emoji,https://github.com/mainrs/terminal-emoji-rs,MIT,Copyright (c) 2020 SirWindfield
 thiserror,https://github.com/dtolnay/thiserror,MIT,Copyright (c) 2019 David Tolnay


### PR DESCRIPTION
## What problem are you trying to solve?

We added a new dependency in #555, but did not add the license information for it

## What is your solution?

Add the license information for streaming-iterator

## Alternatives considered

## What the reviewer should know
