### PR TITLE
Handle invalid UTF-8 characters

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -29,6 +29,7 @@ jobs:
           - { file: './misc/integration-git-hooks.sh', gha_alias: 'Git Hooks' }
           - { file: './misc/integration-test-r.sh', gha_alias: 'R' }
           - { file: './misc/integration-test-rust.sh', gha_alias: 'Rust' }
+          - { file: './misc/integration-test-encoding.sh', gha_alias: 'File Encoding' }
           - { file: './misc/integration-test-sql.sh', gha_alias: 'SQL' }
     name: Run integration test - ${{ matrix.scripts.gha_alias }}
     steps:

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -748,10 +748,9 @@ fn main() -> Result<()> {
     // Secrets detection
     let mut secrets_results: Vec<SecretResult> = vec![];
     if secrets_enabled {
-        let mut path_metadata = HashMap::new();
+        let path_metadata;
         let secrets_start = Instant::now();
-        let mut all_path_metadata_secrets =
-            HashMap::<String, Option<ArtifactClassification>>::new();
+        let all_path_metadata_secrets = HashMap::<String, Option<ArtifactClassification>>::new();
 
         let secrets_files: Vec<PathBuf> = files_to_analyze
             .into_iter()
@@ -772,7 +771,7 @@ fn main() -> Result<()> {
             .into_par_iter()
             .fold(
                 || (Vec::new(), HashMap::new()),
-                |(mut fold_results, mut path_metadata), path| {
+                |(_fold_results, mut path_metadata), path| {
                     let relative_path = path
                         .strip_prefix(directory_path)
                         .unwrap()
@@ -849,8 +848,10 @@ fn main() -> Result<()> {
 
         // adding metadata from secrets
         for (k, v) in path_metadata {
-            if !all_path_metadata.contains_key(&k) && v.is_some() {
-                all_path_metadata.insert(k, v.unwrap());
+            if !all_path_metadata.contains_key(&k) {
+                if let Some(artifact_classification) = v {
+                    all_path_metadata.insert(k, artifact_classification);
+                }
             }
         }
 

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -848,9 +848,9 @@ fn main() -> Result<()> {
 
         // adding metadata from secrets
         for (k, v) in path_metadata {
-            if !all_path_metadata.contains_key(&k) {
+            if let std::collections::hash_map::Entry::Vacant(e) = all_path_metadata.entry(k) {
                 if let Some(artifact_classification) = v {
-                    all_path_metadata.insert(k, artifact_classification);
+                    e.insert(artifact_classification);
                 }
             }
         }

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -26,6 +26,7 @@ use cli::utils::{choose_cpu_count, get_num_threads_to_use, print_configuration};
 use cli::violations_table;
 use common::analysis_options::AnalysisOptions;
 use common::model::diff_aware::DiffAware;
+use datadog_static_analyzer::read_file;
 use getopts::Options;
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -600,7 +601,7 @@ fn main() -> Result<()> {
                         let rule_config = configuration
                             .rule_config_provider
                             .config_for_file(relative_path.as_ref());
-                        let res = if let Ok(file_content) = fs::read_to_string(&path) {
+                        let res = if let Ok(file_content) = read_file(&path) {
                             let mut opt = JS_RUNTIME.replace(None);
                             let runtime_ref = opt.get_or_insert_with(|| {
                                 v8.try_new_runtime().expect("ddsa init should succeed")
@@ -777,7 +778,7 @@ fn main() -> Result<()> {
                         .unwrap()
                         .to_str()
                         .expect("path contains non-Unicode characters");
-                    let res = if let Ok(file_content) = fs::read_to_string(&path) {
+                    let res = if let Ok(file_content) = read_file(&path) {
                         let file_content = Arc::from(file_content);
                         let secrets = find_secrets(
                             &sds_scanner,

--- a/crates/bins/src/lib.rs
+++ b/crates/bins/src/lib.rs
@@ -1,0 +1,17 @@
+use anyhow::format_err;
+use std::fs;
+use std::path::Path;
+
+/// Read a file and if the file has some invalid UTF-8 characters, it returns a string with invalid
+/// characters.
+pub fn read_file(path: &Path) -> anyhow::Result<String> {
+    if let Ok(s) = fs::read_to_string(path) {
+        return Ok(s);
+    }
+
+    if let Ok(bytes) = fs::read(path) {
+        return Ok(String::from_utf8_lossy(&bytes).to_string());
+    }
+
+    Err(format_err!("cannot read file {}", path.display()))
+}

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -56,7 +56,7 @@ fn get_extensions_for_language(language: &Language) -> Option<Vec<String>> {
     None
 }
 
-// if a langauge only match a file for an exact match, return it
+// if a language only match a file for an exact match, return it
 fn get_exact_filename_for_language(language: &Language) -> Option<Vec<String>> {
     for fe in FILE_EXACT_MATCH_PER_LANGUAGE_LIST {
         if fe.0 == *language {
@@ -75,6 +75,47 @@ fn get_prefix_for_language(language: &Language) -> Option<Vec<String>> {
             return Some(extensions.iter().map(|x| x.to_string()).collect());
         }
     }
+    None
+}
+
+/// File the language for a given file.
+pub fn get_language_for_file(path: &PathBuf) -> Option<Language> {
+    // match for extensions (myfile.c, myfile.php, etc).
+    for (language, extensions) in FILE_EXTENSIONS_PER_LANGUAGE_LIST {
+        let extensions_string = extensions
+            .to_vec()
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        if match_extension(path, extensions_string.as_slice()) {
+            return Some(*language);
+        }
+    }
+
+    // match for exact match (e.g. BUILD.bazel, Dockerfile, etc)
+    for (language, filenames) in FILE_EXACT_MATCH_PER_LANGUAGE_LIST {
+        let filename_strings = filenames
+            .to_vec()
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        if match_exact_filename(path, filename_strings.as_slice()) {
+            return Some(*language);
+        }
+    }
+
+    // match for prefix (e.g. Dockerfile.something)
+    for (language, prefixes) in FILE_PREFIX_PER_LANGUAGE_LIST {
+        let prefix_string = prefixes
+            .to_vec()
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>();
+        if match_prefix_filename(path, prefix_string.as_slice()) {
+            return Some(*language);
+        }
+    }
+
     None
 }
 
@@ -861,5 +902,29 @@ mod tests {
             )
             .len()
         );
+    }
+
+    #[test]
+    fn test_get_language_for_file() {
+        // extension
+        assert_eq!(
+            get_language_for_file(&PathBuf::from("path/to/foo.java")),
+            Some(Language::Java)
+        );
+
+        // exact filename
+        assert_eq!(
+            get_language_for_file(&PathBuf::from("BUILD.bazel")),
+            Some(Language::Starlark)
+        );
+
+        // prefix
+        assert_eq!(
+            get_language_for_file(&PathBuf::from("Dockerfile.foobar")),
+            Some(Language::Dockerfile)
+        );
+
+        // none
+        assert_eq!(get_language_for_file(&PathBuf::from("wefwefwef")), None);
     }
 }

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -79,7 +79,7 @@ fn get_prefix_for_language(language: &Language) -> Option<Vec<String>> {
 }
 
 /// File the language for a given file.
-pub fn get_language_for_file(path: &PathBuf) -> Option<Language> {
+pub fn get_language_for_file(path: &Path) -> Option<Language> {
     // match for extensions (myfile.c, myfile.php, etc).
     for (language, extensions) in FILE_EXTENSIONS_PER_LANGUAGE_LIST {
         let extensions_string = extensions

--- a/misc/integration-test-encoding.sh
+++ b/misc/integration-test-encoding.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+## Test that we find errors on repositories with different encoding.
+## The repository https://github.com/muh-nee/sast-files-encoding.git contains
+## code with different encodings.
+
+cargo fetch
+cargo build --locked --profile release-dev --bin datadog-static-analyzer
+
+## An R repository
+echo "Checking muh-nee/sast-files-encoding"
+REPO_DIR=$(mktemp -d)
+export REPO_DIR
+git clone --depth=1 https://github.com/muh-nee/sast-files-encoding.git "${REPO_DIR}"
+
+echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
+echo " - python-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
+
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+
+if [ $? -ne 0 ]; then
+  echo "failed to analyze muh-nee/sast-files-encoding"
+  exit 1
+fi
+
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results.json"`
+
+echo "Found $RES errors"
+
+if [ "$RES" -lt "2" ]; then
+  echo "not enough errors found"
+  exit 1
+fi
+
+echo "All tests passed"
+
+exit 0

--- a/misc/integration-test-secrets.sh
+++ b/misc/integration-test-secrets.sh
@@ -11,7 +11,7 @@ git clone --depth=1 https://github.com/muh-nee/secrets-tests.git "${REPO_DIR}"
 
 # Test without the static-analysis.datadog.yml file
 rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x --enable-secrets true
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x --enable-secrets true --enable-static-analysis false
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze secrets-tests repository"
@@ -22,8 +22,10 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
 
 echo "Found $RES errors on first run"
 
-if [ "$RES" -ne "3" ]; then
-  echo "incorrect number of errors found"
+EXPECTING=5
+
+if [ "$RES" -ne "$EXPECTING" ]; then
+  echo "incorrect number of errors found, found $RES, expecting $EXPECTING"
   exit 1
 fi
 
@@ -45,6 +47,13 @@ status3=`jq '.runs[0].results[2].properties.tags[1]' "${REPO_DIR}/results1.json"
 
 if [ "$status3" != "\"DATADOG_SECRET_VALIDATION_STATUS:NOT_VALIDATED\"" ]; then
   echo "status3: did not find DATADOG_SECRET_VALIDATION_STATUS:NOT_VALIDATED in properties, found $status3"
+  exit 1
+fi
+
+test_file_property=`jq '.runs[0].artifacts[1].properties.tags[0]' "${REPO_DIR}/results1.json"`
+
+if [ "$test_file_property" != "\"DATADOG_ARTIFACT_IS_TEST_FILE\"" ]; then
+  echo "do not tag secret in test files"
   exit 1
 fi
 


### PR DESCRIPTION
## What problem are you trying to solve?

We want to be able to scan files with encoding different than UTF-8

## What is your solution?

Change the functions to read files so that
 - we try to read UTF-8 first
 - if we fail, we fallback and convert the invalid UTF-8 characters into artifacts

## Testing

Added integration tests with the `sast-files-encoding` [repository](https://github.com/muh-nee/sast-files-encoding) that exposes data with different encodings.
