### PR TITLE
[K9VULN-8362] Use API URL

### DIFF
--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -176,6 +176,7 @@ mod tests {
                 arguments: vec![],
                 tests: vec![],
                 is_testing: false,
+                documentation_url: None,
             }],
             rule_config_provider: RuleConfigProvider::default(),
             max_file_size_kb: 1,

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -169,6 +169,7 @@ pub struct ApiResponseRule {
     pub severity: RuleSeverity,
     pub category: RuleCategory,
     pub tests: Vec<ApiResponseRuleTest>,
+    pub documentation_url: Option<String>,
     pub is_testing: bool,
 }
 
@@ -230,6 +231,7 @@ impl APIResponseRuleset {
                         })
                         .collect(),
                     is_testing: rule_from_api.is_testing,
+                    documentation_url: rule_from_api.documentation_url,
                 })
                 .collect(),
             None => Vec::new(),

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1050,6 +1050,7 @@ mod tests {
             .arguments(vec![])
             .tests(vec![])
             .is_testing(false)
+            .documentation_url(None)
             .build()
             .unwrap();
         let rule_taint_flow = Rule {
@@ -1339,6 +1340,7 @@ mod tests {
             .cwe(Some("1234".to_string()))
             .arguments(vec![])
             .tests(vec![])
+            .documentation_url(None)
             .is_testing(false)
             .build()
             .unwrap();
@@ -1587,6 +1589,7 @@ mod tests {
             .cwe(None)
             .tests(vec![])
             .is_testing(false)
+            .documentation_url(None)
             .build()
             .unwrap();
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1069,6 +1069,7 @@ mod tests {
             arguments: vec![],
             tests: vec![],
             is_testing: false,
+            documentation_url: None,
         };
         let region0 = Region {
             start: Position { line: 50, col: 5 },

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -215,8 +215,10 @@ where
                         console_lines,
                         timing,
                     } = execution;
+
                     let console_output = (!console_lines.is_empty() && analysis_option.log_output)
                         .then_some(console_lines.join("\n"));
+
                     violations.retain(|v| {
                         let base_ignored =
                             lines_to_ignore.should_filter_rule(rule.name.as_str(), v.start.line);

--- a/crates/static-analysis-kernel/src/model/ruleset.rs
+++ b/crates/static-analysis-kernel/src/model/ruleset.rs
@@ -89,6 +89,7 @@ mod tests {
             arguments: vec![],
             tests: vec![],
             is_testing: false,
+            documentation_url: None,
         }
     }
 

--- a/crates/static-analysis-server/src/model/analysis_request.rs
+++ b/crates/static-analysis-server/src/model/analysis_request.rs
@@ -61,6 +61,7 @@ impl From<ServerRule> for kernel::model::rule::Rule {
             arguments: value.arguments,
             tests: vec![],
             is_testing: false,
+            documentation_url: None, // no need to have documentation for executing the rule
         }
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

We hardcode the URL for a rule and do not use the optional value returned by the API

## What is your solution?

Use the API reported by the API


## Tested

Added unit tests + tested with a test on an internal repo with a custom rule