### PR TITLE
[K9VULN-4719] Allow rules to specify `beforeAll` and `afterAll` functions

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -360,7 +360,13 @@ impl JsRuntime {
 
 // (Experimental)
 if (typeof beforeAll === \"function\") {{
-    beforeAll();
+    if (beforeAll.length === 0) {{
+        beforeAll();
+    }} else {{
+        // Pass in a clone of the array so the rule code can't mutate the QueryMatchBridge.
+        const allMatches = [...globalThis.__RUST_BRIDGE__query_match];
+        beforeAll(allMatches);
+    }}
 }}
 
 for (const queryMatch of globalThis.__RUST_BRIDGE__query_match) {{
@@ -842,7 +848,7 @@ function visit(captures) {{
 
         // language=javascript
         let valid_before_all = r#"
-function beforeAll() {
+function beforeAll(_allMatches) {
     console.log("beforeAll called");
 }
 "#;
@@ -872,6 +878,49 @@ function afterAll() {
         assert!(res.is_ok(), "should not error on name collision");
         let lines = rt.console.borrow_mut().drain().collect::<Vec<_>>();
         assert_eq!(lines, &["a", "b", "c"]);
+    }
+
+    /// Mutating the `captures` array passed into the `beforeAll` function doesn't mutate the QueryMatchBridge.
+    #[test]
+    fn before_all_no_bridge_mutation() {
+        let mut rt = cfg_test_v8().new_runtime();
+
+        // language=javascript
+        let text = r#"someCall("a", "b", "c");"#;
+        let filename = "some_filename.js";
+        let ts_query = "(string (string_fragment) @str)";
+        // language=javascript
+        let rule = r#"
+function beforeAll(allMatches) {
+    // Test 1: Valid test setup
+    // The number of query matches must be greater than 1 to ensure that we can check equivalence
+    // between the passed in array in this function and the bridge.
+    assert(globalThis.__RUST_BRIDGE__query_match.length > 1, "invalid test setup: not enough query matches");
+
+    // Test 2: The passed in array contains the same data as the bridge.
+    assert(Array.isArray(allMatches), "argument wasn't an array");
+    assert(allMatches.length === globalThis.__RUST_BRIDGE__query_match.length, "arrays not of same length");
+    for (let i = 0, len = allMatches.length; i < len; i++) {
+        assert(allMatches[i] === globalThis.__RUST_BRIDGE__query_match[i], `incorrect capture at index ${i}`);
+    }
+
+    // Test 3: Mutating the array does not mutate the bridge.
+    allMatches[0] = null;
+    assert(allMatches[0] === null, "array could not be mutated");
+    assert(globalThis.__RUST_BRIDGE__query_match[0] !== null, "bridge was mutated");
+
+    console.log("before_all_no_bridge_mutation passed");
+}
+
+function visit(_captures) { }
+"#;
+
+        let res = shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, &rule, None);
+        if let Err(err) = res {
+            panic!("{}", err.to_string());
+        }
+        let lines = rt.console.borrow_mut().drain().collect::<Vec<_>>();
+        assert_eq!(lines[0], "before_all_no_bridge_mutation passed");
     }
 
     /// `scoped_execute` catches and reports JavaScript errors.


### PR DESCRIPTION
## What problem are you trying to solve?
Some rules would be easier to write if there was a way to run code before any `visit` function is invoked or code after all `visit` functions are invoked.

This is useful when the rule's logic depends on the presence of absence of multiple conditions. For example, a C# rule might want to enforce that a type extending System.Exception implements all 3 required constructors, [e.g. like so](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1032)). A rule like this could capture all constructor nodes, set global booleans within the `visit` function if they match a specific pattern, and then after all nodes are visited, determine whether to report a violation or not.

Currently, one could hack together this functionality by incrementing an integer within each visit function and comparing it with the array length to determine whether it's the first or last invocation, but that's...awful.

## What is your solution?
* If a rule specifies a `beforeAll` function, call it before processing any query matches.
    * The function is passed a [copy](https://github.com/DataDog/datadog-static-analyzer/pull/695/commits/64527d54fcbbea6acaa761f0849bf8db70d9492c#diff-994c58d79e1d82b4513246e0ed000503007a0ba771b3f9d7569fb79c7ed94efaR367) of the data in the query match bridge to prevent the rule code from inadvertently mutating the actual bridge's data.
* If the rule specifies an `afterAll` function, call it after processing all query matches.

## Alternatives considered

## What the reviewer should know
* This is marked as "experimental" in the code comments until we decide to officially support it.