### PR TITLE
[K9VULN-6179] Fix CI

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -27,7 +27,5 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: datadog-static-analyzer
-        dd_env: github-action
         dd_site: ${{ vars.DD_SITE }}
 


### PR DESCRIPTION
## What problem are you trying to solve?
CI is broken because we're passing `DD_ENV` and `DD_SERVICE` to `datadog-sca-github-action`, which recently removed support for it.

## What is your solution?
Delete invalid inputs.

## Alternatives considered

## What the reviewer should know
