### PR TITLE
Bump deno_core to 0.329.0

### DIFF
--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -18,15 +18,12 @@ thiserror = { workspace = true }
 tree-sitter = { workspace = true }
 
 # other
-deno_core = "0.328.0"
+deno_core = "0.329.0"
 globset = "0.4.14"
 graphviz-rust = "0.9.0"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 streaming-iterator = "0.1.9"
-
-# Workaround once https://github.com/denoland/deno_core/issues/1034 is fixed
-v8 = "=130.0.5"
 
 [build-dependencies]
 cc = "1.0.97"


### PR DESCRIPTION
## What problem are you trying to solve?
Upgrade deno_core to 0.329.0

## What is your solution?

## Alternatives considered

## What the reviewer should know
* This version of deno_core fixes the underlying issue we had to hotfix by pinning v8 in https://github.com/DataDog/datadog-static-analyzer/pull/599, so that has been removed.