### PR TITLE
fix(ide): capture multiple segments on base64 query path arguments

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::error::ConfigFileError;
 use super::models::{AddRuleSetsRequest, IgnoreRuleRequest};
 use super::static_analysis_config_file::StaticAnalysisConfigFile;
@@ -43,17 +45,19 @@ pub fn post_rulesets(request: Json<AddRuleSetsRequest>) -> Result<String, Custom
 }
 
 #[instrument()]
-#[rocket::get("/v1/config/rulesets/<content>")]
-pub fn get_rulesets(content: &str) -> Json<Vec<String>> {
-    tracing::debug!(%content);
-    Json(StaticAnalysisConfigFile::to_rulesets(content.to_string()))
+#[rocket::get("/v1/config/rulesets/<content..>")]
+pub fn get_rulesets(content: PathBuf) -> Json<Vec<String>> {
+    let content_str = content.to_string_lossy().into_owned();
+    tracing::debug!(%content_str);
+    Json(StaticAnalysisConfigFile::to_rulesets(content_str))
 }
 
 #[instrument()]
-#[rocket::get("/v1/config/can-onboard/<content>")]
-pub fn can_onboard(content: &str) -> Result<Json<bool>, Custom<ConfigFileError>> {
-    tracing::debug!(%content);
-    let config = StaticAnalysisConfigFile::try_from(content.to_string())
+#[rocket::get("/v1/config/can-onboard/<content..>")]
+pub fn can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFileError>> {
+    let content_str = content.to_string_lossy().into_owned();
+    tracing::debug!(%content_str);
+    let config = StaticAnalysisConfigFile::try_from(content_str)
         .map_err(|e| Custom(Status::InternalServerError, e))?;
     let can_onboard = config.is_onboarding_allowed();
     Ok(Json(can_onboard))


### PR DESCRIPTION
## What problem are you trying to solve?

The endpoints `can-onboard` and `rulesets` rely on having a path parameter which is a base64 string. The problem is that this string may have `/` chars, thus making rocket unable to map the route.

## What is your solution?

The fix is matching against [multiple segments](https://rocket.rs/guide/v0.4/requests/#multiple-segments)

## Alternatives considered

This is a fix to support the current IDE extensions/plugins. 

We will provide a new PR with a V2 version of these endpoints to avoid having to care about URL length. Then the IDEs will have time to adapt to these new endpoints.

## What the reviewer should know


IDE-4956