### PR TITLE
K9VULN-3987 update editor schema for cross platform support

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -66,7 +66,8 @@
         "arguments": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/argumentValue"
+            "$ref": "#/definitions/argumentValue",
+            "description": "A rule definition containing category, arguments, severity, and the include / ignore patterns."
           },
           "description": "Key-value pairs of rule-specific arguments that modify its behavior. See rule definition for detailed list of arguments & their usage."
         },
@@ -102,7 +103,8 @@
         "rules": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/rule"
+            "$ref": "#/definitions/rule",
+            "description": "A rule definition containing category, arguments, severity, and the include / ignore patterns."
           },
           "description": "A collection of rules defined for this ruleset, if this field is included, only these rules will be applied."
         },
@@ -114,6 +116,10 @@
           "$ref": "#/definitions/pathList",
           "description": "Glob pattern specifying files or directories where the ruleset should be enforced."
         }
+      },
+      "additionalProperties": {
+        "type": "null",
+        "description": "Name for the ruleset, defined as a key in the ruleset object."
       },
       "minProperties": 2,
       "description": "Defines a ruleset configuration containing specific rules, ignore paths, or included paths."

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -12,7 +12,7 @@
     "rulesets": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "$ref": "#/definitions/ruleset"
           },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -83,30 +83,39 @@
         }
       }
     },
+    "emptyRuleset": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "null"
+      },
+      "minProperties": 1,
+      "maxProperties": 1
+    },
     "ruleset": {
       "type": "object",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "rules": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/rule"
-            }
-          },
-          "ignore": {
-            "$ref": "#/definitions/pathList"
-          },
-          "only": {
-            "$ref": "#/definitions/pathList"
+      "properties": {
+        "rules": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/rule"
           }
         },
-        "required": [
-          "rules"
-        ]
-      }
+        "ignore": {
+          "$ref": "#/definitions/pathList"
+        },
+        "only": {
+          "$ref": "#/definitions/pathList"
+        }
+      },
+      "patternProperties": {
+        "^[a-zA-Z0-9-_]+$": {
+          "type": "null"
+        }
+      },
+      "required": [
+        "rules"
+      ],
+      "minProperties": 2
     },
     "pathList": {
       "type": "array",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -17,6 +17,9 @@
             "$ref": "#/definitions/ruleset"
           },
           {
+            "$ref": "#/definitions/emptyRuleset"
+          },
+          {
             "type": "string",
             "minLength": 1
           }
@@ -107,14 +110,6 @@
           "$ref": "#/definitions/pathList"
         }
       },
-      "patternProperties": {
-        "^[a-zA-Z0-9-_]+$": {
-          "type": "null"
-        }
-      },
-      "required": [
-        "rules"
-      ],
       "minProperties": 2
     },
     "pathList": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -17,9 +17,6 @@
             "$ref": "#/definitions/ruleset"
           },
           {
-            "$ref": "#/definitions/emptyRuleset"
-          },
-          {
             "type": "string",
             "minLength": 1
           }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -17,6 +17,9 @@
             "$ref": "#/definitions/ruleset"
           },
           {
+            "$ref": "#/definitions/emptyRuleset"
+          },
+          {
             "type": "string",
             "minLength": 1
           }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -5,7 +5,9 @@
     "schema-version": {
       "type": "string",
       "default": "v1",
-      "enum": ["v1"]
+      "enum": [
+        "v1"
+      ]
     },
     "rulesets": {
       "type": "array",
@@ -13,9 +15,6 @@
         "anyOf": [
           {
             "$ref": "#/definitions/ruleset"
-          },
-          {
-            "$ref": "#/definitions/emptyRuleset"
           },
           {
             "type": "string",
@@ -84,14 +83,6 @@
         }
       }
     },
-    "emptyRuleset": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "null"
-      },
-      "minProperties": 1,
-      "maxProperties": 1
-    },
     "ruleset": {
       "type": "object",
       "properties": {
@@ -108,7 +99,9 @@
           "$ref": "#/definitions/pathList"
         }
       },
-      "minProperties": 2
+      "required": [
+        "rules"
+      ]
     },
     "pathList": {
       "type": "array",
@@ -155,5 +148,3 @@
     }
   }
 }
-
-

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -7,7 +7,8 @@
       "default": "v1",
       "enum": [
         "v1"
-      ]
+      ],
+      "description": "Defines the version of the schema used in the configuration file. Only 'v1' is currently supported."
     },
     "rulesets": {
       "type": "array",
@@ -18,26 +19,33 @@
           },
           {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "A reference to a predefined ruleset name."
           }
         ]
       },
-      "minItems": 1
+      "minItems": 1,
+      "description": "List of rulesets to be applied. A ruleset can either be a predefined ruleset name or an object containing rules."
     },
     "ignore": {
-      "$ref": "#/definitions/pathList"
+      "$ref": "#/definitions/pathList",
+      "description": "Glob pattern for files or directories to exclude from analysis for all rulesets."
     },
     "only": {
-      "$ref": "#/definitions/pathList"
+      "$ref": "#/definitions/pathList",
+      "description": "Glob pattern for files or directories to be exclusively analyzed for all rulesets."
     },
     "ignore-gitignore": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "If set to 'true', the rules engine will automatically ignore files specified in the .gitignore file."
     },
     "ignore-generated-files": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "If set to 'true', auto-detects and excludes generated files from analysis."
     },
     "max-file-size-kb": {
-      "type": "number"
+      "type": "number",
+      "description": "Specifies the maximum file size (in kilobytes) to analyze. Files exceeding this size will be ignored."
     }
   },
   "required": [
@@ -48,16 +56,19 @@
       "type": "object",
       "properties": {
         "ignore": {
-          "$ref": "#/definitions/pathList"
+          "$ref": "#/definitions/pathList",
+          "description": "Glob pattern specifying files or directories where this rule should not be applied for this rule."
         },
         "only": {
-          "$ref": "#/definitions/pathList"
+          "$ref": "#/definitions/pathList",
+          "description": "Glob pattern specifying files or directories where this rule should be enforced for this rule."
         },
         "arguments": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/argumentValue"
-          }
+          },
+          "description": "Key-value pairs of rule-specific arguments that modify its behavior. See rule definition for detailed list of arguments & their usage."
         },
         "severity": {
           "anyOf": [
@@ -70,7 +81,8 @@
                 "$ref": "#/definitions/singularSeverityValue"
               }
             }
-          ]
+          ],
+          "description": "Defines the severity level of the rule. Can be 'ERROR', 'WARNING', 'NOTICE', or 'NONE'."
         },
         "category": {
           "enum": [
@@ -79,17 +91,10 @@
             "ERROR_PRONE",
             "PERFORMANCE",
             "SECURITY"
-          ]
+          ],
+          "description": "Classifies the rule into one of the predefined categories such as Security, Best Practices, etc."
         }
       }
-    },
-    "emptyRuleset": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "null"
-      },
-      "minProperties": 1,
-      "maxProperties": 1
     },
     "ruleset": {
       "type": "object",
@@ -98,23 +103,28 @@
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/rule"
-          }
+          },
+          "description": "A collection of rules defined for this ruleset, if this field is included, only these rules will be applied."
         },
         "ignore": {
-          "$ref": "#/definitions/pathList"
+          "$ref": "#/definitions/pathList",
+          "description": "Glob pattern specifying files or directories where the ruleset should not be applied."
         },
         "only": {
-          "$ref": "#/definitions/pathList"
+          "$ref": "#/definitions/pathList",
+          "description": "Glob pattern specifying files or directories where the ruleset should be enforced."
         }
       },
-      "minProperties": 2
+      "minProperties": 2,
+      "description": "Defines a ruleset configuration containing specific rules, ignore paths, or included paths."
     },
     "pathList": {
       "type": "array",
       "items": {
         "type": "string",
         "minLength": 1
-      }
+      },
+      "description": "An array of glob patterns specifying file paths."
     },
     "argumentValue": {
       "anyOf": [
@@ -127,7 +137,8 @@
             "$ref": "#/definitions/singularArgumentValue"
           }
         }
-      ]
+      ],
+      "description": "Specifies argument values for a rule, either as a direct value or a mapping of file paths to values."
     },
     "singularArgumentValue": {
       "anyOf": [
@@ -142,7 +153,8 @@
           "type": "boolean",
           "$comment": "will be internally coerced to string"
         }
-      ]
+      ],
+      "description": "A singular value that can be a string, number, or boolean, used as an argument for a rule."
     },
     "singularSeverityValue": {
       "enum": [
@@ -150,7 +162,8 @@
         "WARNING",
         "NOTICE",
         "NONE"
-      ]
+      ],
+      "description": "Defines the severity level of a rule, indicating its impact."
     }
   }
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -85,23 +85,28 @@
     },
     "ruleset": {
       "type": "object",
-      "properties": {
-        "rules": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/rule"
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "rules": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/rule"
+            }
+          },
+          "ignore": {
+            "$ref": "#/definitions/pathList"
+          },
+          "only": {
+            "$ref": "#/definitions/pathList"
           }
         },
-        "ignore": {
-          "$ref": "#/definitions/pathList"
-        },
-        "only": {
-          "$ref": "#/definitions/pathList"
-        }
-      },
-      "required": [
-        "rules"
-      ]
+        "required": [
+          "rules"
+        ]
+      }
     },
     "pathList": {
       "type": "array",


### PR DESCRIPTION
## What problem are you trying to solve?

Make the schema work smoothly with monaco editor + potentially include in our IDE support in the future.

## What is your solution?

Update the `schema.json`
- This is a breaking change, so I'd like to create a new file that's specifically used for the editor 
- The breaking change is removing rulesets that are `null`, this was causing issues with autocompletion for rulesets. 

## Alternatives considered
- Using the [datadog/schema](https://github.com/DataDog/schema) repository.

## What the reviewer should know
🚢 
