### PR TITLE
Add flag to disable static analysis

### DIFF
--- a/misc/github-action.sh
+++ b/misc/github-action.sh
@@ -56,6 +56,12 @@ else
 	SECRETS_ENABLED_VALUE=""
 fi
 
+if [ "$STATIC_ANALYSIS_ENABLED" = "false" ]; then
+	STATIC_ANALYSIS_ENABLED_VALUE="--enable-static-analysis false"
+else
+	STATIC_ANALYSIS_ENABLED_VALUE="--enable-static-analysis true"
+fi
+
 ########################################################
 # Output directory
 ########################################################
@@ -92,7 +98,7 @@ if [ "$DIFF_AWARE" = "true" ]; then
 fi
 
 echo "Starting Static Analysis"
-datadog-static-analyzer -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE $SECRETS_ENABLED_VALUE || exit 1
+datadog-static-analyzer -i "$GITHUB_WORKSPACE" -g -o "$OUTPUT_FILE" -f sarif --cpus "$CPU_COUNT" "$ENABLE_PERFORMANCE_STATISTICS" --debug $DEBUG_ARGUMENT_VALUE $SUBDIRECTORY_OPTION $DIFF_AWARE_VALUE $SECRETS_ENABLED_VALUE $STATIC_ANALYSIS_ENABLED_VALUE || exit 1
 echo "Done"
 
 echo "Uploading Static Analysis Results to Datadog"


### PR DESCRIPTION
## What problem are you trying to solve?

We want to add a flag to let the user enable or disable static analysis via environment variable. This will let the GitHub action disable static analysis if a user wants to only use secrets

## What is your solution?

Follow the same pattern as secrets except that static analysis is enabled by default. The value has to be explicitely set to false to fail.


## Related PR

[PR for the GItHub action](https://github.com/DataDog/datadog-static-analyzer-github-action/pull/50) to inject this variable