### PR TITLE
bump SDS version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "dd-sds"
 version = "0.1.2"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=6f933121394d7d0fe62f58065623cba657f7bb5d#6f933121394d7d0fe62f58065623cba657f7bb5d"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=95f3884aa7a502b848d234c27cc53800ad2a0947#95f3884aa7a502b848d234c27cc53800ad2a0947"
 dependencies = [
  "ahash",
  "async-trait",

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,4 +15,4 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "6f933121394d7d0fe62f58065623cba657f7bb5d" }
+dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "95f3884aa7a502b848d234c27cc53800ad2a0947" }


### PR DESCRIPTION
## What problem are you trying to solve?
Bug in existing `dd-sds` version

## What is your solution?
Updating the `dd-sds` lib version with a [bugfix](https://github.com/DataDog/dd-sensitive-data-scanner/pull/177)

## Alternatives considered
Not updating the version (not good)

## What the reviewer should know
The bug removed matches from the returned list of matches after calling `.validate_matches`, if there was no match validator assigned. Now, all matches are returned and the status is set to `NotAvailable` if a match validator was not available. This is an existing status so it shouldn't require any additional code changes.

