### PR TITLE
Split logs in stdout and stderr & also write there when logging to file

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/cli.rs
@@ -9,6 +9,9 @@ use std::{env, process, thread};
 use thiserror::Error;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
+use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 use crate::datadog_static_analyzer_server::error_codes::{
@@ -124,7 +127,7 @@ pub enum RocketPreparation {
         rocket: Box<Rocket<Build>>,
         state: ServerState,
         tx_rocket_shutdown: Sender<Shutdown>,
-        guard: Option<WorkerGuard>,
+        guards: Vec<WorkerGuard>,
     },
     NoServerInteraction,
 }
@@ -153,8 +156,15 @@ pub fn prepare_rocket(tx_keep_alive_error: Sender<i32>) -> Result<RocketPreparat
         return Ok(RocketPreparation::NoServerInteraction);
     }
 
+    let (non_blocking_stdout, stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
+    let (non_blocking_stderr, stderr_guard) = tracing_appender::non_blocking(std::io::stderr());
+    let stdouterr = non_blocking_stderr
+        .with_max_level(tracing::Level::WARN)
+        .or_else(non_blocking_stdout);
+    let stdouterr_layer = tracing_subscriber::fmt::layer().with_writer(stdouterr);
+
     // initialize the tracing subscriber here as we're only interested in the server logs not the other CLI instructions
-    let guard = if let Some(log_rolling) = matches.opt_str("l") {
+    let guards = if let Some(log_rolling) = matches.opt_str("l") {
         // tracing with logs
         let log_dir = matches
             .opt_str("d")
@@ -164,20 +174,26 @@ pub fn prepare_rocket(tx_keep_alive_error: Sender<i32>) -> Result<RocketPreparat
             log_dir,
             format!("server.{}.log", std::process::id()),
         )?;
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        let (non_blocking_file, file_guard) = tracing_appender::non_blocking(file_appender);
 
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .json()
-            .with_writer(non_blocking)
-            .init();
-        Some(guard)
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking_file)
+            .json();
+
+        tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env())
+            .with(stdouterr_layer)
+            .with(file_layer)
+            .try_init()
+            .expect("Unable to install global subscriber");
+        vec![file_guard, stdout_guard, stderr_guard]
     } else {
-        // regular tracing subscriber
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
-            .init();
-        None
+        tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env())
+            .with(stdouterr_layer)
+            .try_init()
+            .expect("Unable to install global subscriber");
+        vec![stdout_guard, stderr_guard]
     };
 
     // server state
@@ -299,6 +315,6 @@ pub fn prepare_rocket(tx_keep_alive_error: Sender<i32>) -> Result<RocketPreparat
         rocket: Box::new(rocket),
         state: server_state,
         tx_rocket_shutdown,
-        guard,
+        guards,
     })
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/mod.rs
@@ -47,7 +47,7 @@ pub async fn start() {
             mut rocket,
             state,
             tx_rocket_shutdown,
-            guard,
+            guards,
         }) => {
             // set fairings
             *rocket = rocket
@@ -71,7 +71,9 @@ pub async fn start() {
                     "Something went wrong while trying to ignite the rocket: {error_str}"
                 );
                 // flushing the pending logs by dropping the guard before panic
-                drop(guard);
+                for guard in guards {
+                    drop(guard);
+                }
 
                 match e {
                     EndpointError::ExitCode(code) => process::exit(code),


### PR DESCRIPTION
## What problem are you trying to solve?
When the static analyzer finishes with an error, from the IDE plugins we want to report the error logs to Datadog. 

## What is your solution?
- Send warning and error logs to `stderr` and the rest to `stdout`, so we can read `stderr` only from the IDE.
- Still print to the standard output even when logging to a file is enabled. Earlier, if logging to a file was enabled we would not log anything to the standard output. Note that logging to a file is still done in JSON format like earlier.

## Alternatives considered
I'm not sure whether the stderr/stdout writers can actually block and need the `non_blocking` wrapper (like the file writer does). I saw some open source projects wrapping them, so I also did it just in case. This means we can now have more than one guard.