### PR TITLE
Handle `no-dd-sa` with comment blocks

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -78,12 +78,11 @@ fn get_lines_to_ignore(code: &str, language: &Language) -> LinesToIgnore {
     // get the //no-dd-sa //datadog-disable
     let disabling_patterns = DISABLE_KEYWORDS
         .iter()
-        .map(|pattern| {
+        .flat_map(|pattern| {
             comment_prefixes // e.g. ["//", "/*"]
                 .iter()
                 .map(|prefix| format!("{}{}", *prefix, *pattern))
         })
-        .flatten()
         .collect::<Vec<_>>();
 
     let mut ignore_file_all_rules: bool = false;


### PR DESCRIPTION
## What problem are you trying to solve?

We do have customers who want to specify the `no-dd-sa` in block comments.

For example, code such as

```
# no-dd-sa
# another comment
def line_with_violation(bla):
  pass
```

The `no-dd-sa` should then mute violation for line `def line_with_violation(bla):`

This happens especially when customers are running multiple linters (e.g. eslint) and ignore also eslint findings. For example, in the following case, we want to disable the violation for `doSomethingThatTriggerAViolation();`

```
// no-dd-sa
// eslint-disable-next-line
doSomethingThatTriggerAViolation();
```


## What is your solution?

We see if the `no-dd-sa` directive is in a comment block. When we find a `no-dd-sa` comment, we check is there was comments below and if yes, ignore the next line until it's not a comment.