### PR TITLE
Open repositories instead of initializing them

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -405,7 +405,7 @@ fn main() -> Result<()> {
 
     let files_filtered_by_size = filter_files_by_size(&files_in_repository, &configuration);
     let repository =
-        Repository::init(&configuration.source_directory).expect("fail to initialize repository");
+        Repository::open(&configuration.source_directory).expect("fail to open repository");
 
     let modifications: HashMap<PathBuf, Vec<u32>> = match (
         &default_branch_opt,

--- a/crates/cli/src/git_utils.rs
+++ b/crates/cli/src/git_utils.rs
@@ -105,7 +105,7 @@ fn get_changed_files(diff: &Diff) -> anyhow::Result<HashMap<PathBuf, Vec<u32>>> 
 }
 
 pub fn get_repository_url(path: &str) -> anyhow::Result<String> {
-    let repository_opt = Repository::init(path);
+    let repository_opt = Repository::open(path);
     match repository_opt {
         Ok(repository) => Ok(repository
             .find_remote(ORIGIN)?

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -98,7 +98,7 @@ impl CliConfiguration {
     ) -> anyhow::Result<DiffAwareRequestArguments> {
         let config_hash = self.generate_diff_aware_digest();
 
-        let repository_opt = Repository::init(&self.source_directory);
+        let repository_opt = Repository::open(&self.source_directory);
 
         if repository_opt.is_err() {
             eprintln!("Fail to get repository information");


### PR DESCRIPTION
The original code creates undesired .git directories when trying to analyze non-git-repo directories.
