### PR TITLE
[K9VULN-2775] Fix gaps in default ruleset CI coverage

### DIFF
--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -33,7 +33,7 @@ jobs:
             # Strip the null byte added by -z
             tr '\0' '\n' |
             # Get any strings present
-            grep -Po '".*?"' |
+            grep -Po '"[^"]*"' |
             # Delete quotation marks
             tr -d '"' |
             # Convert each newline to a space


### PR DESCRIPTION
## What problem are you trying to solve?
If no configuration is specified, the analyzer CLI uses a default list of languages, specified in `datadog_utils.rs`:
```rs
const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
    "CSHARP",
    // ...and so on
];
```
([source](https://github.com/DataDog/datadog-static-analyzer/blob/f088246e22a46238556e625729e7d923847317e0/crates/cli/src/datadog_utils.rs#L30-L42))

In CI, we've been manually syncing that list of languages to ensure we test all default rulesets:
```sh
for language in go python typescript javascript csharp java ruby; do
    # ...test logic
done
```
([source](https://github.com/DataDog/datadog-static-analyzer/blob/f088246e22a46238556e625729e7d923847317e0/.github/workflows/test-rules.yaml#L29))

These two have drifted out of sync (presently, the CI job is missing "Dockerfile", "Kotlin", and "PHP")

## What is your solution?
Ensure CI coverage can't drift by dynamically parsing `datadog_utils.rs` and extracting the list of languages. That file is now the single source of truth.

### Robustness
This script always makes sure it can parse _something_, [otherwise it returns an error](https://github.com/DataDog/datadog-static-analyzer/commit/ccf5dc87be52a33e75ed171b45c687f3a14f6697#diff-b1a7cc3b15bf6b3765328ae0ceb6d1ed680656747bb629b3fb294973496ff959R45-R48). Thus, if the "DEFAULT_RULESETS_LANGUAGES" code is refactored, the "extract-languages" job will fail until it's updated (rather than looping over zero languages, causing the entire test to inaccurately be marked successful)

### Testing
You can confirm that the CI job correctly tests all of the languages by [viewing the logs of this successful run](https://github.com/DataDog/datadog-static-analyzer/actions/runs/12779832469/job/35625115665#step:4:175).

## Alternatives considered
* Writing the parse logic in a more universally understandable form--e.g a Python script--instead of `grep`, `tr`, and `sed`.
## What the reviewer should know