### PR TITLE
[K9VULN-6127] Add json file extension mapping

### DIFF
--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -20,6 +20,7 @@ static FILE_EXTENSIONS_PER_LANGUAGE_LIST: &[(Language, &[&str])] = &[
     (Language::Go, &["go"]),
     (Language::Java, &["java"]),
     (Language::JavaScript, &["js", "jsx", "mjs", "cjs"]),
+    (Language::Json, &["json"]),
     (Language::Kotlin, &["kt", "kts"]),
     (Language::Python, &["py", "py3"]),
     (Language::Ruby, &["rb"]),


### PR DESCRIPTION
## What problem are you trying to solve?
We're not scanning `.json` files because we didn't explicitly list it as a file extension.

## What is your solution?
Add the file extension.

## Alternatives considered

## What the reviewer should know
To avoid this in the future, we should implement a compile-time guarantee that we've covered all mappings. This can be done in a followup PR.