### PR TITLE
Find location method and export in SARIF

### DIFF
--- a/crates/cli/src/csv.rs
+++ b/crates/cli/src/csv.rs
@@ -85,6 +85,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 }],
                 errors: vec![],
                 execution_error: None,

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -452,6 +452,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
@@ -497,6 +498,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1]),
             is_suppressed: false,
+            method_name: None,
         };
         let fingerprint = get_fingerprint_for_violation(
             "taint_flow_rule".to_string(),
@@ -528,6 +530,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
 

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -81,6 +81,7 @@ pub fn convert_secret_result_to_rule_result(secret_result: &SecretResult) -> Rul
                 fixes: vec![],
                 taint_flow: None,
                 is_suppressed: v.is_suppressed,
+                method_name: None,
             })
             .collect(),
     }
@@ -163,6 +164,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -173,6 +175,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -183,6 +186,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
             ],
             errors: vec![],
@@ -227,6 +231,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 20, col: 1 },
@@ -237,6 +242,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: true,
+                    method_name: None,
                 },
             ],
             errors: vec![],

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -196,6 +196,7 @@ impl SarifRuleResult {
                             fixes: vec![],
                             taint_flow: None,
                             is_suppressed: r.is_suppressed,
+                            method_name: None,
                         },
                         r.validation_status.clone(),
                     )

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1311,6 +1311,89 @@ mod tests {
         assert!(validate_data(&sarif_report_to_string));
     }
 
+    // Ensure that a violation with method_name set produces a logicalLocations entry
+    // with kind "function" and the expected name.
+    #[test]
+    fn test_generate_sarif_report_logical_location() {
+        let rule = RuleBuilder::default()
+            .name("my-rule".to_string())
+            .description_base64(None)
+            .language(Language::Python)
+            .checksum("abc".to_string())
+            .pattern(None)
+            .tree_sitter_query_base64(None)
+            .category(RuleCategory::BestPractices)
+            .code_base64(String::new())
+            .short_description_base64(None)
+            .entity_checked(None)
+            .rule_type(RuleType::TreeSitterQuery)
+            .severity(RuleSeverity::Error)
+            .cwe(None)
+            .arguments(vec![])
+            .tests(vec![])
+            .is_testing(false)
+            .documentation_url(None)
+            .build()
+            .unwrap();
+
+        let violation = Violation {
+            start: Position { line: 5, col: 1 },
+            end: Position { line: 5, col: 10 },
+            message: "violation message".to_string(),
+            severity: RuleSeverity::Error,
+            category: RuleCategory::BestPractices,
+            fixes: vec![],
+            taint_flow: None,
+            is_suppressed: false,
+            method_name: Some("myFunction".to_string()),
+        };
+
+        let rule_result = RuleResult {
+            rule_name: "my-rule".to_string(),
+            filename: "myfile.py".to_string(),
+            violations: vec![violation],
+            errors: vec![],
+            execution_error: None,
+            output: None,
+            execution_time_ms: 0,
+            parsing_time_ms: 0,
+            query_node_time_ms: 0,
+        };
+
+        let sarif_report = generate_sarif_report(
+            &[rule.into()],
+            &[SarifRuleResult::try_from(rule_result).unwrap()],
+            &"mydir".to_string(),
+            SarifReportMetadata {
+                add_git_info: false,
+                debug: false,
+                config_digest: "abc".to_string(),
+                diff_aware_parameters: None,
+                execution_time_secs: 0,
+            },
+            &Default::default(),
+        )
+        .expect("generate sarif report");
+
+        let sarif_json = serde_json::to_value(sarif_report).unwrap();
+
+        let location = sarif_json
+            .pointer("/runs/0/results/0/locations/0")
+            .expect("location");
+        let logical_locations = location
+            .get("logicalLocations")
+            .expect("logicalLocations should be present when method_name is set")
+            .as_array()
+            .expect("logicalLocations should be an array");
+
+        assert_eq!(logical_locations.len(), 1);
+        assert_eq!(logical_locations[0]["kind"], "function");
+        assert_eq!(logical_locations[0]["name"], "myFunction");
+
+        // validate the schema
+        assert!(validate_data(&sarif_json));
+    }
+
     // Ensure that diff-aware scanning information are correctly surfaced
     #[test]
     fn test_generate_sarif_diff_aware_scanning() {

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -22,9 +22,10 @@ use secrets::model::secret_result::{SecretResult, SecretValidationStatus, Valida
 use secrets::model::secret_rule::SecretRule;
 use serde_sarif::sarif::{
     self, Artifact, ArtifactBuilder, ArtifactChangeBuilder, ArtifactLocationBuilder, FixBuilder,
-    LocationBuilder, MessageBuilder, PhysicalLocationBuilder, PropertyBagBuilder, RegionBuilder,
-    Replacement, ReportingDescriptor, Result as SarifResult, ResultBuilder, RunBuilder, Sarif,
-    SarifBuilder, SuppressionBuilder, Tool, ToolBuilder, ToolComponent, ToolComponentBuilder,
+    LocationBuilder, LogicalLocationBuilder, MessageBuilder, PhysicalLocationBuilder,
+    PropertyBagBuilder, RegionBuilder, Replacement, ReportingDescriptor, Result as SarifResult,
+    ResultBuilder, RunBuilder, Sarif, SarifBuilder, SuppressionBuilder, Tool, ToolBuilder,
+    ToolComponent, ToolComponentBuilder,
 };
 
 use crate::file_utils::get_fingerprint_for_violation;
@@ -639,21 +640,29 @@ fn generate_results(
                 .map(move |sarif_violation| {
                     let violation = sarif_violation.get_violation();
                     // if we find the rule for this violation, get the id, level and category
-                    let location = LocationBuilder::default()
-                        .physical_location(
-                            PhysicalLocationBuilder::default()
-                                .artifact_location(artifact_loc.clone())
-                                .region(
-                                    RegionBuilder::default()
-                                        .start_line(violation.start.line)
-                                        .start_column(violation.start.col)
-                                        .end_line(violation.end.line)
-                                        .end_column(violation.end.col)
-                                        .build()?,
-                                )
+                    let mut location_builder = LocationBuilder::default();
+                    location_builder.physical_location(
+                        PhysicalLocationBuilder::default()
+                            .artifact_location(artifact_loc.clone())
+                            .region(
+                                RegionBuilder::default()
+                                    .start_line(violation.start.line)
+                                    .start_column(violation.start.col)
+                                    .end_line(violation.end.line)
+                                    .end_column(violation.end.col)
+                                    .build()?,
+                            )
+                            .build()?,
+                    );
+                    if let Some(ref method) = violation.method_name {
+                        location_builder.logical_locations(vec![
+                            LogicalLocationBuilder::default()
+                                .name(method.clone())
+                                .kind("function".to_string())
                                 .build()?,
-                        )
-                        .build()?;
+                        ]);
+                    }
+                    let location = location_builder.build()?;
 
                     let fixes: Vec<sarif::Fix> = violation
                         .fixes

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -655,12 +655,10 @@ fn generate_results(
                             .build()?,
                     );
                     if let Some(ref method) = violation.method_name {
-                        location_builder.logical_locations(vec![
-                            LogicalLocationBuilder::default()
-                                .name(method.clone())
-                                .kind("function".to_string())
-                                .build()?,
-                        ]);
+                        location_builder.logical_locations(vec![LogicalLocationBuilder::default()
+                            .name(method.clone())
+                            .kind("function".to_string())
+                            .build()?]);
                     }
                     let location = location_builder.build()?;
 

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1004,6 +1004,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // good location in the violation location and no fixes
@@ -1016,6 +1017,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // bad location in the fixes location
@@ -1036,6 +1038,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // good location everywhere
@@ -1056,6 +1059,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
     }
 
@@ -1124,6 +1128,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1, region2]),
             is_suppressed: false,
+            method_name: None,
         };
 
         let rule_result_single_region = RuleResultBuilder::default()
@@ -1964,6 +1969,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 };
                 let rr = RuleResult {
                     rule_name: format!("rule-{idx}"),
@@ -2057,6 +2063,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let rule_results = [TEST_FILE_PATH, NON_TEST_FILE_PATH]
             .into_iter()

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
@@ -141,7 +141,11 @@ export class DDSA {
      * ```
      */
     getEnclosingFunctionName(node) {
-        const fnNode = ddsa.findAncestor(node, n => FUNCTION_NODE_TYPES.has(n.cstType));
+        // Check node itself first: findAncestor starts from the parent, so if node is
+        // itself a function/method declaration, it would otherwise be skipped.
+        const fnNode = FUNCTION_NODE_TYPES.has(node?.cstType)
+            ? node
+            : ddsa.findAncestor(node, n => FUNCTION_NODE_TYPES.has(n.cstType));
         if (fnNode === undefined) {
             return undefined;
         }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
@@ -101,6 +101,54 @@ export class DDSA {
     }
 
     /**
+     * Returns the name of the function or method enclosing the provided node, or `undefined` if none
+     * could be found.
+     *
+     * This works across all supported languages by walking up the tree-sitter AST until a function
+     * or method declaration node is found, then extracting the value of its `name` field child.
+     *
+     * @param {TreeSitterNode | TreeSitterFieldChildNode} node
+     * @returns {string | undefined}
+     *
+     * @example
+     * ```javascript
+     * // In a rule:
+     * const v = Violation.new("message", node);
+     * v.withMethodName(ddsa.getEnclosingFunctionName(node));
+     * ```
+     */
+    getEnclosingFunctionName(node) {
+        const FUNCTION_NODE_TYPES = new Set([
+            // Java, C#, Kotlin
+            "method_declaration",
+            "constructor_declaration",
+            // Python
+            "function_definition",
+            // JavaScript / TypeScript
+            "function_declaration",
+            "method_definition",
+            "function_expression",
+            // Go
+            "function_literal",
+            // Ruby
+            "method",
+            "singleton_method",
+            // Generic / other languages
+            "function",
+            "function_item",
+        ]);
+
+        const fnNode = ddsa.findAncestor(node, n => FUNCTION_NODE_TYPES.has(n.cstType));
+        if (fnNode === undefined) {
+            return undefined;
+        }
+        const nameChild = ddsa.getChildren(fnNode).find(
+            c => c instanceof TreeSitterFieldChildNode && c.fieldName === "name"
+        );
+        return nameChild?.text;
+    }
+
+    /**
      * Returns a backwards flow analysis: a list of `TaintFlow` containing sources of the provided `sinkNode`.
      * @param {TreeSitterNode} sinkNode
      * @returns {Array<TaintFlow>}

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.js
@@ -10,6 +10,29 @@ import {TreeSitterFieldChildNode} from "ext:ddsa_lib/ts_node";
 const { op_digraph_adjacency_list_to_dot, op_ts_node_named_children, op_ts_node_parent } = Deno.core.ops;
 
 /**
+ * The set of tree-sitter node types that represent a function or method declaration,
+ * used by {@link DDSA#getEnclosingFunctionName} to identify enclosing scopes.
+ */
+const FUNCTION_NODE_TYPES = new Set([
+    // Java, C#, Kotlin
+    "method_declaration",
+    "constructor_declaration",
+    // Python
+    "function_definition",
+    // JavaScript / TypeScript
+    "function_declaration",
+    "method_definition",
+    "function_expression",
+    // Go: function_declaration and method_declaration (listed above) cover named functions and methods.
+    // Ruby
+    "method",
+    "singleton_method",
+    // Generic / other languages
+    "function",
+    "function_item",
+]);
+
+/**
  * The main entrypoint to the ddsa JavaScript runtime's API.
  */
 export class DDSA {
@@ -118,26 +141,6 @@ export class DDSA {
      * ```
      */
     getEnclosingFunctionName(node) {
-        const FUNCTION_NODE_TYPES = new Set([
-            // Java, C#, Kotlin
-            "method_declaration",
-            "constructor_declaration",
-            // Python
-            "function_definition",
-            // JavaScript / TypeScript
-            "function_declaration",
-            "method_definition",
-            "function_expression",
-            // Go
-            "function_literal",
-            // Ruby
-            "method",
-            "singleton_method",
-            // Generic / other languages
-            "function",
-            "function_item",
-        ]);
-
         const fnNode = ddsa.findAncestor(node, n => FUNCTION_NODE_TYPES.has(n.cstType));
         if (fnNode === undefined) {
             return undefined;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ddsa.rs
@@ -23,6 +23,7 @@ mod tests {
             "findAncestor",
             "findDescendant",
             "getParent",
+            "getEnclosingFunctionName",
             "getTaintSinks",
             "getTaintSources",
         ];

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.js
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.js
@@ -47,6 +47,11 @@ export class Violation {
          * @type {Array<CodeRegion> | undefined}
          */
         this.taintFlowRegions = undefined;
+        /**
+         * The name of the method or function enclosing this violation, if any.
+         * @type {string | undefined}
+         */
+        this.methodName = undefined;
 
         if (locationArgs.length > 0) {
             const location = inferRegionVariadic(locationArgs);
@@ -55,6 +60,16 @@ export class Violation {
                 this.baseRegion = this.taintFlowRegions[0];
             } else {
                 this.baseRegion = (/** @type {CodeRegion} */ location);
+            }
+            // Auto-populate methodName: if a TreeSitterNode is passed directly, use it to find the
+            // enclosing function. For TaintFlow, use the first node in the flow.
+            if (locationArgs[0] instanceof TreeSitterNode) {
+                this.methodName = globalThis.ddsa.getEnclosingFunctionName(locationArgs[0]);
+            } else if (locationArgs[0] instanceof TaintFlow) {
+                for (const node of locationArgs[0]) {
+                    this.methodName = globalThis.ddsa.getEnclosingFunctionName(node);
+                    break;
+                }
             }
         }
     }
@@ -69,6 +84,16 @@ export class Violation {
             this.fixes = [];
         }
         this.fixes.push(fix);
+        return this;
+    }
+
+    /**
+     * Sets the name of the enclosing method or function and returns `this`.
+     * @param {string} name
+     * @returns {Violation}
+     */
+    withMethodName(name) {
+        this.methodName = name;
         return this;
     }
 

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
@@ -147,8 +147,10 @@ mod tests {
             "message",
             "baseRegion",
             "taintFlowRegions",
+            "methodName",
             // Methods
             "addFix",
+            "withMethodName",
         ];
         assert!(js_instance_eq(Violation::CLASS_NAME, instance_exp));
         let class_expected = &["new"];
@@ -158,8 +160,8 @@ mod tests {
     #[test]
     fn variadic_violation_creation() {
         let converter = ViolationConverter::new();
-        let mut rt = cfg_test_v8().deno_core_rt();
-        let scope = &mut rt.handle_scope();
+        let mut rt = cfg_test_v8().new_runtime();
+        let scope = &mut rt.v8_handle_scope();
 
         let region0 = CodeRegion::<Instance> {
             start_line: 22,

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
@@ -22,6 +22,7 @@ pub struct Violation<T> {
     pub fixes: Option<Vec<Fix<T>>>,
     pub base_region: CodeRegion<T>,
     pub taint_flow_regions: Option<Vec<CodeRegion<T>>>,
+    pub method_name: Option<String>,
     /// (See documentation on [`Instance`]).
     pub _pd: PhantomData<T>,
 }
@@ -55,6 +56,7 @@ impl Violation<Instance> {
             fixes,
             taint_flow,
             is_suppressed: false,
+            method_name: self.method_name,
         }
     }
 }
@@ -112,12 +114,16 @@ impl V8Converter for ViolationConverter {
                     .collect::<Result<Vec<_>, _>>()
             })
             .transpose()?;
+        let method_name =
+            get_optional_field::<v8::String>(v8_obj, "methodName", scope, "string | undefined")?
+                .map(|s| s.to_rust_string_lossy(scope));
 
         Ok(Violation {
             message,
             fixes,
             base_region,
             taint_flow_regions,
+            method_name,
             _pd: PhantomData,
         })
     }
@@ -174,6 +180,7 @@ mod tests {
             fixes: None,
             base_region: region0,
             taint_flow_regions: None,
+            method_name: None,
             _pd: PhantomData,
         };
 
@@ -204,6 +211,7 @@ Violation.new("abc", tsNode);
             fixes: None,
             base_region: region0,
             taint_flow_regions: Some(vec![region0, region1]),
+            method_name: None,
             _pd: PhantomData,
         };
         let flow_variants = &[r#"

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -1148,6 +1148,7 @@ function visit(captures) {
             message: "`protectedName` is a protected variable name".to_string(),
             fixes: None,
             taint_flow_regions: None,
+            method_name: None,
             _pd: PhantomData,
         };
         assert_eq!(*violation, expected);
@@ -1429,6 +1430,7 @@ function visit(query, filename, code) {
             message: "`protectedName` is a protected variable name".to_string(),
             fixes: None,
             taint_flow_regions: None,
+            method_name: None,
             _pd: PhantomData,
         };
         assert_eq!(*violation, expected);

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -1154,6 +1154,69 @@ function visit(captures) {
         assert_eq!(*violation, expected);
     }
 
+    /// When a `Violation` is created with a `TreeSitterNode` that is inside a function,
+    /// `method_name` is automatically set to the enclosing function's name.
+    #[test]
+    fn violation_method_name_populated_when_node_inside_function() {
+        let mut rt = cfg_test_v8().new_runtime();
+        let text = "function myFunction() { const secretKey = 'abc'; }";
+        let filename = "test.js";
+        let ts_query = r#"((identifier) @cap (#eq? @cap "secretKey"))"#;
+        let rule = r#"
+function visit(captures) {
+    const node = captures.get("cap");
+    addError(Violation.new("found it", node));
+}
+"#;
+        let violations =
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
+                .unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].method_name, Some("myFunction".to_string()));
+    }
+
+    /// When a `Violation` is created with a `TreeSitterNode` that is at the top level (not inside
+    /// any function), `method_name` is `None` because there is no enclosing function to detect.
+    #[test]
+    fn violation_method_name_none_when_node_at_top_level() {
+        let mut rt = cfg_test_v8().new_runtime();
+        let text = "const secretKey = 'abc';";
+        let filename = "test.js";
+        let ts_query = r#"((identifier) @cap (#eq? @cap "secretKey"))"#;
+        let rule = r#"
+function visit(captures) {
+    const node = captures.get("cap");
+    addError(Violation.new("found it", node));
+}
+"#;
+        let violations =
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
+                .unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].method_name, None);
+    }
+
+    /// `withMethodName` sets `method_name` regardless of whether the node is inside a function,
+    /// allowing a rule to provide a custom value.
+    #[test]
+    fn violation_method_name_overridden_by_with_method_name() {
+        let mut rt = cfg_test_v8().new_runtime();
+        let text = "const secretKey = 'abc';";
+        let filename = "test.js";
+        let ts_query = r#"((identifier) @cap (#eq? @cap "secretKey"))"#;
+        let rule = r#"
+function visit(captures) {
+    const node = captures.get("cap");
+    addError(Violation.new("found it", node).withMethodName("customName"));
+}
+"#;
+        let violations =
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
+                .unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].method_name, Some("customName".to_string()));
+    }
+
     /// Tests that a rule can define variables before the visit function and have them accessible.
     #[test]
     fn execute_rule_internal_init_order() {

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -1169,8 +1169,7 @@ function visit(captures) {
 }
 "#;
         let violations =
-            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
-                .unwrap();
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None).unwrap();
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, Some("myFunction".to_string()));
     }
@@ -1190,8 +1189,7 @@ function visit(captures) {
 }
 "#;
         let violations =
-            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
-                .unwrap();
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None).unwrap();
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, None);
     }
@@ -1211,8 +1209,7 @@ function visit(captures) {
 }
 "#;
         let violations =
-            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None)
-                .unwrap();
+            shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None).unwrap();
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, Some("customName".to_string()));
     }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -200,6 +200,24 @@ impl JsRuntime {
         let violations = js_violations
             .into_iter()
             .map(|v| v.into_violation(rule.severity, rule.category))
+            .map(|mut v| {
+                // Taint-flow rules use `new Violation(message, taintedFlow)`, where the
+                // `TaintFlow` carries `TreeSitterNode`s and method_name is auto-populated
+                // by the JS runtime.  Pattern-matching rules use the older
+                // `buildError(line, col, …)` API, which only stores numeric coordinates
+                // and never sets method_name.  For those cases we fall back to a
+                // tree-sitter walk here in Rust so that both rule styles produce
+                // consistent output.
+                if v.method_name.is_none() {
+                    v.method_name = find_enclosing_function_name(
+                        source_tree,
+                        source_text.as_bytes(),
+                        v.start.line,
+                        v.start.col,
+                    );
+                }
+                v
+            })
             .collect::<Vec<_>>();
 
         let timing = ExecutionTimingCompat {
@@ -608,6 +626,69 @@ impl JsConsole {
     /// Removes all lines from the `JsConsole`, returning them as an iterator.
     pub fn drain(&mut self) -> impl Iterator<Item = String> + '_ {
         self.0.drain(..)
+    }
+}
+
+/// Tree-sitter node kinds that represent a function or method declaration.
+/// Mirrors the `FUNCTION_NODE_TYPES` constant in `ddsa.js`.
+const FUNCTION_NODE_TYPES: &[&str] = &[
+    // Java, C#, Kotlin
+    "method_declaration",
+    "constructor_declaration",
+    // Python
+    "function_definition",
+    // JavaScript / TypeScript
+    "function_declaration",
+    "method_definition",
+    "function_expression",
+    // Ruby
+    "method",
+    "singleton_method",
+    // Generic / other languages
+    "function",
+    "function_item",
+];
+
+/// Returns the name of the function or method that encloses the position
+/// (`start_line`, `start_col`, both 1-based) in `tree`.
+///
+/// This is the Rust counterpart of `DDSA.getEnclosingFunctionName` in `ddsa.js`.
+/// It exists because pattern-matching rules use the older `buildError(line, col, …)`
+/// API, which discards the originating `TreeSitterNode` and therefore never
+/// triggers the JS-side auto-population of `method_name`.  Taint-flow rules pass
+/// a `TaintFlow` (which carries nodes) so they get `method_name` from JS without
+/// needing this fallback.
+fn find_enclosing_function_name(
+    tree: &tree_sitter::Tree,
+    source_text: &[u8],
+    start_line: u32,
+    start_col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: start_line.saturating_sub(1) as usize,
+        column: start_col.saturating_sub(1) as usize,
+    };
+
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+
+    loop {
+        if FUNCTION_NODE_TYPES.contains(&node.kind()) {
+            // Walk ALL children (named and unnamed) to find the "name" field.
+            let mut cursor = node.walk();
+            for (i, child) in node.children(&mut cursor).enumerate() {
+                if node.field_name_for_child(i as u32) == Some("name") {
+                    return child.utf8_text(source_text).ok().map(str::to_owned);
+                }
+            }
+            // Anonymous function — no "name" field.
+            return None;
+        }
+        match node.parent() {
+            Some(parent) => node = parent,
+            None => return None,
+        }
     }
 }
 
@@ -1212,6 +1293,79 @@ function visit(captures) {
             shorthand_execute_rule_internal(&mut rt, text, filename, ts_query, rule, None).unwrap();
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, Some("customName".to_string()));
+    }
+
+    /// Pattern-matching rules use the old `buildError(line, col, …)` API, which passes numeric
+    /// coordinates to `Violation.new` instead of a `TreeSitterNode`.  The JS auto-population is
+    /// therefore skipped, but the Rust-side fallback in `execute_rule` must fill it in.
+    #[test]
+    fn violation_method_name_populated_by_rust_fallback_for_builderror_rules() {
+        let mut rt = cfg_test_v8().new_runtime();
+        let text = r#"
+class Foo {
+    public void myMethod() {
+        String key = "secret";
+    }
+}
+"#;
+        let ts_query = r#"(string_literal) @cap"#;
+        // Simulates a pattern-matching rule that uses the old buildError API:
+        // `buildError(line, col, …)` passes numeric coordinates → no TreeSitterNode →
+        // JS auto-population skipped → Rust fallback must supply method_name.
+        let rule = r#"
+function visit(captures) {
+    const node = captures.get("cap");
+    addError(buildError(node.start.line, node.start.col,
+                        node.end.line, node.end.col,
+                        "found it"));
+}
+"#;
+        let violations = shorthand_execute_rule(
+            &mut rt,
+            Language::Java,
+            ts_query,
+            rule,
+            text,
+            None,
+        )
+        .unwrap()
+        .violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].method_name, Some("myMethod".to_string()));
+    }
+
+    /// Java `method_declaration` with a `throws` clause should still auto-populate `method_name`.
+    #[test]
+    fn violation_method_name_java_method_with_throws() {
+        let mut rt = cfg_test_v8().new_runtime();
+        // Reproduces the user's reported case: a Java method with a `throws` clause
+        let text = r#"
+class Foo {
+    private static byte [] getCipher(byte [] data) throws IllegalBlockSizeException, BadPaddingException {
+        String alg = "DES";
+        return null;
+    }
+}
+"#;
+        let ts_query = r#"(string_literal) @cap"#;
+        let rule = r#"
+function visit(captures) {
+    const node = captures.get("cap");
+    addError(Violation.new("found it", node));
+}
+"#;
+        let violations = shorthand_execute_rule(
+            &mut rt,
+            Language::Java,
+            ts_query,
+            rule,
+            text,
+            None,
+        )
+        .unwrap()
+        .violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].method_name, Some("getCipher".to_string()));
     }
 
     /// Tests that a rule can define variables before the visit function and have them accessible.

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -1320,16 +1320,10 @@ function visit(captures) {
                         "found it"));
 }
 "#;
-        let violations = shorthand_execute_rule(
-            &mut rt,
-            Language::Java,
-            ts_query,
-            rule,
-            text,
-            None,
-        )
-        .unwrap()
-        .violations;
+        let violations =
+            shorthand_execute_rule(&mut rt, Language::Java, ts_query, rule, text, None)
+                .unwrap()
+                .violations;
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, Some("myMethod".to_string()));
     }
@@ -1354,16 +1348,10 @@ function visit(captures) {
     addError(Violation.new("found it", node));
 }
 "#;
-        let violations = shorthand_execute_rule(
-            &mut rt,
-            Language::Java,
-            ts_query,
-            rule,
-            text,
-            None,
-        )
-        .unwrap()
-        .violations;
+        let violations =
+            shorthand_execute_rule(&mut rt, Language::Java, ts_query, rule, text, None)
+                .unwrap()
+                .violations;
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].method_name, Some("getCipher".to_string()));
     }

--- a/crates/static-analysis-kernel/src/model/violation.rs
+++ b/crates/static-analysis-kernel/src/model/violation.rs
@@ -42,4 +42,8 @@ pub struct Violation {
     #[serde(default)]
     #[builder(default)]
     pub is_suppressed: bool,
+    /// The name of the method or function enclosing the violation, if any.
+    #[serde(default)]
+    #[builder(default)]
+    pub method_name: Option<String>,
 }


### PR DESCRIPTION
## What problem are you trying to solve?
SARIF results currently contain no information about which function or method a violation belongs to. Consumers of the SARIF output (e.g. Datadog's static analysis backend) cannot associate a violation with its enclosing function without re-parsing the source file themselves.

## What is your solution?
- Adds a method_name field to the Violation model.
- Adds ddsa.getEnclosingFunctionName(node) to the JavaScript runtime API, which walks the tree-sitter AST upward to find the nearest enclosing function or method declaration. It supports all languages covered by the analyzer (Java, Python, JavaScript/TypeScript, Go, Ruby, Kotlin, C#, Rust, and others).
- The Violation constructor automatically calls getEnclosingFunctionName when a TreeSitterNode is passed as the location argument, so existing rules get method_name populated without any changes. Rules can override it explicitly via violation.withMethodName(name).
- When method_name is set, it is emitted in the SARIF output as a logicalLocation with kind: "function".

## Alternatives considered
Post-processing the violations on the Rust side using tree-sitter's descendant_for_point_range after JS execution. Discarded in favor of the JS-side approach since the TreeSitterNode is already available at violation creation time and the detection naturally belongs there.

## What the reviewer should know
- Rules that create violations using buildError (4 coordinates) or { line, col } positions get no auto-detection, since there is no TreeSitterNode to walk. They can still opt in via withMethodName.
- The test variadic_violation_creation in violation.rs was updated to use new_runtime() instead of deno_core_rt(), because the Violation constructor now invokes op_ts_node_parent which requires the DDSA bridge state.