### PR TITLE
[K9VULN-4729] Fix regression in v8 initialization order

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -21,7 +21,7 @@ use datadog_static_analyzer::{secret_analysis, static_analysis};
 use getopts::Options;
 use git2::Repository;
 use itertools::Itertools;
-use kernel::analysis::ddsa_lib::v8_platform::initialize_v8;
+use kernel::analysis::ddsa_lib::v8_platform::{initialize_v8, Initialized, V8Platform};
 use kernel::classifiers::ArtifactClassification;
 use kernel::constants::{CARGO_VERSION, VERSION};
 use kernel::model::common::OutputFormat::Json;
@@ -392,6 +392,12 @@ fn main() -> Result<()> {
         }
     }
 
+    let mut v8: Option<V8Platform<Initialized>> = None;
+    if static_analysis_enabled {
+        let platform = initialize_v8(configuration.get_num_threads() as u32);
+        _ = v8.insert(platform)
+    }
+
     // This must be called _after_ `initialize_v8` (otherwise, PKU-related segfaults on Linux will occur).
     rayon::ThreadPoolBuilder::new()
         .num_threads(configuration.get_num_threads())
@@ -482,9 +488,8 @@ fn main() -> Result<()> {
 
     if static_analysis_enabled {
         let languages = get_languages_for_rules(&configuration.rules);
-        let v8 = initialize_v8(configuration.get_num_threads() as u32);
         let execution_result = static_analysis(
-            v8,
+            v8.expect("v8 should have been initialized manually"),
             &configuration,
             &analysis_options,
             &files_to_analyze,


### PR DESCRIPTION
## What problem are you trying to solve?
https://github.com/DataDog/datadog-static-analyzer/pull/686 inadvertently changed the relative order in which v8 is initialized, which is causing segfaults (see for context: https://github.com/DataDog/datadog-static-analyzer/pull/589).

<img width="591" alt="image" src="https://github.com/user-attachments/assets/9d6f199e-a309-4156-9dda-cf31dc51c1c0" />

## What is your solution?
Restore the original ordering such that v8 is initialized before Rayon.

## Alternatives considered

## What the reviewer should know
* [CI failure](https://github.com/DataDog/datadog-static-analyzer/actions/runs/14579298199/job/40892250765) is _unrelated_ to this PR (there is a broken formatting rule which causes the job to fail)