### PR TITLE
Bump itertools to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.21.2"
 dashmap = "6.1.0"
 git2 = "0.19.0"
 indexmap = { version = "2.2", features = ["serde"] }
-itertools = "0.12.1"
+itertools = "0.14.0"
 derive_builder = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,7 +31,6 @@ prettytable-rs = "0.10.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 valico = "4.0.0"
 walkdir = "2.5.0"
-itertools = "0.12.1"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -67,7 +67,7 @@ pub fn find_secrets(
                 validation_status: SecretValidationStatus::from(&sds_match.match_status),
             })
         })
-        .group_by(|v| v.rule_index)
+        .chunk_by(|v| v.rule_index)
         .into_iter()
         .map(|(k, vals)| SecretResult {
             rule_id: sds_rules[k].clone().id,


### PR DESCRIPTION
## What problem are you trying to solve?
Upgrade itertools from 0.12.1 to 0.14.0

Supersedes https://github.com/DataDog/datadog-static-analyzer/pull/598

## What is your solution?
Changing our use of `group_by` to [chunk_by](https://github.com/DataDog/datadog-static-analyzer/commit/c52bfcee7da4572dca782d699df5d79c52ce6e1f#diff-63c8047e3794f8d52c0ffe228c61c83c50396a390fe5af2205db80e17441f120R70) is necessary because `group_by` [was deprecated](https://docs.rs/itertools/0.13.0/itertools/trait.Itertools.html#method.group_by) in 0.13.0.

## Alternatives considered

## What the reviewer should know
- I've reviewed all changes between the two versions and there are no other updates possible (e.g. use of new APIs that simplify or are more idiomatic)
