### PR TITLE
[K9VULN-3202] ci(ghcr): downgrade the runner OS to ubuntu-22.04

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read


### PR DESCRIPTION
## What problem are you trying to solve?

With our latest release (0.5.4), publishing to GH succeeded, but building the Docker container to publish it to GHCR [failed](https://github.com/DataDog/datadog-static-analyzer/actions/runs/13012485515/job/36294483506). The runner is randomly segfaulting, and it appears to be an [upstream issue](https://github.com/tonistiigi/binfmt/issues/215) in `binfmt`, which the Docker setup QEMU action uses. 

In the linked issue, the comment [here](https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613004741) suggests that this is an issue with Ubuntu, and so, downgrading the Ubuntu version should fix our GHCR workflow from segfaulting randomly.

## What is your solution?

In the `GHCR` workflow, I've set the runner to `ubuntu-22.04` instead of `ubuntu-latest`, which fixes the segfaulting. A successful run can be observed [here](https://github.com/amaanq/datadog-static-analyzer/actions/runs/13017824009/job/36312106924), where the action can be observed running for over 2 hours with no segfaults (prior to this, a segfault could be observed within ~22 minutes of the "Build & push" step being kicked off).

## Alternatives considered

## What the reviewer should know

There was an additional suggested fix of pinning the QEMU version to v8 for the `binfmt` image used in the Docker action, but that did not fix the bug in our case.

Additionally, we should cut a new release after this PR is merged, so that the versions for our GH release and GHCR container are not out of sync for too long.
