### PR TITLE
[K9VULN-4521] ci(ghcr): fix broken build by unpinning qemu

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -33,8 +33,6 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28 # Pinned due to https://github.com/tonistiigi/binfmt/issues/240
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read


### PR DESCRIPTION
## What problem are you trying to solve?

Our GHCR workflow is failing for the latest release, see [here](https://github.com/DataDog/datadog-static-analyzer/actions/runs/14317017350/job/40126453574)

## What is your solution?

Removing the pinning of the image works, which means we're using QEMU v9 for ARM emulation.

This PR reverts the following PRs that downgraded the runner and pinned QEMU to v7:

- https://github.com/DataDog/datadog-static-analyzer/pull/618
- https://github.com/DataDog/datadog-static-analyzer/pull/643

## Verification

A successful run of this build can be observed in my fork [here](https://github.com/amaanq/datadog-static-analyzer/actions/runs/14408677579/job/40412273588)

## Alternatives considered

## What the reviewer should know

I bumped to Ubuntu latest because that, along with the unpinning, had succeeded in my fork. Ideally, we should be on the latest stable release of Ubuntu, but we had to downgrade to fix the segfaults in the past.


[K9VULN-3202]: https://datadoghq.atlassian.net/browse/K9VULN-3202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ