### PR TITLE
[K9VULN-1928] feat: bump tree-sitter Kotlin grammar

### DIFF
--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -101,7 +101,7 @@ fn main() {
             compilation_unit: "tree-sitter-kotlin".to_string(),
             repository: "https://github.com/tree-sitter-grammars/tree-sitter-kotlin.git"
                 .to_string(),
-            commit_hash: "33c8fa9913e5518724b1e4b3bce6ed69b8117ee7".to_string(),
+            commit_hash: "77dd60ea0a9003ce062c9728a513ffe1aaff8c82".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,


### PR DESCRIPTION
## What problem are you trying to solve?

Writing rules for the Kotlin grammar is a little more tedious than it could be, as when I was writing a rule I noticed there is a simple update to make the experience a little better. Consider the current parse tree for the given Kotlin code:

<img width="618" alt="image" src="https://github.com/user-attachments/assets/d37db332-c96e-4ad9-a732-63fc83cac32d" />

Every statement in the parse tree has a visible `statement` node as its parent, and so querying the actual node inside these statement nodes requires an unnecessary level of nesting. Ideally, the `statement` node should be a [supertype](https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types.html#supertype-nodes) node, similar to how the Java grammar does it [here](https://github.com/tree-sitter/tree-sitter-java/blob/94703d5a6bed02b98e438d7cad1136c01a60ba2c/grammar.js#L59).

## What is your solution?

I've updated the upstream Kotlin grammar to mark the `statement` nodes as a supertype node [here](https://github.com/tree-sitter-grammars/tree-sitter-kotlin/commit/f110eb8a7b7dc0c868150423f45eb305d5ed5d3b), so all this PR does is bump the Kotlin grammar to the git sha that includes this change.

## Alternatives considered

## What the reviewer should know

Although the parser now considers the `statement` node to be hidden (meaning it won't show up in the parse tree), this is *not* a breaking change because supertype nodes can still be queried as-is, just like normal nodes. So, all of our currently rules are still compatible with this change.