### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,6 +31,7 @@ jobs:
           - { file: './misc/integration-test-rust.sh', gha_alias: 'Rust' }
           - { file: './misc/integration-test-sql.sh', gha_alias: 'SQL' }
           - { file: './misc/integration-test-encoding.sh', gha_alias: 'File Encoding' }
+          - { file: './misc/integration-test-default-config.sh', gha_alias: 'Default Config' }
     name: Run integration test - ${{ matrix.scripts.gha_alias }}
     steps:
       - uses: actions/checkout@v4

--- a/misc/integration-test-default-config.sh
+++ b/misc/integration-test-default-config.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This test ensures that an invocation of the analyzer fetches a default configuration (if it exists and credentials are valid).
+
+cargo fetch
+cargo build --locked --profile release-dev --bin datadog-static-analyzer
+
+# (An arbitrary repository that contains at least one file with an extension supported by datadog-static-analyzer)
+#
+# Note that we override the repo name to be `datadog-static-analyzer-test-repo` (which is set up to have a repo-specific
+# configuration to ensure a stable test setup)
+REPO_DIR=$(mktemp -d)
+git clone https://github.com/juli1/rosie-tests.git "${REPO_DIR}" \
+    && git -C "${REPO_DIR}" checkout 37874bd2fcb1d39a9ce4a614e6a07826e04d0cb1 -q \
+    && git -C "${REPO_DIR}" remote set-url origin https://github.com/DataDog/datadog-static-analyzer-test-repo
+
+SARIF_FILENAME="results.json"
+
+rm -f "${REPO_DIR}/static-analysis.datadog.yml"
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/${SARIF_FILENAME}" -f sarif
+
+sarif_ruleset_count=$(jq '[.runs[0].tool.driver.rules[].id | split("/") | .[0]] | unique | length' "${REPO_DIR}/${SARIF_FILENAME}") \
+    || { echo "failed to parse SARIF ruleset count" >&2; exit 1; }
+
+if ! [[ "${sarif_ruleset_count}" =~ ^[0-9]+$ ]]; then
+  echo "expected jq to output an integer for sarif_ruleset_count, got \`${sarif_ruleset_count}\`" >&2
+  exit 1
+fi
+
+if [[ "${sarif_ruleset_count}" -le 1 ]]; then
+  echo "expected at least one ruleset to have been fetched" >&2
+  exit 1
+fi
+
+echo "All tests passed"
+exit 0

--- a/misc/integration-test-docker.sh
+++ b/misc/integration-test-docker.sh
@@ -9,42 +9,22 @@ REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone --depth=1 https://github.com/juli1/dd-sa-dockerfile.git "${REPO_DIR}"
 
-echo "Try without the static-analysis.datadog.yml file"
-rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
-
-if [ $? -ne 0 ]; then
-  echo "fail to analyze docker repository"
-  exit 1
-fi
-
-RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
-
-echo "Found $RES errors on first run"
-
-if [ "$RES" -lt "2" ]; then
-  echo "not enough errors found without the static-analysis.datadog.yml file"
-  exit 1
-fi
-
-echo "Try with the static-analysis.datadog.yml file"
-
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - docker-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze docker repository"
   exit 1
 fi
 
-RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results.json"`
 
 echo "Found $RES errors on first run"
 
-if [ "$RES" -lt "8" ]; then
-  echo "not enough errors found with the static-analysis.datadog.yml file"
+if [ "$RES" -lt "1" ]; then
+  echo "test invariant: expected at least 1 violation"
   exit 1
 fi
 

--- a/misc/integration-test-js-ts.sh
+++ b/misc/integration-test-js-ts.sh
@@ -29,8 +29,8 @@ fi
 
 FINDINGS=`jq '.runs[0].results|length' ${REPO_DIR}/results.json`
 echo "Found $FINDINGS violations"
-if [ $FINDINGS -lt 2 ]; then
-  echo "only $FINDINGS found, expected at least 2 findings"
+if [ $FINDINGS -lt 1 ]; then
+  echo "test invariant: expected at least 1 violation"
   exit 1
 fi
 

--- a/misc/integration-test-python.sh
+++ b/misc/integration-test-python.sh
@@ -9,49 +9,33 @@ REPO_DIR=$(mktemp -d)
 export REPO_DIR
 git clone --depth=1 https://github.com/gothinkster/django-realworld-example-app.git "${REPO_DIR}"
 
-# Test without the static-analysis.datadog.yml file
-rm -f "${REPO_DIR}/static-analysis.datadog.yml"
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results1.json" -f sarif -x
 
-if [ $? -ne 0 ]; then
-  echo "fail to analyze django repository"
-  exit 1
-fi
-
-RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results1.json"`
-
-echo "Found $RES errors on first run"
-
-if [ "$RES" -lt "2" ]; then
-  echo "not enough errors found"
-  exit 1
-fi
-
-# Test with the static-analysis.datadog.yml file
 echo "rulesets:"> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-security" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-best-practices" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-django" >> "${REPO_DIR}/static-analysis.datadog.yml"
 echo " - python-inclusive" >> "${REPO_DIR}/static-analysis.datadog.yml"
 
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x
+
+cat "${REPO_DIR}/results.json"
 
 if [ $? -ne 0 ]; then
   echo "fail to analyze django repository"
   exit 1
 fi
 
-RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
+RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results.json"`
 
-echo "Found $RES errors on second run"
+echo "Found $RES errors"
 
-if [ "$RES" -lt "2" ]; then
-  echo "not enough errors found"
+if [ "$RES" -lt "1" ]; then
+  echo "test invariant: expected at least 1 violation"
   exit 1
 fi
 
 # Test that --fail-on-any-violation returns a non-zero return code
-./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results2.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
+./target/release-dev/datadog-static-analyzer --directory "${REPO_DIR}" -o "${REPO_DIR}/results.json" -f sarif -x --fail-on-any-violation=none,notice,warning,error
 
 if [ $? -eq 0 ]; then
   echo "static analyzer reports 0 when it should not"

--- a/misc/integration-test-r.sh
+++ b/misc/integration-test-r.sh
@@ -24,8 +24,8 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
 
 echo "Found $RES errors on second run"
 
-if [ "$RES" -lt "2" ]; then
-  echo "not enough errors found"
+if [ "$RES" -lt "1" ]; then
+  echo "test invariant: expected at least 1 violation"
   exit 1
 fi
 

--- a/misc/integration-test-sql.sh
+++ b/misc/integration-test-sql.sh
@@ -24,8 +24,8 @@ RES=`jq '.runs[0].results | length ' "${REPO_DIR}/results2.json"`
 
 echo "Found $RES errors on second run"
 
-if [ "$RES" -lt "2" ]; then
-  echo "not enough errors found"
+if [ "$RES" -lt "1" ]; then
+  echo "test invariant: expected at least 1 violation"
   exit 1
 fi
 


### PR DESCRIPTION
## What problem are you trying to solve?
Our integration tests rely on production data, which can change in ways that unintentionally violate expected test invariants. This can lead to failures in CI. For example, on May 1st, a change to the application key's org-wide configuration caused some integration tests to break:
<img width="560" alt="image" src="https://github.com/user-attachments/assets/ce07f443-6200-438f-90b2-d29e8821786a" />

([Associated failed CI job](https://github.com/DataDog/datadog-static-analyzer/actions/runs/14841748892/job/41666142370))

## What is your solution?
* Remove redundant tests of "no configuration file" behavior, and instead consolidate them into `integration-test-default-config.sh`.
* Test the "no configuration file" behavior on a repository with a known-stable configuration. (slightly hacky: this is done by having the repo masquerade as `datadog-static-analyzer-test-repo`, a private repo with a repo-level configuration).

## Alternatives considered
* Converting the default configuration test from an integration test to a unit test
* Removing per-language integration tests altogether (leaving only one language for the workflow)

## What the reviewer should know
* The important behavior tested is that rulesets can be fetched and used to find violations. Thus, finding 1 violation proves the same thing as finding 8 violations, meaning it makes sense to change existing tests to look for [only at least one](https://github.com/DataDog/datadog-static-analyzer/pull/700/commits/7cda00ed4852268a67bd29904a1e5bb34b6d78a3#diff-ae1051170e63df7449d0cb374849981196bc3c264f51a67ba26dbd14eb626f3dL46-R27) to decrease their flakiness.