### PR TITLE
Fix Docker Run in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ datadog-static-analyzer --directory /path/to/directory --output report.csv --for
 #### Using Docker
 
 ```shell
-docker run ghcr.io/datadog/datadog-static-analyzer:latest -v /path/to/directory:/data --directory /data --output /data/report.csv --format csv
+docker run -it --rm -v /path/to/directory:/data ghcr.io/datadog/datadog-static-analyzer:latest --directory /data --output /data/report.csv --format csv
 ```
 
 For more information on the Docker container, see the documentation [here](./doc/docker-container.md).


### PR DESCRIPTION
## What problem are you trying to solve?
The `docker run` command in the README does not run.

## What is your solution?
The command should have the volume mount before the image name. Arguments after the image name are sent to the application within the container. 

Also added `-it` and `--rm` so the container cleans itself and has a interactive TTY to print to. It seems like a more sensible copy-past default to me

## Alternatives considered
N/A

## What the reviewer should know
N/A