### PR TITLE
[K9VULN-2188] feat: bump tree-sitter to `0.24.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ sha2 = "0.10.7"
 num_cpus = "1.15.0"
 tracing = "0.1.40"
 uuid = { version = "1.6.1", features = ["v4"] }
-tree-sitter = "0.24.4"
+tree-sitter = "0.24.5"


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, our CI sporadically fails on one specific test recently added that tests the timing out functionality with tree-sitter queries. The reason for this is because in tree-sitter, a guard was added to prevent macOS from using a monotonic clock. The reason for this is because back in 2019, there were still some users on OS X El Capitan (released in 2015), which does not have monotonic clock support at all, and would crash if any tree-sitter binaries built on a mac with monotonic clock support were executed on them. The commit from back then can be found [here](https://github.com/tree-sitter/tree-sitter/commit/25b0fbd6). However, OS X El Capitan is over 9 years old today, and macOS Sierra, the first version that *wouldn't* crash with monotonic clock support, is over 8 years old, so it was pretty safe to revert that change, and have macOS use a monotonic clock again. Thus, a patch release was cut that includes this change and a few bug fixes. 

The reason our test fails when macOS uses `clock` (not monotonic) instead of `clock_gettime` (monotonic) is because the `clock` function measures time in CPU time ([ref](https://linux.die.net/man/3/clock)), and not wall time, but our timeout test is intended to test wall time.

## What is your solution?

Upgrade the tree-sitter dependency to include the upstream fix which allows macOS to use a monotonic clock for calculating time elapsed.

## Alternatives considered

## What the reviewer should know
