### PR TITLE
Update build to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest, image: 'ubuntu:20.04' }
-          - { target: x86_64-unknown-linux-gnu,  os: ubuntu-latest, image: 'ubuntu:20.04' }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest, image: 'ubuntu:22.04' }
+          - { target: x86_64-unknown-linux-gnu,  os: ubuntu-latest, image: 'ubuntu:22.04' }
           - { target: aarch64-apple-darwin,      os: macos-latest                         }
           - { target: x86_64-apple-darwin,       os: macos-13                             }
           - { target: x86_64-pc-windows-msvc,    os: windows-latest                       }


### PR DESCRIPTION
## What problem are you trying to solve?

We build binaries for Ubuntu 20.04, which is [EOL](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare).

## What is your solution?

Switch to 22.04