### PR TITLE
[K9VULN-12862] Skip crawling of non-UTF-8 paths

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -405,7 +405,7 @@ fn main() -> Result<()> {
         subdirectories_to_analyze.clone(),
         &path_config,
     )
-    .expect("unable to get the list of files to analyze");
+    .context("unable to get the list of files to analyze")?;
 
     let num_cores_requested = matches
         .opt_str("c")

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -913,6 +913,23 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn get_files_non_utf8_path() {
+        let tmp = TestDir::new();
+
+        let valid_path = tmp.base_path().join("valid.js");
+        fs::File::create(&valid_path).unwrap();
+        // (0xFF isn't a valid UTF-8 byte)
+        let invalid_path = tmp
+            .base_path()
+            .join(<std::ffi::OsStr as std::os::unix::ffi::OsStrExt>::from_bytes(b"\xFF.js"));
+        fs::File::create(&invalid_path).unwrap();
+
+        let files = get_files(tmp.base_path(), vec![], &PathConfig::default()).unwrap();
+        assert_eq!(files, vec![valid_path]);
+    }
+
     #[test]
     fn test_get_language_for_file() {
         // extension Java

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -333,19 +333,16 @@ pub fn filter_files_by_diff_aware_info(
     directory_path: &Path,
     diff_aware_info: &DiffAwareData,
 ) -> Vec<PathBuf> {
-    let files_to_scan: HashSet<&str> =
-        HashSet::from_iter(diff_aware_info.files.iter().map(|f| f.as_str()));
+    let files_to_scan: HashSet<&Path> =
+        HashSet::from_iter(diff_aware_info.files.iter().map(Path::new));
 
     files
         .iter()
-        .filter(|f| {
-            let p = f
-                .strip_prefix(directory_path)
-                .unwrap()
-                .to_str()
-                .expect("path contains non-Unicode characters");
-
-            files_to_scan.contains(p)
+        .filter(|file_path| {
+            let Ok(rel_path) = file_path.strip_prefix(directory_path) else {
+                return false;
+            };
+            files_to_scan.contains(rel_path)
         })
         .cloned()
         .collect()

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -196,14 +196,12 @@ pub fn get_files(
             // repo with a custom rule.
             let mut should_include = entry.is_file() && !entry.is_symlink();
 
-            let relative_path_str = entry
-                .strip_prefix(directory)
-                .ok()
-                .and_then(|p| p.to_str())
-                .ok_or_else(|| anyhow::Error::msg("should get the path"))?;
+            let Ok(Some(rel_path_str)) = entry.strip_prefix(directory).map(|p| p.to_str()) else {
+                continue;
+            };
 
             // check if the path is allowed by the configuration.
-            should_include = should_include && path_config.allows_file(relative_path_str);
+            should_include = should_include && path_config.allows_file(rel_path_str);
 
             // do not include the git directory.
             if entry.starts_with(&git_directory) {


### PR DESCRIPTION
## What problem are you trying to solve?
We currently panic when encountering a path with non-UTF-8 characters while crawling the directory for files to scan.

## What is your solution?
* Skip non-UTF-8 paths
* In case of some other error -- return an exit instead of panicking.

## Alternatives considered

## What the reviewer should know
* This behaves consistent with how [we drop lines](https://github.com/DataDog/datadog-static-analyzer/blob/a6874d56010f6a477d98ef644f97050561521dae/crates/cli/src/file_utils.rs#L145-L148) containing non-UTF-8 paths from the `.gitignore`
* I updated a diff aware function to use `&Path` instead of `&str` (i.e. don't try to convert to UTF-8), however a non-UTF-8 `PathBuf` is impossible because the data is populated from a JSON response from the backend.