### PR TITLE
[K9VULN-6236] Read file extension if format flag not used within datadog-static-analyzer

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -200,7 +200,6 @@ fn main() -> Result<()> {
     let output_file = matches
         .opt_str("o")
         .context("output file must be specified")?;
-    
     let output_format = match matches.opt_str("f") {
         Some(f) => match f.as_str() {
             "csv" => OutputFormat::Csv,


### PR DESCRIPTION
## What problem are you trying to solve?
Ticket attached: [link](https://datadoghq.atlassian.net/browse/K9VULN-6236) and ticket with more context: [link](https://datadoghq.atlassian.net/browse/K9VULN-5947) 
## What is your solution?
I check to see if the format flag is being called and if it isn't I check the file extension and match it to `csv` or `sarif`
## What the reviewer should know
Command I ran 
```
cargo run --profile release-dev --bin datadog-static-analyzer -- --directory ../../datadog/datadog-sbom-generator --output result.sarif
```
Gist from before changes: [link](https://gist.github.com/JoshuaDelgado2/213da510bc7a4e8949ddaa1bc585168e)
Gist from after changes: [link](https://gist.github.com/JoshuaDelgado2/629d3d41ff70f77eb2a8bfca6786da99)