### PR TITLE
[K9VULN-8459] Add `findNamedChild` function

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
@@ -87,6 +87,24 @@ export class DDSA {
     }
 
     /**
+     * Returns an ancestor node that satisfies a given condition, or undefined if none could be found.
+     * @param {TreeSitterNode | TreeSitterFieldChildNode} node
+     * @param {string} childName
+     * @returns {TreeSitterNode | TreeSitterFieldChildNode | undefined}
+     */
+    findNamedChild(node, childName) {
+        if (node === undefined) {
+            return undefined;
+        }
+        for (const c of ddsa.getChildren(node)){
+            if (c.fieldName === childName){
+                return c;
+            }
+        }
+        return undefined;
+    }
+
+    /**
      * Fetches and returns the provided node's parent in the tree-sitter tree.
      * If the node is the root node of the tree, `undefined` will be returned.
      * @param {TreeSitterNode | TreeSitterFieldChildNode} node

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
@@ -22,7 +22,7 @@ mod tests {
             "getChildren",
             "findAncestor",
             "findDescendant",
-            "getNamedChild",
+            "findNamedChild",
             "getParent",
             "getTaintSinks",
             "getTaintSources",

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
@@ -22,6 +22,7 @@ mod tests {
             "getChildren",
             "findAncestor",
             "findDescendant",
+            "getNamedChild",
             "getParent",
             "getTaintSinks",
             "getTaintSources",
@@ -56,6 +57,26 @@ function visit(query, filename, code) {{
         let res =
             shorthand_execute_rule(&mut rt, Python, ts_query, &rule_code, text, None).unwrap();
         assert_eq!(res.console_lines[0], "print");
+    }
+
+    #[test]
+    fn test_find_named_child() {
+        let mut rt = cfg_test_v8().new_runtime();
+        let text = "def mymethod():\n  pass";
+        let ts_query = "(function_definition)@func";
+        let rule_code = r#"
+
+function visit(query, filename, code) {{
+  const n = query.captures.func;
+  const c = ddsa.findNamedChild(n, "body");
+  console.log(c.text);
+}}
+"#;
+
+        // Then execute the rule that fetches the children of the node.
+        let res =
+            shorthand_execute_rule(&mut rt, Python, ts_query, &rule_code, text, None).unwrap();
+        assert_eq!(res.console_lines[0], "pass");
     }
 
     #[test]


### PR DESCRIPTION
## What problem are you trying to solve?

Add the function `findNamedChild()` that is used to get a named child.

## What is your solution?

Add the function + add tests.