### PR TITLE
Pin v8 to 130.0.7

### DIFF
--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -25,5 +25,8 @@ sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
 streaming-iterator = "0.1.9"
 
+# We're experiencing issues with v8 130.0.8. Until we can resolve this, pin to the last-known-working.
+v8 = "=130.0.7"
+
 [build-dependencies]
 cc = "1.0.97"


### PR DESCRIPTION
## What problem are you trying to solve?
The build is broken, as we aren't using a lockfile, and v8 130.0.8 will not compile.

## What is your solution?
Pin v8 to the last working version.

## Alternatives considered

## What the reviewer should know
* This PR [fails](https://github.com/DataDog/datadog-static-analyzer/actions/runs/13056865348/job/36429997932) the regression check because `main` currently will not build. This is expected.