### PR TITLE
[K9VULN-3472] Enforce `RuleSet` validation upon struct creation

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -317,7 +317,7 @@ fn main() -> Result<()> {
             let rulesets_from_api =
                 get_all_default_rulesets(use_staging, use_debug).expect("cannot get default rules");
 
-            rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));
+            rules.extend(rulesets_from_api.into_iter().flat_map(|rs| rs.into_rules()));
         }
     }
 

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -97,11 +97,10 @@ fn main() {
         match get_ruleset(ruleset.as_str(), use_staging, true) {
             Ok(r) => {
                 println!("Testing ruleset {}", r.name);
-                for rule in r.rules.clone() {
+                for rule in r.rules() {
                     println!("   rule {} ... ", rule.name);
-                    let c = rule.clone();
-                    for t in rule.tests {
-                        match test_rule(&mut runtime, &c, &t) {
+                    for t in &rule.tests {
+                        match test_rule(&mut runtime, rule, t) {
                             Ok(_) => {
                                 println!("      test {} passed", t.filename);
                             }

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -334,14 +334,14 @@ fn main() -> Result<()> {
             let rulesets_from_api =
                 get_all_default_rulesets(use_staging, use_debug).expect("cannot get default rules");
 
-            rules.extend(rulesets_from_api.into_iter().flat_map(|v| v.rules.clone()));
+            rules.extend(rulesets_from_api.into_iter().flat_map(|rs| rs.into_rules()));
         } else {
             let rulesets_from_file = get_rulesets_from_file(rules_file.clone().unwrap().as_str());
             rules.extend(
                 rulesets_from_file
                     .context("cannot read ruleset from file")?
                     .into_iter()
-                    .flat_map(|v| v.rules),
+                    .flat_map(|rs| rs.into_rules()),
             );
         }
     }

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -198,7 +198,7 @@ impl APIResponseRuleset {
             Some(r) => r
                 .into_iter()
                 .map(|rule_from_api| Rule {
-                    name: format!("{}/{}", ruleset_name, rule_from_api.name),
+                    name: rule_from_api.name,
                     description_base64: rule_from_api.description,
                     short_description_base64: rule_from_api.short_description,
                     language: rule_from_api.language,
@@ -234,11 +234,7 @@ impl APIResponseRuleset {
                 .collect(),
             None => Vec::new(),
         };
-        RuleSet {
-            rules,
-            description: Some(description),
-            name: ruleset_name,
-        }
+        RuleSet::new(ruleset_name, Some(description), rules)
     }
 }
 
@@ -484,8 +480,8 @@ mod tests {
         });
         let res = serde_json::from_value::<StaticAnalysisRulesAPIResponse>(data);
         let ruleset = res.unwrap().into_ruleset();
-        assert_eq!(1, ruleset.rules.len());
-        let rule = ruleset.rules.get(0).unwrap();
+        assert_eq!(1, ruleset.rules().len());
+        let rule = &ruleset.rules()[0];
         assert_eq!(rule.name, "python-inclusive/function-definition");
         assert_eq!(
             rule.checksum,
@@ -520,7 +516,7 @@ mod tests {
         });
         let res = serde_json::from_value::<StaticAnalysisRulesAPIResponse>(data);
         let ruleset = res.unwrap().into_ruleset();
-        assert_eq!(0, ruleset.rules.len());
+        assert_eq!(0, ruleset.rules().len());
     }
 
     #[test]

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -223,8 +223,8 @@ mod tests {
         let rulesets = res.expect("ruleset");
         assert_eq!(1, (&rulesets).len());
         let ruleset = rulesets.get(0).unwrap();
-        assert_eq!(1, ruleset.rules.len());
-        let rule = ruleset.rules.get(0).unwrap();
+        assert_eq!(1, ruleset.rules().len());
+        let rule = &ruleset.rules()[0];
         assert_eq!(rule.name, "python-inclusive/function-definition");
         assert_eq!(
             rule.checksum,

--- a/crates/static-analysis-kernel/src/model/ruleset.rs
+++ b/crates/static-analysis-kernel/src/model/ruleset.rs
@@ -1,9 +1,132 @@
 use crate::model::rule::Rule;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Clone, Deserialize, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct RuleSet {
     pub name: String,
     pub description: Option<String>,
-    pub rules: Vec<Rule>,
+    rules: Vec<Rule>,
+    /// A private field to prevent this struct from being created manually. Use [`RuleSet::new`] instead.
+    _private: std::marker::PhantomData<()>,
+}
+
+impl RuleSet {
+    /// Creates a new `RuleSet` from the provided rules, ensuring that the name of each rule
+    /// has the ruleset id prepended in the format `ruleset_id/rule_name`.
+    pub fn new(
+        ruleset_id: impl Into<String>,
+        description: Option<String>,
+        mut rules: Vec<Rule>,
+    ) -> Self {
+        let ruleset_id = ruleset_id.into();
+        let expected_start = format!("{ruleset_id}/");
+
+        for rule in &mut rules {
+            // Ensure the rule's name has this ruleset's id prepended:
+            if !ruleset_id.is_empty() && !rule.name.starts_with(&expected_start) {
+                rule.name = format!("{expected_start}{}", rule.name);
+            }
+            rule.fix_cwe();
+        }
+        Self {
+            name: ruleset_id,
+            description,
+            rules,
+            _private: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns a list of the rules within this ruleset.
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
+    }
+
+    /// Consumes the `RuleSet`, returning its rules.
+    pub fn into_rules(self) -> Vec<Rule> {
+        self.rules
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        /// A copy of [`RuleSet`] with a default Deserialize impl.
+        #[derive(Deserialize)]
+        struct Helper {
+            name: String,
+            description: Option<String>,
+            rules: Vec<Rule>,
+        }
+        Helper::deserialize(deserializer)
+            .map(|ruleset| RuleSet::new(ruleset.name, ruleset.description, ruleset.rules))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuleSet;
+    use crate::model::common::Language;
+    use crate::model::rule::{Rule, RuleCategory, RuleSeverity, RuleType};
+
+    /// A shorthand function to create a rule with the given name.
+    fn rule_with_name(name: &str) -> Rule {
+        Rule {
+            name: name.to_string(),
+            short_description_base64: None,
+            description_base64: None,
+            category: RuleCategory::BestPractices,
+            severity: RuleSeverity::Error,
+            language: Language::Csharp,
+            rule_type: RuleType::TreeSitterQuery,
+            entity_checked: None,
+            code_base64: "".to_string(),
+            cwe: None,
+            checksum: "".to_string(),
+            pattern: None,
+            tree_sitter_query_base64: None,
+            arguments: vec![],
+            tests: vec![],
+            is_testing: false,
+        }
+    }
+
+    /// Returns an in-order list of rule names from the ruleset.
+    fn rule_names(ruleset: &RuleSet) -> Vec<&str> {
+        ruleset
+            .rules
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>()
+    }
+
+    /// A [`RuleSet`] with a non-empty id prepends rules with its id.
+    #[test]
+    fn ruleset_rule_names() {
+        let rules = vec![
+            rule_with_name("rule-1"),
+            rule_with_name("rule-2"),
+            rule_with_name("rs-id/rule-3"),
+        ];
+        let ruleset = RuleSet::new("rs-id", None, rules);
+        assert_eq!(
+            rule_names(&ruleset),
+            vec!["rs-id/rule-1", "rs-id/rule-2", "rs-id/rule-3"]
+        );
+    }
+
+    #[test]
+    fn ruleset_blank_id_rule_names() {
+        let rules = vec![
+            rule_with_name("rule-1"),
+            rule_with_name("rule-2"),
+            rule_with_name("rs-id/rule-3"),
+        ];
+        let ruleset = RuleSet::new("", None, rules);
+        assert_eq!(
+            rule_names(&ruleset),
+            vec!["rule-1", "rule-2", "rs-id/rule-3"]
+        );
+    }
 }


### PR DESCRIPTION
## What problem are you trying to solve?
When deserializing a `RuleSet` from the Datadog API, we apply special validation logic:

https://github.com/DataDog/datadog-static-analyzer/blob/a37a1c0200b29a823b3528b05b23898141a06751/crates/cli/src/model/datadog_api.rs#L201

https://github.com/DataDog/datadog-static-analyzer/blob/a37a1c0200b29a823b3528b05b23898141a06751/crates/cli/src/datadog_utils.rs#L233

Because not all rulesets need come from the Datadog API (e.g. they can also be passed in via a file with the CLI param `--rules rule-file.json`), the validation logic is not consistent everywhere.

## What is your solution?
Enforce validation when a `RuleSet` is created by forcing the use of `RuleSet::new`.

## Alternatives considered

## What the reviewer should know
