### PR TITLE
build: bump rust toolchain to 1.82

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.81.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.82"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82"
+channel = "1.83.0"


### PR DESCRIPTION
## What problem are you trying to solve?

Currently, our CI is failing because a transitive dependency of ours requires a Rust toolchain of `1.81` or greater. See this [workflow failure](https://github.com/DataDog/datadog-static-analyzer/actions/runs/12359902668/job/34493619718?pr=579#step:4:122) for evidence. This dependency is a part of [`rust-lang/cargo`](https://github.com/rust-lang/cargo), and we can see the MSRV was bumped in [this](https://github.com/rust-lang/cargo/commit/afb938628ec4f9781fdd51ba78f4147f6091b95f) commit to 1.81. As such, we should bump our Rust toolchain to avoid this build failure

## What is your solution?

I've bumped our Rust toolchain to 1.82, which is now close to 3 weeks old, and should be future-proof for quite some time.

## Alternatives considered

## What the reviewer should know

Some CI jobs will fail, notably, the `check regressions` jobs as those CI workflows intend to compare results from the analyzer before and after a PR, but because the analyzer doesn't build properly before this PR, the job will fail.