### PR TITLE
feat(cli): add cache and timeout information to custom headers

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -198,6 +198,7 @@ pub fn prepare_rocket(tx_keep_alive_error: Sender<i32>) -> Result<RocketPreparat
     // Create a cache for rules, if requested
     if matches.opt_present("use-rules-cache") {
         RULE_CACHE.set(RuleCache::new()).expect("should init once");
+        server_state.is_rule_cache_enabled = true;
     }
 
     let mut rocket_configuration = rocket::config::Config {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/fairings.rs
@@ -5,8 +5,8 @@ use rocket::{
     Data, Request, Response, State,
 };
 use server::constants::{
-    SERVER_HEADER_KEEPALIVE_ENABLED, SERVER_HEADER_SERVER_REVISION, SERVER_HEADER_SERVER_VERSION,
-    SERVER_HEADER_SHUTDOWN_ENABLED,
+    SERVER_HEADER_KEEPALIVE_ENABLED, SERVER_HEADER_RULE_CACHE_ENABLED, SERVER_HEADER_RULE_TIMEOUT,
+    SERVER_HEADER_SERVER_REVISION, SERVER_HEADER_SERVER_VERSION, SERVER_HEADER_SHUTDOWN_ENABLED,
 };
 use tracing::Span;
 use uuid::Uuid;
@@ -63,6 +63,17 @@ impl Fairing for CustomHeaders {
                 SERVER_HEADER_KEEPALIVE_ENABLED,
                 state.is_keepalive_enabled.to_string(),
             ));
+            response.set_header(Header::new(
+                SERVER_HEADER_RULE_CACHE_ENABLED,
+                state.is_rule_cache_enabled.to_string(),
+            ));
+
+            if let Some(rule_timeout) = state.rule_timeout_ms {
+                response.set_header(Header::new(
+                    SERVER_HEADER_RULE_TIMEOUT,
+                    rule_timeout.as_millis().to_string(),
+                ));
+            }
         }
 
         response.set_header(Header::new(SERVER_HEADER_SERVER_VERSION, get_version()));

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/Makefile.toml
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/Makefile.toml
@@ -12,6 +12,9 @@ args = [
   "--",
   "-p",
   "49159",
+  "-c",
+  "--rule-timeout-ms",
+  "500",
 ]
 
 [tasks.ide-test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/state.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/state.rs
@@ -10,6 +10,7 @@ pub struct ServerState {
     pub static_directory: Option<String>,
     pub is_shutdown_enabled: bool,
     pub is_keepalive_enabled: bool,
+    pub is_rule_cache_enabled: bool,
     pub rule_timeout_ms: Option<Duration>,
 }
 
@@ -24,6 +25,7 @@ impl ServerState {
             static_directory,
             is_shutdown_enabled,
             is_keepalive_enabled: false,
+            is_rule_cache_enabled: false,
             rule_timeout_ms: timeout,
         }
     }

--- a/crates/static-analysis-server/src/constants.rs
+++ b/crates/static-analysis-server/src/constants.rs
@@ -16,5 +16,7 @@ pub const ERROR_CHECKSUM_MISMATCH: &str = "checksum-mismatch";
 
 pub const SERVER_HEADER_SHUTDOWN_ENABLED: &str = "X-static-analyzer-server-shutdown-enabled";
 pub const SERVER_HEADER_KEEPALIVE_ENABLED: &str = "X-static-analyzer-server-keepalive-enabled";
+pub const SERVER_HEADER_RULE_CACHE_ENABLED: &str = "X-static-analyzer-server-rule-cache-enabled";
+pub const SERVER_HEADER_RULE_TIMEOUT: &str = "X-static-analyzer-server-rule-timeout";
 pub const SERVER_HEADER_SERVER_VERSION: &str = "X-static-analyzer-server-version";
 pub const SERVER_HEADER_SERVER_REVISION: &str = "X-static-analyzer-server-revision";


### PR DESCRIPTION
## What problem are you trying to solve?
All the responses from the static analysis server include some custom headers with the state of the server (i.e. whether it was initialised with a `keep-alive`, with the ability to auto shutdown...). 

`rule-timeout` and `rule-cache` where missing.

## What is your solution?

Added the missing custom headers:

<img width="448" alt="image" src="https://github.com/user-attachments/assets/2c938170-d269-461c-a206-f03562023258" />


## Alternatives considered

## What the reviewer should know

IDE-4042