### PR TITLE
[K9VULN-7322] Allow pre-releases from any branch

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,8 +3,8 @@ name: Publish to GHCR
 on:
   workflow_call:
     inputs:
-      release:
-        description: "Whether this is a release build or not"
+      is-production:
+        description: "Whether this is a production build or not"
         required: true
         default: false
         type: boolean
@@ -50,9 +50,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            latest=${{ inputs.release }}
+            latest=${{ inputs.is-production }}
           tags: |
-            type=raw,value=latest,enable=${{ inputs.release }}
+            type=raw,value=latest,enable=${{ inputs.is-production }}
             type=ref,event=tag
             type=sha
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,34 @@ permissions:
   contents: write
 
 jobs:
+  release-type:
+    name: Determine release type
+    runs-on: ubuntu-latest
+    outputs:
+      is-production: ${{ steps.set-var.outputs.is-production }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse tag and branch
+        id: set-var
+        run: |
+          # Releases must be from the main branch and match a specific pattern.
+          if [[ $GITHUB_REF =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            git fetch -q -n origin main
+
+            if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/main"; then
+              echo "::error::Release for tag ${{ github.ref_name }} must be from a commit on the main branch."
+              exit 1
+            else
+              echo "is-production=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "is-production=false" >> $GITHUB_OUTPUT
+          fi
+
   test-rules:
     uses: './.github/workflows/test-rules.yaml'
 
@@ -26,6 +54,8 @@ jobs:
     uses: './.github/workflows/versions-check.yaml'
 
   build:
+    needs:
+      - release-type
     strategy:
       fail-fast: false
       matrix:
@@ -101,9 +131,10 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  release:
+  github-release:
     name: Release on GitHub
     needs:
+      - release-type
       - test-rules
       - test-docker-build
       - integration-tests
@@ -113,26 +144,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      release: ${{ steps.set-release.outputs.release }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set release variable
-        id: set-release
-        run: |
-          mainCount=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)" | grep -xc main)
-          if [[ $mainCount -eq 0 ]]; then
-            echo "Tag was not pushed onto main branch, exiting"
-            exit 1
-          elif [[ $GITHUB_REF =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "release=true" >> $GITHUB_OUTPUT
-          else
-            echo "release=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -143,8 +159,8 @@ jobs:
         run: ls -lR
         working-directory: artifacts
 
-      - name: Create release
-        if: ${{ steps.set-release.outputs.release == 'true' }}
+      - name: Create production release
+        if: ${{ needs.release-type.outputs.is-production == 'true' }}
         run: |-
           gh release create --generate-notes  \
             ${{ github.ref_name }} \
@@ -154,7 +170,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create pre-release
-        if: ${{ steps.set-release.outputs.release == 'false' }}
+        if: ${{ needs.release-type.outputs.is-production != 'true' }}
         run: |-
           gh release create --generate-notes --prerelease \
             ${{ github.ref_name }} \
@@ -164,10 +180,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   ghcr:
-    needs: release
+    needs:
+      - release-type
+      - github-release
+    if: ${{ needs.release-type.outputs.is-production == 'true' }}
     uses: './.github/workflows/ghcr.yml'
     with:
-      release: ${{ needs.release.outputs.release == 'true' }}
+      is-production: ${{ needs.release-type.outputs.is-production == 'true' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What problem are you trying to solve?
Currently, "pre-release" GitHub releases via the `release.yml` workflow do not work unless the branch is `main`, which defeats the purpose of a pre-release.

## What is your solution?
* Allow pre-releases from any branch
    * As part of this, I refactored the check for "is this commit on main?" to use commit ancestry. This is more robust (and communicates intent better) than string manipulation and parsing of branch names.

## Testing
E2E test methodology:

1. 185fed6 from this PR was merged into the main branch of a forked repo (https://github.com/jasonforal/datadog-static-analyzer/commit/628c4abcca0835ec19323f6e90fc329c02dbfa3b)
2. Releases were attempted for all of the below permutations:

||Main Branch|Non-Main Branch|
|-|-|-|
|Production|✅ (see [successful job](https://github.com/jasonforal/datadog-static-analyzer/actions/runs/17273122545), [release](https://github.com/jasonforal/datadog-static-analyzer/releases/tag/0.6.9), [ghcr image](https://github.com/jasonforal/datadog-static-analyzer/pkgs/container/datadog-static-analyzer/498277214?tag=latest))|❌ (See [failed job](https://github.com/jasonforal/datadog-static-analyzer/actions/runs/17271778041))|
|Pre-Release|✅ (see [successful job](https://github.com/jasonforal/datadog-static-analyzer/actions/runs/17273482379), [pre-release](https://github.com/jasonforal/datadog-static-analyzer/releases/tag/0.6.9-beta.2))|✅ (see [successful job](https://github.com/jasonforal/datadog-static-analyzer/actions/runs/17271803507), [pre-release](https://github.com/jasonforal/datadog-static-analyzer/releases/tag/0.6.9-beta.1))|

## Alternatives considered
N/A

## What the reviewer should know
* I also removed the GHCR publishing step for pre-releases. We don't use these internally, so it's wasteful to build them.
* I changed some job/step/variable names to be more clear about the production/pre-release distinction