### PR TITLE
Replace broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can use it in your CI/CD pipeline using our integration:
 - [GitHub Action](https://github.com/DataDog/datadog-static-analyzer-github-action)
 - [CircleCI ORB](https://circleci.com/developer/orbs/orb/datadog/datadog-static-analyzer-circleci-orb)
 
-If you use it in your own CI/CD pipeline, you can integrate the tool directly: see the [Datadog documentation for more information](https://docs.datadoghq.com/code_analysis/static_analysis/setup).
+If you use it in your own CI/CD pipeline, you can integrate the tool directly: see the [Datadog documentation for more information](https://docs.datadoghq.com/security/code_security/static_analysis/setup).
 
 
 ### IntelliJ JetBrains products


### PR DESCRIPTION
One of the links in the readme was dead: https://docs.datadoghq.com/code_analysis/static_analysis/setup.

I replaced it with https://docs.datadoghq.com/security/code_security/static_analysis/setup, which I believe to be the correct replacement.