### PR TITLE
Bump reqwest to 0.12.12

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,7 +28,8 @@ csv = "1.3.0"
 path-slash = "0.2.1"
 percent-encoding = "2.3.1"
 prettytable-rs = "0.10.0"
-reqwest = { version = "0.12.12", features = ["blocking", "json"] }
+# Default features are disabled to turn off "http2", "charset".
+reqwest = { version = "0.12.12", default-features = false, features = ["default-tls", "macos-system-configuration", "blocking", "json"] }
 valico = "4.0.0"
 walkdir = "2.5.0"
 


### PR DESCRIPTION
## What problem are you trying to solve?
Bump reqwest from version 0.11 to 0.12.12

Supersedes https://github.com/DataDog/datadog-static-analyzer/pull/594

## What is your solution?
As of 0.12.0, reqwest added "http2" and "charset" features to the default. These have been disabled (by omission -- see 0.12.12's default features [here](https://github.com/seanmonstar/reqwest/blob/8b8fdd2552ad645c7e9dd494930b3e95e2aedef2/Cargo.toml#L30))

We only use reqwest to query Datadog services we control, which neither use http2 nor require extended charset support to parse).

## Alternatives considered

## What the reviewer should know
* I've reviewed all changes between the two versions and there are no other updates possible (e.g. use of new APIs that simplify or are more idiomatic)