### PR TITLE
[K9VULN-7909] Update swift grammar

### DIFF
--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -178,6 +178,9 @@ fn main() {
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },
+        // fork of tree-sitter-swift based on
+        // https://github.com/alex-pinkus/tree-sitter-swift/commit/78d84ef82c387fceeb6094038da28717ea052e39
+        // with the generated parser.c and scanner.c
         TreeSitterProject {
             name: "tree-sitter-swift".to_string(),
             compilation_unit: "tree-sitter-swift".to_string(),

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -181,9 +181,9 @@ fn main() {
         TreeSitterProject {
             name: "tree-sitter-swift".to_string(),
             compilation_unit: "tree-sitter-swift".to_string(),
-            repository: "https://github.com/alex-pinkus/tree-sitter-swift.git".to_string(),
+            repository: "https://github.com/muh-nee/tree-sitter-swift.git".to_string(),
             build_dir: "src".into(),
-            commit_hash: "fadd0a0188f4bff57bdfc9ba829ae71b7b01488b".to_string(),
+            commit_hash: "434a6e90a6ce04ee8cc800902fa6357d0723c833".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -541,8 +541,10 @@ fun main() {
     #[test]
     fn test_swift_get_tree() {
         let source_code = r#"
-print("Hello, world!")
-}
+// HelloWorld.swift
+import Foundation
+print("Hello, World!")
+
 "#;
         let t = get_tree(source_code, &Language::Swift);
         assert!(t.is_some());


### PR DESCRIPTION
## What problem are you trying to solve?

We want to upgrade the swift grammar of the analyzer.

## What is your solution?

Since the `parser.c` is not available in the official repo (see [this link](https://github.com/alex-pinkus/tree-sitter-swift?tab=readme-ov-file#where-is-your-parserc)), we forked the repo [here](https://github.com/muh-nee/tree-sitter-swift) and ran `tree-sitter generate` to generate the `parser.c` and `scanner.c`

## Alternatives considered

I tried to use the rust package but the ABI of tree-sitter mismatched and was not working.

