### PR TITLE
Update tree-sitter-jaa

### DIFF
--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -110,7 +110,7 @@ fn main() {
             name: "tree-sitter-java".to_string(),
             compilation_unit: "tree-sitter-java".to_string(),
             repository: "https://github.com/tree-sitter/tree-sitter-java.git".to_string(),
-            commit_hash: "5e62fbb519b608dfd856000fdc66536304c414de".to_string(),
+            commit_hash: "e10607b45ff745f5f876bfa3e94fbcc6b44bdc11".to_string(),
             build_dir: "src".into(),
             files: vec!["parser.c".to_string()],
             cpp: false,


### PR DESCRIPTION
## What problem are you trying to solve?

Update the `tree-sitter-java` grammar to support more modern construct (e.g. use of `var`, etc).

## What is your solution?

Upgrade the `sha` of the grammar.