### PR TITLE
Change message in SARIF results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bstr",
@@ -699,7 +699,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "datadog-static-analyzer"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -3228,7 +3228,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "common",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-kernel"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-server"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.9"
+version = "0.6.0"
 
 [profile.release]
 lto = true

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -73,7 +73,7 @@ pub fn find_secrets(
             rule_id: sds_rules[k].clone().id,
             rule_name: sds_rules[k].clone().name,
             filename: filename.to_string(),
-            message: sds_rules[k].clone().description,
+            message: sds_rules[k].clone().name,
             matches: vals
                 .map(|v| SecretResultMatch {
                     start: v.start,
@@ -87,7 +87,6 @@ pub fn find_secrets(
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -73,6 +73,9 @@ pub fn find_secrets(
             rule_id: sds_rules[k].clone().id,
             rule_name: sds_rules[k].clone().name,
             filename: filename.to_string(),
+            // there is no message for secret rules like we do with the static analyzer.
+            // we are putting the rule name instead. Update this if you want to change
+            // and put more context.
             message: sds_rules[k].clone().name,
             matches: vals
                 .map(|v| SecretResultMatch {

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+        "0.6.0": {
+            "cli": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-aarch64-apple-darwin.zip"
+                }
+            },
+            "server": {
+                "windows": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+                },
+                "linux": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+                },
+                "macos": {
+                    "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+                    "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.6.0/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+                }
+            }
+        },
         "0.5.9": {
             "cli": {
                 "windows": {


### PR DESCRIPTION
## What problem are you trying to solve?

Today, the message reported in the SARIF format is the description of the rule. We should put the name of the rule to avoid very large message like the following.

![image](https://github.com/user-attachments/assets/b1457c75-f28e-4956-9575-2b9b7d59b4e3)


## What is your solution?

Put the name of the rule in the SARIF results.

## Testing

Tested in staging, result

```
                {
                    "fixes": [],
                    "level": "none",
                    "locations": [
                        {
                            "physicalLocation": {
                                "artifactLocation": {
                                    "uri": "plop.js"
                                },
                                "region": {
                                    "endColumn": 58,
                                    "endLine": 6,
                                    "startColumn": 18,
                                    "startLine": 6
                                }
                            }
                        }
                    ],
                    "message": {
                        "text": "Github Access Token Scanner"
                    },
                    "partialFingerprints": {
                        "DATADOG_FINGERPRINT": "049bd4ae32bcbe59949e2dec09eb7d8ab1185b753056ab10dc2dc200ab7ef32d"
                    },
                    "properties": {
                        "tags": [
                            "DATADOG_CATEGORY:SECURITY",
                            "DATADOG_SECRET_VALIDATION_STATUS:INVALID"
                        ]
                    },
                    "ruleId": "secrets/github-access-token",
                    "ruleIndex": 900
                },
```
