### PR TITLE
[K9VULN-1925] fix: improve unsound test by testing the production code path

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -634,7 +634,9 @@ mod tests {
     use crate::analysis::ddsa_lib::common::{
         compile_script, v8_interned, v8_uint, DDSAJsRuntimeError, Instance,
     };
-    use crate::analysis::ddsa_lib::test_utils::{cfg_test_v8, try_execute};
+    use crate::analysis::ddsa_lib::test_utils::{
+        cfg_test_v8, shorthand_execute_rule, try_execute, ExecuteOptions,
+    };
     use crate::analysis::ddsa_lib::{js, JsRuntime};
     use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language, TSQuery};
     use crate::model::common::Language;
@@ -955,13 +957,20 @@ function visit(captures) {
     addError(error);
 }
 "#;
-        let err = shorthand_execute_rule_internal(
+
+        let options = ExecuteOptions {
+            file_name: Some(filename),
+            rule_arguments: None,
+            timeout: Some(timeout),
+        };
+
+        let err = shorthand_execute_rule(
             &mut runtime,
-            &code,
-            filename,
+            Language::JavaScript,
             ts_query,
             rule_code,
-            Some(timeout),
+            &code,
+            Some(options),
         )
         .expect_err("Expected a timeout error");
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/test_utils.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/test_utils.rs
@@ -315,9 +315,9 @@ pub(crate) fn make_stub_root_context<'s>(
 // (This keeps the function signature of `shorthand_execute_rule` concise)
 #[derive(Debug, Default, Clone)]
 pub(crate) struct ExecuteOptions<'a> {
-    file_name: Option<&'a str>,
-    rule_arguments: Option<&'a HashMap<String, String>>,
-    timeout: Option<Duration>,
+    pub(crate) file_name: Option<&'a str>,
+    pub(crate) rule_arguments: Option<&'a HashMap<String, String>>,
+    pub(crate) timeout: Option<Duration>,
 }
 
 /// Executes the provided code and tree-sitter query as a [`RuleCategory::Unknown`] and


### PR DESCRIPTION
## What problem are you trying to solve?

In https://github.com/DataDog/datadog-static-analyzer/pull/555 we added support for timing out tree-sitter query executions, as this was necessary to prevent the analyzing spinning forever in case a query suffered from combinatorial explosion. However, with that change, the test added to verify this actually works used the `shorthand_execute_rule_internal` function, when it should have used `shorthand_execute_rule` instead because the former does *not* test the production code path, so any changes to `JsRuntime::execute_rule` that affect the query timeout will not be caught by the test, unless the corresponding internal function is updated as well.

## What is your solution?

Instead of using `shorthand_execute_rule_internal`, we should be using `shorthand_execute_rule` to test the production code path, which this PR does.

## Alternatives considered

## What the reviewer should know

`shorthand_execute_rule` takes in an optional `ExecuteOptions` struct. All tests that use this function, though, pass in `None` for this argument, and as such, never suffered from the fact that the fields of this struct are private, and there's no method on this struct to create an instance of it. As such, I've marked the fields as `pub(crate)` so that I can create this struct with a timeout and pass it into `shorthand_execute_rule`.