### PR TITLE
ci(ghcr): pin binfmt to v7.0.0-28

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28 # Pinned due to https://github.com/tonistiigi/binfmt/issues/240
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## What problem are you trying to solve?

Our latest release of the analyzer had a failing GHCR workflow, because of some upstream issues with Ubuntu and binfmt (which the Docker setup-qemu-action uses). For reference, see this issue - https://github.com/tonistiigi/binfmt/issues/240

## What is your solution?

As others have mentioned in the linked issue, pinning the`binfmt` image to v7.0.0-28 fixes the intermittent segfaults, and it does for us as well. In my fork, I've done a full run of the release workflow to verify that pinning the image works - [job summary](https://github.com/amaanq/datadog-static-analyzer/actions/runs/13332618563/job/37241206613)

## Alternatives considered

## What the reviewer should know
