### PR TITLE
update tree-sitter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ sha2 = "0.10.7"
 num_cpus = "1.15.0"
 tracing = "0.1.40"
 uuid = { version = "1.6.1", features = ["v4"] }
-tree-sitter = "0.24.4"
+tree-sitter = "0.24.5"


### PR DESCRIPTION
Update tree-sitter to the latest version to prevent Mac OS X issues on timeout.
