### PR TITLE
[K9VULN-2634] ci: test that the Docker container can actually be built and run

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+  workflow_call:
+
+name: Test Docker Container
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t test-image .
+
+      - name: Verify binary exists and runs
+        run: |
+          # Run container and execute the binaries to verify they exist and run
+          docker run --rm test-image datadog-static-analyzer --help
+          docker run --rm test-image datadog-static-analyzer-server --help
+          docker run --rm test-image datadog-static-analyzer-git-hook --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   test-rules:
     uses: './.github/workflows/test-rules.yaml'
 
+  test-docker-build:
+    uses: './.github/workflows/docker-build.yml'
+
   integration-tests:
     uses: './.github/workflows/integration-tests.yaml'
     secrets: inherit
@@ -100,6 +103,7 @@ jobs:
     name: Release on GitHub
     needs:
       - test-rules
+      - test-docker-build
       - integration-tests
       - verify-schema
       - versions-check


### PR DESCRIPTION
## What problem are you trying to solve?

This is a follow-up PR to #600, where we noticed that our Docker container could be failing to build, and CI would not let us know of this failure. Currently, the only time we build the Docker container is when we trigger a release workflow, and not during any commit push or PR, which is not ideal. This should be tested in CI

## What is your solution?

I've added a workflow that runs on commit pushes and PRs that builds the Docker container, and verifies the binaries can be executed. The workflow is simple, and involves four steps:

- Check out the repository code
- Set up Rust
- Build the Docker container with the tag "test-image"
- Run this container 3 times one for each of our binaries (`datadog-static-analyzer`, `datadog-static-analyzer-server`, and `datadog-static-analyzer-git-hook`)

Additionally, our release process could run into a situation where our GH release works just fine, but the GHCR workflow fails, thus leading to our release version and container version being out of sync. As such, I've made the docker workflow a pre-requisite for the release job in the release workflow.

A successful run of the workflow can be found [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/12793812132/job/35667492624?pr=609).

A successful run of the release workflow, with the docker build workflow being a required step, can be found [here](https://github.com/amaanq/datadog-static-analyzer/actions/runs/12798093526)

## Alternatives considered

## What the reviewer should know

Note that Docker is a [preinstalled software](https://github.com/actions/runner-images/blob/ubuntu24/20250105.1/images/ubuntu/Ubuntu2404-Readme.md#tools) in GitHub actions, and we don't need any additional functionality that a specialized action might provide for us, as all we're looking to do is build and run a local container.

If the Docker invocation of the binary fails, then the job does indeed fail, as seen [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/12793504841/job/35666500109) (this failed because I hadn't passed in `--help`).