### PR TITLE
Remove old migration code

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -138,8 +138,6 @@ fn main() -> Result<()> {
         "add-git-info",
         "add Git information to the SARIF report",
     );
-    // TODO (JF): Remove this when releasing 0.3.8
-    opts.optflag("", "ddsa-runtime", "(deprecated)");
     opts.optopt(
         "",
         "rule-timeout-ms",
@@ -388,9 +386,6 @@ fn main() -> Result<()> {
     // (Option<T> is used to prevent checking the same file path multiple times).
     let mut all_path_metadata = HashMap::<String, Option<ArtifactClassification>>::new();
 
-    if matches.opt_present("ddsa-runtime") {
-        println!("[WARNING] the --ddsa-runtime flag is deprecated and will be removed in the next version");
-    }
     let timeout = matches
         .opt_str("rule-timeout-ms")
         .map(|val| {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -57,8 +57,6 @@ fn get_opts() -> Options {
         "/tmp/static-analysis-server",
     );
 
-    // TODO (JF): Remove this when releasing 0.3.8
-    opts.optflag("", "ddsa-runtime", "(deprecated)");
     opts
 }
 
@@ -201,11 +199,6 @@ pub fn prepare_rocket(tx_keep_alive_error: Sender<i32>) -> Result<RocketPreparat
             }
         };
         tracing::debug!("Address set to {addr}");
-    }
-
-    // TODO: should this be removed already?
-    if matches.opt_present("ddsa-runtime") {
-        println!("[WARNING] the --ddsa-runtime flag is deprecated and will be removed in the next version");
     }
 
     // channel used to send the shutdown handler so that we can exit the server gracefully


### PR DESCRIPTION
## What problem are you trying to solve?
https://github.com/DataDog/datadog-static-analyzer/pull/446 preserved the `--ddsa-runtime` CLI flag to provide a graceful migration. Removing it is long overdue.

## What is your solution?
Delete the old code.

## Alternatives considered

## What the reviewer should know
* All internal usages of this flag have been removed.