### PR TITLE
Only run `docker build` CI when `Dockerfile` changes.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,12 @@
 on:
   push:
+    paths:
+      - "Dockerfile"
     branches:
       - "**"
   pull_request:
+    paths:
+      - "Dockerfile"
   workflow_call:
 
 name: Test Docker Container


### PR DESCRIPTION
## What problem are you trying to solve?
CI takes longer than necessary to run because compiling a Docker image is relatively time-consuming. We only need to do this test when the `Dockerfile` actually changes.

## What is your solution?

### Testing
Look at https://github.com/DataDog/datadog-static-analyzer/pull/631/commits/f65e3a0b3fb6c5a48026b58fb2e6066672580697. Confirm there were no changes to the `Dockerfile`. Check the CI run and confirm the "Test Docker Container" job did not run:
<img width="595" alt="image" src="https://github.com/user-attachments/assets/9d98c992-1777-490b-b177-ea2e03466042" />

Look at https://github.com/DataDog/datadog-static-analyzer/pull/631/commits/23997fe98f2de86aba64bb0673ac334653b835cd. Confirm there was a change to the `Dockerfile`. Check the CI run and confirm the "Test Docker Container" job ran:
<img width="589" alt="image" src="https://github.com/user-attachments/assets/22aaa46a-0eb2-43c3-b3e8-110c869b7f98" />

## What the reviewer should know
* https://github.com/DataDog/datadog-static-analyzer/pull/631/commits/23997fe98f2de86aba64bb0673ac334653b835cd will be squashed away before the PR is merged.