### PR TITLE
Detect violation enclosing method

### DIFF
--- a/crates/cli/src/csv.rs
+++ b/crates/cli/src/csv.rs
@@ -85,6 +85,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 }],
                 errors: vec![],
                 execution_error: None,

--- a/crates/cli/src/csv.rs
+++ b/crates/cli/src/csv.rs
@@ -85,7 +85,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 }],
                 errors: vec![],
                 execution_error: None,

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -452,6 +452,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
@@ -497,6 +498,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1]),
             is_suppressed: false,
+            method_name: None,
         };
         let fingerprint = get_fingerprint_for_violation(
             "taint_flow_rule".to_string(),
@@ -528,6 +530,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
 

--- a/crates/cli/src/file_utils.rs
+++ b/crates/cli/src/file_utils.rs
@@ -452,7 +452,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
         let fingerprint = get_fingerprint_for_violation(
@@ -498,7 +498,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1]),
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
         let fingerprint = get_fingerprint_for_violation(
             "taint_flow_rule".to_string(),
@@ -530,7 +530,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
         let directory_string = d.into_os_string().into_string().unwrap();
 

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -81,6 +81,7 @@ pub fn convert_secret_result_to_rule_result(secret_result: &SecretResult) -> Rul
                 fixes: vec![],
                 taint_flow: None,
                 is_suppressed: v.is_suppressed,
+                method_name: None,
             })
             .collect(),
     }
@@ -163,6 +164,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -173,6 +175,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -183,6 +186,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
             ],
             errors: vec![],
@@ -227,6 +231,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 },
                 Violation {
                     start: Position { line: 20, col: 1 },
@@ -237,6 +242,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: true,
+                    method_name: None,
                 },
             ],
             errors: vec![],

--- a/crates/cli/src/rule_utils.rs
+++ b/crates/cli/src/rule_utils.rs
@@ -81,7 +81,7 @@ pub fn convert_secret_result_to_rule_result(secret_result: &SecretResult) -> Rul
                 fixes: vec![],
                 taint_flow: None,
                 is_suppressed: v.is_suppressed,
-                method_name: None,
+                enclosing_function: None,
             })
             .collect(),
     }
@@ -164,7 +164,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -175,7 +175,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 },
                 Violation {
                     start: Position { line: 10, col: 12 },
@@ -186,7 +186,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 },
             ],
             errors: vec![],
@@ -231,7 +231,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 },
                 Violation {
                     start: Position { line: 20, col: 1 },
@@ -242,7 +242,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: true,
-                    method_name: None,
+                    enclosing_function: None,
                 },
             ],
             errors: vec![],

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1311,6 +1311,101 @@ mod tests {
         assert!(validate_data(&sarif_report_to_string));
     }
 
+    #[test]
+    fn test_generate_sarif_report_logical_location() {
+        let rule = RuleBuilder::default()
+            .name("my-rule".to_string())
+            .description_base64(None)
+            .language(Language::Python)
+            .checksum("abc".to_string())
+            .pattern(None)
+            .tree_sitter_query_base64(None)
+            .category(RuleCategory::BestPractices)
+            .code_base64("Zm9v".to_string())
+            .short_description_base64(None)
+            .entity_checked(None)
+            .rule_type(RuleType::TreeSitterQuery)
+            .severity(RuleSeverity::Error)
+            .cwe(None)
+            .arguments(vec![])
+            .tests(vec![])
+            .is_testing(false)
+            .documentation_url(None)
+            .build()
+            .unwrap();
+
+        let violation_with_method = Violation {
+            start: Position { line: 10, col: 1 },
+            end: Position { line: 10, col: 20 },
+            message: "some violation".to_string(),
+            severity: RuleSeverity::Error,
+            category: RuleCategory::BestPractices,
+            fixes: vec![],
+            taint_flow: None,
+            is_suppressed: false,
+            method_name: Some("my_method".to_string()),
+        };
+        let violation_without_method = Violation {
+            start: Position { line: 20, col: 1 },
+            end: Position { line: 20, col: 5 },
+            message: "another violation".to_string(),
+            severity: RuleSeverity::Error,
+            category: RuleCategory::BestPractices,
+            fixes: vec![],
+            taint_flow: None,
+            is_suppressed: false,
+            method_name: None,
+        };
+
+        let rule_result = RuleResult {
+            rule_name: "my-rule".to_string(),
+            filename: "myfile.py".to_string(),
+            violations: vec![violation_with_method, violation_without_method],
+            errors: vec![],
+            execution_error: None,
+            output: None,
+            execution_time_ms: 0,
+            parsing_time_ms: 0,
+            query_node_time_ms: 0,
+        };
+
+        let sarif_report = generate_sarif_report(
+            &[rule.into()],
+            &[rule_result.try_into().unwrap()],
+            &"mydir".to_string(),
+            SarifReportMetadata {
+                add_git_info: false,
+                debug: false,
+                config_digest: "abc".to_string(),
+                diff_aware_parameters: None,
+                execution_time_secs: 0,
+            },
+            &Default::default(),
+        )
+        .expect("generate sarif report");
+
+        let sarif_json = serde_json::to_value(sarif_report).unwrap();
+
+        // Violation with method_name: logicalLocations must be present with kind and name.
+        let logical_locations = sarif_json
+            .pointer("/runs/0/results/0/locations/0/logicalLocations")
+            .expect("logicalLocations should be present when method_name is set");
+        assert_json_include!(
+            actual: logical_locations,
+            expected: serde_json::json!([{"kind": "function", "name": "my_method"}])
+        );
+
+        // Violation without method_name: no logicalLocations key at all.
+        let no_logical_locations = sarif_json
+            .pointer("/runs/0/results/1/locations/0/logicalLocations");
+        assert!(
+            no_logical_locations.is_none(),
+            "logicalLocations should be absent when method_name is None"
+        );
+
+        assert!(validate_data(&sarif_json));
+    }
+
     // Ensure that diff-aware scanning information are correctly surfaced
     #[test]
     fn test_generate_sarif_diff_aware_scanning() {

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -197,7 +197,7 @@ impl SarifRuleResult {
                             fixes: vec![],
                             taint_flow: None,
                             is_suppressed: r.is_suppressed,
-                            method_name: None,
+                            enclosing_function: None,
                         },
                         r.validation_status.clone(),
                     )
@@ -654,9 +654,10 @@ fn generate_results(
                             )
                             .build()?,
                     );
-                    if let Some(ref method) = violation.method_name {
+                    if let Some(ref ef) = violation.enclosing_function {
                         location_builder.logical_locations(vec![LogicalLocationBuilder::default()
-                            .name(method.clone())
+                            .name(ef.name.clone())
+                            .fully_qualified_name(ef.fully_qualified_name.clone())
                             .kind("function".to_string())
                             .build()?]);
                     }
@@ -1004,7 +1005,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         }));
 
         // good location in the violation location and no fixes
@@ -1017,7 +1018,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         }));
 
         // bad location in the fixes location
@@ -1038,7 +1039,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         }));
 
         // good location everywhere
@@ -1059,7 +1060,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         }));
     }
 
@@ -1128,7 +1129,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1, region2]),
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
 
         let rule_result_single_region = RuleResultBuilder::default()
@@ -1343,7 +1344,10 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: Some("my_method".to_string()),
+            enclosing_function: Some(EnclosingFunction {
+                name: "my_method".to_string(),
+                fully_qualified_name: "def my_method(self)".to_string(),
+            }),
         };
         let violation_without_method = Violation {
             start: Position { line: 20, col: 1 },
@@ -1354,7 +1358,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
 
         let rule_result = RuleResult {
@@ -1386,21 +1390,25 @@ mod tests {
 
         let sarif_json = serde_json::to_value(sarif_report).unwrap();
 
-        // Violation with method_name: logicalLocations must be present with kind and name.
+        // Violation with enclosing_function: logicalLocations must carry name, fullyQualifiedName, and kind.
         let logical_locations = sarif_json
             .pointer("/runs/0/results/0/locations/0/logicalLocations")
-            .expect("logicalLocations should be present when method_name is set");
+            .expect("logicalLocations should be present when enclosing_function is set");
         assert_json_include!(
             actual: logical_locations,
-            expected: serde_json::json!([{"kind": "function", "name": "my_method"}])
+            expected: serde_json::json!([{
+                "kind": "function",
+                "name": "my_method",
+                "fullyQualifiedName": "def my_method(self)"
+            }])
         );
 
-        // Violation without method_name: no logicalLocations key at all.
+        // Violation without enclosing_function: no logicalLocations key at all.
         let no_logical_locations = sarif_json
             .pointer("/runs/0/results/1/locations/0/logicalLocations");
         assert!(
             no_logical_locations.is_none(),
-            "logicalLocations should be absent when method_name is None"
+            "logicalLocations should be absent when enclosing_function is None"
         );
 
         assert!(validate_data(&sarif_json));
@@ -2064,7 +2072,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
-                    method_name: None,
+                    enclosing_function: None,
                 };
                 let rr = RuleResult {
                     rule_name: format!("rule-{idx}"),
@@ -2158,7 +2166,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         };
         let rule_results = [TEST_FILE_PATH, NON_TEST_FILE_PATH]
             .into_iter()

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -974,7 +974,7 @@ mod tests {
     use super::*;
     use assert_json_diff::{assert_json_eq, assert_json_include};
     use common::model::position::{Position, PositionBuilder, Region};
-    use kernel::model::violation::{Fix, Violation};
+    use kernel::model::violation::{EnclosingFunction, Fix, Violation};
     use kernel::model::{
         common::Language,
         rule::{RuleBuilder, RuleCategory, RuleResultBuilder, RuleSeverity, RuleType},

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -22,9 +22,10 @@ use secrets::model::secret_result::{SecretResult, SecretValidationStatus, Valida
 use secrets::model::secret_rule::SecretRule;
 use serde_sarif::sarif::{
     self, Artifact, ArtifactBuilder, ArtifactChangeBuilder, ArtifactLocationBuilder, FixBuilder,
-    LocationBuilder, MessageBuilder, PhysicalLocationBuilder, PropertyBagBuilder, RegionBuilder,
-    Replacement, ReportingDescriptor, Result as SarifResult, ResultBuilder, RunBuilder, Sarif,
-    SarifBuilder, SuppressionBuilder, Tool, ToolBuilder, ToolComponent, ToolComponentBuilder,
+    LocationBuilder, LogicalLocationBuilder, MessageBuilder, PhysicalLocationBuilder,
+    PropertyBagBuilder, RegionBuilder, Replacement, ReportingDescriptor, Result as SarifResult,
+    ResultBuilder, RunBuilder, Sarif, SarifBuilder, SuppressionBuilder, Tool, ToolBuilder,
+    ToolComponent, ToolComponentBuilder,
 };
 
 use crate::file_utils::get_fingerprint_for_violation;
@@ -196,6 +197,7 @@ impl SarifRuleResult {
                             fixes: vec![],
                             taint_flow: None,
                             is_suppressed: r.is_suppressed,
+                            method_name: None,
                         },
                         r.validation_status.clone(),
                     )
@@ -638,21 +640,27 @@ fn generate_results(
                 .map(move |sarif_violation| {
                     let violation = sarif_violation.get_violation();
                     // if we find the rule for this violation, get the id, level and category
-                    let location = LocationBuilder::default()
-                        .physical_location(
-                            PhysicalLocationBuilder::default()
-                                .artifact_location(artifact_loc.clone())
-                                .region(
-                                    RegionBuilder::default()
-                                        .start_line(violation.start.line)
-                                        .start_column(violation.start.col)
-                                        .end_line(violation.end.line)
-                                        .end_column(violation.end.col)
-                                        .build()?,
-                                )
-                                .build()?,
-                        )
-                        .build()?;
+                    let mut location_builder = LocationBuilder::default();
+                    location_builder.physical_location(
+                        PhysicalLocationBuilder::default()
+                            .artifact_location(artifact_loc.clone())
+                            .region(
+                                RegionBuilder::default()
+                                    .start_line(violation.start.line)
+                                    .start_column(violation.start.col)
+                                    .end_line(violation.end.line)
+                                    .end_column(violation.end.col)
+                                    .build()?,
+                            )
+                            .build()?,
+                    );
+                    if let Some(ref method) = violation.method_name {
+                        location_builder.logical_locations(vec![LogicalLocationBuilder::default()
+                            .name(method.clone())
+                            .kind("function".to_string())
+                            .build()?]);
+                    }
+                    let location = location_builder.build()?;
 
                     let fixes: Vec<sarif::Fix> = violation
                         .fixes
@@ -996,6 +1004,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // good location in the violation location and no fixes
@@ -1008,6 +1017,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // bad location in the fixes location
@@ -1028,6 +1038,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
 
         // good location everywhere
@@ -1048,6 +1059,7 @@ mod tests {
             }],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         }));
     }
 
@@ -1116,6 +1128,7 @@ mod tests {
             fixes: vec![],
             taint_flow: Some(vec![region0, region1, region2]),
             is_suppressed: false,
+            method_name: None,
         };
 
         let rule_result_single_region = RuleResultBuilder::default()
@@ -1956,6 +1969,7 @@ mod tests {
                     fixes: vec![],
                     taint_flow: None,
                     is_suppressed: false,
+                    method_name: None,
                 };
                 let rr = RuleResult {
                     rule_name: format!("rule-{idx}"),
@@ -2049,6 +2063,7 @@ mod tests {
             fixes: vec![],
             taint_flow: None,
             is_suppressed: false,
+            method_name: None,
         };
         let rule_results = [TEST_FILE_PATH, NON_TEST_FILE_PATH]
             .into_iter()

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1404,8 +1404,8 @@ mod tests {
         );
 
         // Violation without enclosing_function: no logicalLocations key at all.
-        let no_logical_locations = sarif_json
-            .pointer("/runs/0/results/1/locations/0/logicalLocations");
+        let no_logical_locations =
+            sarif_json.pointer("/runs/0/results/1/locations/0/logicalLocations");
         assert!(
             no_logical_locations.is_none(),
             "logicalLocations should be absent when enclosing_function is None"

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
@@ -55,7 +55,7 @@ impl Violation<Instance> {
             fixes,
             taint_flow,
             is_suppressed: false,
-            method_name: None,
+            enclosing_function: None,
         }
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/violation.rs
@@ -55,6 +55,7 @@ impl Violation<Instance> {
             fixes,
             taint_flow,
             is_suppressed: false,
+            method_name: None,
         }
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -201,7 +201,7 @@ impl JsRuntime {
             .into_iter()
             .map(|v| v.into_violation(rule.severity, rule.category))
             .map(|mut v| {
-                v.method_name = analysis::languages::find_enclosing_function(
+                v.method_name = analysis::languages::find_enclosing_function_with_tree(
                     source_text.as_ref(),
                     source_tree.as_ref(),
                     v.start.line,

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -200,6 +200,16 @@ impl JsRuntime {
         let violations = js_violations
             .into_iter()
             .map(|v| v.into_violation(rule.severity, rule.category))
+            .map(|mut v| {
+                v.method_name = analysis::languages::find_enclosing_function(
+                    source_text.as_ref(),
+                    source_tree.as_ref(),
+                    v.start.line,
+                    v.start.col,
+                    &rule.language,
+                );
+                v
+            })
             .collect::<Vec<_>>();
 
         let timing = ExecutionTimingCompat {

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -201,7 +201,7 @@ impl JsRuntime {
             .into_iter()
             .map(|v| v.into_violation(rule.severity, rule.category))
             .map(|mut v| {
-                v.method_name = analysis::languages::find_enclosing_function_with_tree(
+                v.enclosing_function = analysis::languages::find_enclosing_function_with_tree(
                     source_text.as_ref(),
                     source_tree.as_ref(),
                     v.start.line,

--- a/crates/static-analysis-kernel/src/analysis/languages.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages.rs
@@ -66,6 +66,54 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use crate::model::common::{Language, ALL_LANGUAGES};
+
+    // Languages with an enclosing-function implementation in this module.
+    const SUPPORTED: &[Language] = &[
+        Language::Python,
+        Language::Java,
+        Language::Go,
+        Language::JavaScript,
+        Language::TypeScript,
+        Language::Csharp,
+    ];
+
+    // Languages that intentionally have no implementation yet.
+    // When adding a new language to the analyzer, add it here (no detection) or to
+    // SUPPORTED (detection implemented) — leaving it out causes this test to fail.
+    const NOT_IMPLEMENTED: &[Language] = &[
+        Language::Dockerfile,
+        Language::Elixir,
+        Language::Json,
+        Language::Kotlin,
+        Language::Ruby,
+        Language::Rust,
+        Language::Swift,
+        Language::Terraform,
+        Language::Yaml,
+        Language::Starlark,
+        Language::Bash,
+        Language::PHP,
+        Language::Markdown,
+        Language::Apex,
+        Language::R,
+        Language::SQL,
+    ];
+
+    #[test]
+    fn all_languages_accounted_for() {
+        for lang in ALL_LANGUAGES {
+            assert!(
+                SUPPORTED.contains(lang) || NOT_IMPLEMENTED.contains(lang),
+                "{lang:?} is not listed in SUPPORTED or NOT_IMPLEMENTED — \
+                 either add enclosing-function detection for it or add it to NOT_IMPLEMENTED"
+            );
+        }
+    }
+}
+
 /// Returns the text that `node` spans.
 ///
 /// This is simply a wrapper around [`tree_sitter::Node::utf8_text`]

--- a/crates/static-analysis-kernel/src/analysis/languages.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages.rs
@@ -10,10 +10,10 @@ pub mod python;
 pub mod typescript;
 
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost function or method enclosing the given source position
-/// for the specified language, or `None` if the position is not inside any named function or
-/// the language does not have a specific implementation.
+/// Returns the enclosing function for the given source position, or `None` if the position
+/// is not inside any named function or the language has no implementation.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
@@ -22,7 +22,7 @@ pub fn find_enclosing_function(
     line: u32,
     col: u32,
     language: &Language,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     match language {
         Language::Python => python::methods::find_enclosing_function(source_code, line, col),
         Language::Java => java::methods::find_enclosing_function(source_code, line, col),
@@ -34,15 +34,15 @@ pub fn find_enclosing_function(
     }
 }
 
-/// Returns the name of the innermost function or method enclosing the given source position,
-/// reusing an already-parsed tree. See [`find_enclosing_function`] for documentation.
+/// Returns the enclosing function for the given source position, reusing an already-parsed tree.
+/// See [`find_enclosing_function`] for documentation.
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
     language: &Language,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     match language {
         Language::Python => {
             python::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
@@ -64,6 +64,35 @@ pub fn find_enclosing_function_with_tree(
         }
         _ => None,
     }
+}
+
+/// Walks up from `node` looking for an ancestor whose `kind()` is one of `class_kinds`.
+/// Returns the text of that ancestor's `name` field, or `None` if not found.
+pub(crate) fn enclosing_class_name<'s>(
+    source_code: &'s str,
+    mut node: tree_sitter::Node<'_>,
+    class_kinds: &[&str],
+) -> Option<&'s str> {
+    loop {
+        node = node.parent()?;
+        if class_kinds.contains(&node.kind()) {
+            return node.child_by_field_name("name").map(|n| ts_node_text(source_code, n));
+        }
+    }
+}
+
+
+/// Returns the text that `node` spans.
+///
+/// This is simply a wrapper around [`tree_sitter::Node::utf8_text`]
+/// to make implementations less verbose while still documenting assumptions.
+///
+/// # Panics
+/// This panics if the node specifies out-of-bounds indices or indices that aren't along a utf-8
+/// sequence boundary. This can only happen if the provided `node` is not from a tree generated from `parsed_text`.
+pub(crate) fn ts_node_text<'text>(parsed_text: &'text str, node: tree_sitter::Node) -> &'text str {
+    node.utf8_text(parsed_text.as_bytes())
+        .expect("node should be from `parsed_text`'s tree")
 }
 
 #[cfg(test)]
@@ -112,17 +141,4 @@ mod tests {
             );
         }
     }
-}
-
-/// Returns the text that `node` spans.
-///
-/// This is simply a wrapper around [`tree_sitter::Node::utf8_text`]
-/// to make implementations less verbose while still documenting assumptions.
-///
-/// # Panics
-/// This panics if the node specifies out-of-bounds indices or indices that aren't along a utf-8
-/// sequence boundary. This can only happen if the provided `node` is not from a tree generated from `parsed_text`.
-pub(crate) fn ts_node_text<'text>(parsed_text: &'text str, node: tree_sitter::Node) -> &'text str {
-    node.utf8_text(parsed_text.as_bytes())
-        .expect("node should be from `parsed_text`'s tree")
 }

--- a/crates/static-analysis-kernel/src/analysis/languages.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages.rs
@@ -27,8 +27,12 @@ pub fn find_enclosing_function(
         Language::Python => python::methods::find_enclosing_function(source_code, line, col),
         Language::Java => java::methods::find_enclosing_function(source_code, line, col),
         Language::Go => go::methods::find_enclosing_function(source_code, line, col),
-        Language::JavaScript => javascript::methods::find_enclosing_function(source_code, line, col),
-        Language::TypeScript => typescript::methods::find_enclosing_function(source_code, line, col),
+        Language::JavaScript => {
+            javascript::methods::find_enclosing_function(source_code, line, col)
+        }
+        Language::TypeScript => {
+            typescript::methods::find_enclosing_function(source_code, line, col)
+        }
         Language::Csharp => csharp::methods::find_enclosing_function(source_code, line, col),
         _ => None,
     }
@@ -76,11 +80,12 @@ pub(crate) fn enclosing_class_name<'s>(
     loop {
         node = node.parent()?;
         if class_kinds.contains(&node.kind()) {
-            return node.child_by_field_name("name").map(|n| ts_node_text(source_code, n));
+            return node
+                .child_by_field_name("name")
+                .map(|n| ts_node_text(source_code, n));
         }
     }
 }
-
 
 /// Returns the text that `node` spans.
 ///

--- a/crates/static-analysis-kernel/src/analysis/languages.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages.rs
@@ -14,7 +14,29 @@ use crate::model::common::Language;
 /// Returns the name of the innermost function or method enclosing the given source position
 /// for the specified language, or `None` if the position is not inside any named function or
 /// the language does not have a specific implementation.
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
 pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+    language: &Language,
+) -> Option<String> {
+    match language {
+        Language::Python => python::methods::find_enclosing_function(source_code, line, col),
+        Language::Java => java::methods::find_enclosing_function(source_code, line, col),
+        Language::Go => go::methods::find_enclosing_function(source_code, line, col),
+        Language::JavaScript => javascript::methods::find_enclosing_function(source_code, line, col),
+        Language::TypeScript => typescript::methods::find_enclosing_function(source_code, line, col),
+        Language::Csharp => csharp::methods::find_enclosing_function(source_code, line, col),
+        _ => None,
+    }
+}
+
+/// Returns the name of the innermost function or method enclosing the given source position,
+/// reusing an already-parsed tree. See [`find_enclosing_function`] for documentation.
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -22,16 +44,24 @@ pub fn find_enclosing_function(
     language: &Language,
 ) -> Option<String> {
     match language {
-        Language::Python => python::methods::find_enclosing_function(source_code, tree, line, col),
-        Language::Java => java::methods::find_enclosing_function(source_code, tree, line, col),
-        Language::Go => go::methods::find_enclosing_function(source_code, tree, line, col),
+        Language::Python => {
+            python::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
+        }
+        Language::Java => {
+            java::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
+        }
+        Language::Go => {
+            go::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
+        }
         Language::JavaScript => {
-            javascript::methods::find_enclosing_function(source_code, tree, line, col)
+            javascript::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
         }
         Language::TypeScript => {
-            typescript::methods::find_enclosing_function(source_code, tree, line, col)
+            typescript::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
         }
-        Language::Csharp => csharp::methods::find_enclosing_function(source_code, tree, line, col),
+        Language::Csharp => {
+            csharp::methods::find_enclosing_function_with_tree(source_code, tree, line, col)
+        }
         _ => None,
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/languages.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages.rs
@@ -9,6 +9,33 @@ pub mod javascript;
 pub mod python;
 pub mod typescript;
 
+use crate::model::common::Language;
+
+/// Returns the name of the innermost function or method enclosing the given source position
+/// for the specified language, or `None` if the position is not inside any named function or
+/// the language does not have a specific implementation.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+    language: &Language,
+) -> Option<String> {
+    match language {
+        Language::Python => python::methods::find_enclosing_function(source_code, tree, line, col),
+        Language::Java => java::methods::find_enclosing_function(source_code, tree, line, col),
+        Language::Go => go::methods::find_enclosing_function(source_code, tree, line, col),
+        Language::JavaScript => {
+            javascript::methods::find_enclosing_function(source_code, tree, line, col)
+        }
+        Language::TypeScript => {
+            typescript::methods::find_enclosing_function(source_code, tree, line, col)
+        }
+        Language::Csharp => csharp::methods::find_enclosing_function(source_code, tree, line, col),
+        _ => None,
+    }
+}
+
 /// Returns the text that `node` spans.
 ///
 /// This is simply a wrapper around [`tree_sitter::Node::utf8_text`]

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp.rs
@@ -4,3 +4,4 @@
 
 mod using_directives;
 pub use using_directives::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
@@ -12,7 +12,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Csharp)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -74,7 +78,10 @@ pub fn find_enclosing_function_with_tree(
                     format!("{fqn_prefix}.{name}({params_str})")
                 };
 
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             _ => {}
         }
@@ -93,7 +100,10 @@ fn find_namespace(source_code: &str, mut node: tree_sitter::Node) -> Option<Stri
             Some(p) => p,
             None => break,
         };
-        if matches!(node.kind(), "namespace_declaration" | "file_scoped_namespace_declaration") {
+        if matches!(
+            node.kind(),
+            "namespace_declaration" | "file_scoped_namespace_declaration"
+        ) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 parts.push(ts_node_text(source_code, name_node).to_owned());
             }
@@ -113,7 +123,9 @@ fn find_namespace(source_code: &str, mut node: tree_sitter::Node) -> Option<Stri
 fn extract_param_types(source_code: &str, params_node: tree_sitter::Node) -> Vec<String> {
     let mut types = vec![];
     for i in 0..params_node.named_child_count() {
-        let Some(child) = params_node.named_child(i) else { continue };
+        let Some(child) = params_node.named_child(i) else {
+            continue;
+        };
         if child.kind() == "parameter" {
             if let Some(type_node) = child.child_by_field_name("type") {
                 types.push(ts_node_text(source_code, type_node).to_owned());
@@ -136,7 +148,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]
@@ -188,7 +203,10 @@ namespace MyApp.Controllers {
     }
 }
 ";
-        assert_eq!(find(src, 4, 13), ef("DoSomething", "MyApp.Controllers.Foo.DoSomething()"));
+        assert_eq!(
+            find(src, 4, 13),
+            ef("DoSomething", "MyApp.Controllers.Foo.DoSomething()")
+        );
     }
 
     #[test]
@@ -202,7 +220,10 @@ namespace MyApp {
     }
 }
 ";
-        assert_eq!(find(src, 4, 13), ef("Handle", "MyApp.Foo.Handle(string, int)"));
+        assert_eq!(
+            find(src, 4, 13),
+            ef("Handle", "MyApp.Foo.Handle(string, int)")
+        );
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
@@ -125,7 +125,7 @@ fn extract_param_types(source_code: &str, params_node: tree_sitter::Node) -> Vec
 
 #[cfg(test)]
 mod tests {
-    use super::{find_enclosing_function, find_enclosing_function_with_tree};
+    use super::find_enclosing_function_with_tree;
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
     use crate::model::violation::EnclosingFunction;

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost method, constructor, or local function enclosing the given
+/// source position, or `None` if the position is not inside any such construct.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "method_declaration" | "constructor_declaration" | "local_function_statement" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::Csharp).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_method() {
+        let src = "\
+class Foo {
+    public void DoSomething() {
+        var x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("DoSomething".to_string()));
+    }
+
+    #[test]
+    fn inside_constructor() {
+        let src = "\
+class Foo {
+    public Foo() {
+        this.x = 0;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("Foo".to_string()));
+    }
+
+    #[test]
+    fn inside_local_function() {
+        let src = "\
+class Foo {
+    public void Outer() {
+        void Inner() {
+            var x = 1;
+        }
+    }
+}
+";
+        assert_eq!(find(src, 4, 13), Some("Inner".to_string()));
+    }
+
+    #[test]
+    fn class_field() {
+        let src = "\
+class Foo {
+    int x = 1;
+}
+";
+        assert_eq!(find(src, 2, 9), None);
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
@@ -3,10 +3,22 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost method, constructor, or local function enclosing the given
 /// source position, or `None` if the position is not inside any such construct.
-pub fn find_enclosing_function(
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::Csharp)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost method, constructor, or local function enclosing the given
+/// source position. See [`find_enclosing_function`] for documentation.
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -34,13 +46,13 @@ pub fn find_enclosing_function(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::Csharp).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/methods.rs
@@ -2,28 +2,36 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::analysis::languages::ts_node_text;
+use crate::analysis::languages::{enclosing_class_name, ts_node_text};
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost method, constructor, or local function enclosing the given
-/// source position, or `None` if the position is not inside any such construct.
+/// Returns the enclosing method, constructor, or local function for the given source position,
+/// or `None` if the position is not inside any such construct.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Csharp)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost method, constructor, or local function enclosing the given
-/// source position. See [`find_enclosing_function`] for documentation.
+/// Returns the enclosing method, constructor, or local function for the given source position.
+/// See [`find_enclosing_function`] for documentation.
+///
+/// The `fullyQualifiedName` follows the Roslyn / XML documentation ID convention:
+///   `Namespace.ClassName.MethodName(ParamType1, ParamType2)`
+///
+/// Access modifiers, attributes (`[HttpGet]`), and the return type are excluded.
+/// Parameter types are included as simple names (not namespace-resolved), consistent
+/// with how Roslyn presents method signatures in quick-info and SARIF output.
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -34,9 +42,39 @@ pub fn find_enclosing_function_with_tree(
     loop {
         match node.kind() {
             "method_declaration" | "constructor_declaration" | "local_function_statement" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+
+                let class_kinds = &[
+                    "class_declaration",
+                    "interface_declaration",
+                    "struct_declaration",
+                    "record_declaration",
+                ];
+                let namespace = find_namespace(source_code, node);
+                let class_name = enclosing_class_name(source_code, node, class_kinds);
+
+                let fqn_prefix = match (namespace.as_deref(), class_name) {
+                    (Some(ns), Some(cls)) => format!("{ns}.{cls}"),
+                    (None, Some(cls)) => cls.to_string(),
+                    (Some(ns), None) => ns.to_string(),
+                    (None, None) => String::new(),
+                };
+
+                let param_types = node
+                    .child_by_field_name("parameters")
+                    .map(|p| extract_param_types(source_code, p))
+                    .unwrap_or_default();
+
+                let params_str = param_types.join(", ");
+                let fully_qualified_name = if fqn_prefix.is_empty() {
+                    format!("{name}({params_str})")
+                } else {
+                    format!("{fqn_prefix}.{name}({params_str})")
+                };
+
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             _ => {}
         }
@@ -44,15 +82,61 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
+/// Walks up from `node` collecting names from every enclosing `namespace_declaration` or
+/// `file_scoped_namespace_declaration`, then joins them outermost-first with `.`.
+///
+/// Handles both nested namespace blocks and the C# 10 file-scoped `namespace Foo.Bar;` form.
+fn find_namespace(source_code: &str, mut node: tree_sitter::Node) -> Option<String> {
+    let mut parts: Vec<String> = vec![];
+    loop {
+        node = match node.parent() {
+            Some(p) => p,
+            None => break,
+        };
+        if matches!(node.kind(), "namespace_declaration" | "file_scoped_namespace_declaration") {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                parts.push(ts_node_text(source_code, name_node).to_owned());
+            }
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        parts.reverse(); // outermost namespace first
+        Some(parts.join("."))
+    }
+}
+
+/// Extracts the ordered list of parameter types from a `parameter_list` node.
+/// Attributes (`[FromBody]`), modifiers (`ref`, `out`, `params`), and parameter names
+/// are excluded — only the type name is kept.
+fn extract_param_types(source_code: &str, params_node: tree_sitter::Node) -> Vec<String> {
+    let mut types = vec![];
+    for i in 0..params_node.named_child_count() {
+        let Some(child) = params_node.named_child(i) else { continue };
+        if child.kind() == "parameter" {
+            if let Some(type_node) = child.child_by_field_name("type") {
+                types.push(ts_node_text(source_code, type_node).to_owned());
+            }
+        }
+    }
+    types
+}
+
 #[cfg(test)]
 mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::Csharp).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
@@ -64,7 +148,7 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("DoSomething".to_string()));
+        assert_eq!(find(src, 3, 9), ef("DoSomething", "Foo.DoSomething()"));
     }
 
     #[test]
@@ -76,7 +160,7 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("Foo".to_string()));
+        assert_eq!(find(src, 3, 9), ef("Foo", "Foo.Foo()"));
     }
 
     #[test]
@@ -90,7 +174,62 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 4, 13), Some("Inner".to_string()));
+        assert_eq!(find(src, 4, 13), ef("Inner", "Foo.Inner()"));
+    }
+
+    #[test]
+    fn with_namespace() {
+        let src = "\
+namespace MyApp.Controllers {
+    class Foo {
+        public void DoSomething() {
+            var x = 1;
+        }
+    }
+}
+";
+        assert_eq!(find(src, 4, 13), ef("DoSomething", "MyApp.Controllers.Foo.DoSomething()"));
+    }
+
+    #[test]
+    fn with_parameters() {
+        let src = "\
+namespace MyApp {
+    class Foo {
+        public void Handle(string req, int count) {
+            var x = 1;
+        }
+    }
+}
+";
+        assert_eq!(find(src, 4, 13), ef("Handle", "MyApp.Foo.Handle(string, int)"));
+    }
+
+    #[test]
+    fn skips_attribute() {
+        let src = "\
+class Foo {
+    [HttpGet]
+    public void Handle() {
+        var x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 4, 9), ef("Handle", "Foo.Handle()"));
+    }
+
+    #[test]
+    fn skips_complex_attribute() {
+        let src = "\
+class Foo {
+    [Route(\"/path\")]
+    [HttpGet]
+    public void Handle(string req) {
+        var x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 5, 9), ef("Handle", "Foo.Handle(string)"));
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/go.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go.rs
@@ -4,3 +4,4 @@
 
 mod imports;
 pub use imports::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
@@ -12,7 +12,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Go)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -50,7 +54,10 @@ pub fn find_enclosing_function_with_tree(
                     Some(pkg) => format!("{pkg}.{name}"),
                     None => name.clone(),
                 };
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             "method_declaration" => {
                 let name = node
@@ -64,7 +71,10 @@ pub fn find_enclosing_function_with_tree(
                     (Some(pkg), None) => format!("{pkg}.{name}"),
                     (None, None) => name.clone(),
                 };
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             _ => {}
         }
@@ -75,7 +85,9 @@ pub fn find_enclosing_function_with_tree(
 /// Returns the package name declared at the top of the Go source file.
 fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
     for i in 0..root.named_child_count() {
-        let Some(child) = root.named_child(i) else { continue };
+        let Some(child) = root.named_child(i) else {
+            continue;
+        };
         if child.kind() == "package_clause" {
             // package_identifier is the only named child of package_clause
             return child
@@ -93,7 +105,9 @@ fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
 fn extract_receiver_type(source_code: &str, method_node: tree_sitter::Node) -> Option<String> {
     let receiver_list = method_node.child_by_field_name("receiver")?;
     for i in 0..receiver_list.named_child_count() {
-        let Some(param_decl) = receiver_list.named_child(i) else { continue };
+        let Some(param_decl) = receiver_list.named_child(i) else {
+            continue;
+        };
         if param_decl.kind() == "parameter_declaration" {
             if let Some(type_node) = param_decl.child_by_field_name("type") {
                 return match type_node.kind() {
@@ -122,7 +136,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
@@ -111,7 +111,7 @@ fn extract_receiver_type(source_code: &str, method_node: tree_sitter::Node) -> O
 
 #[cfg(test)]
 mod tests {
-    use super::{find_enclosing_function, find_enclosing_function_with_tree};
+    use super::find_enclosing_function_with_tree;
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
     use crate::model::violation::EnclosingFunction;

--- a/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
@@ -5,25 +5,33 @@
 use crate::analysis::languages::ts_node_text;
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost function or method enclosing the given source position,
-/// or `None` if the position is not inside any function.
+/// Returns the enclosing function or method for the given source position, or `None` if the
+/// position is not inside any function.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Go)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost function or method enclosing the given source position.
+/// Returns the enclosing function or method for the given source position.
 /// See [`find_enclosing_function`] for documentation.
+///
+/// The `fullyQualifiedName` follows the godoc / `go/types` convention:
+///   - Package-level function: `packageName.FunctionName`
+///   - Method on a type: `packageName.TypeName.MethodName`
+///
+/// Pointer receivers (`*Server`) are stripped to their base type (`Server`),
+/// consistent with how godoc presents method documentation.
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -33,10 +41,30 @@ pub fn find_enclosing_function_with_tree(
         .named_descendant_for_point_range(point, point)?;
     loop {
         match node.kind() {
-            "function_declaration" | "method_declaration" => {
-                return node
+            "function_declaration" => {
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let package = find_package(source_code, tree.root_node());
+                let fully_qualified_name = match package.as_deref() {
+                    Some(pkg) => format!("{pkg}.{name}"),
+                    None => name.clone(),
+                };
+                return Some(EnclosingFunction { name, fully_qualified_name });
+            }
+            "method_declaration" => {
+                let name = node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let package = find_package(source_code, tree.root_node());
+                let receiver_type = extract_receiver_type(source_code, node);
+                let fully_qualified_name = match (package.as_deref(), receiver_type.as_deref()) {
+                    (Some(pkg), Some(recv)) => format!("{pkg}.{recv}.{name}"),
+                    (None, Some(recv)) => format!("{recv}.{name}"),
+                    (Some(pkg), None) => format!("{pkg}.{name}"),
+                    (None, None) => name.clone(),
+                };
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             _ => {}
         }
@@ -44,15 +72,57 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
+/// Returns the package name declared at the top of the Go source file.
+fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
+    for i in 0..root.named_child_count() {
+        let Some(child) = root.named_child(i) else { continue };
+        if child.kind() == "package_clause" {
+            // package_identifier is the only named child of package_clause
+            return child
+                .named_child(0)
+                .filter(|n| n.kind() == "package_identifier")
+                .map(|n| ts_node_text(source_code, n).to_owned());
+        }
+    }
+    None
+}
+
+/// Extracts the receiver type name from a `method_declaration` node.
+/// Pointer receivers (`*Server`) are unwrapped to their base type (`Server`)
+/// to match the godoc URL and documentation format.
+fn extract_receiver_type(source_code: &str, method_node: tree_sitter::Node) -> Option<String> {
+    let receiver_list = method_node.child_by_field_name("receiver")?;
+    for i in 0..receiver_list.named_child_count() {
+        let Some(param_decl) = receiver_list.named_child(i) else { continue };
+        if param_decl.kind() == "parameter_declaration" {
+            if let Some(type_node) = param_decl.child_by_field_name("type") {
+                return match type_node.kind() {
+                    // *Server → "Server"
+                    "pointer_type" => type_node
+                        .named_child(0)
+                        .map(|n| ts_node_text(source_code, n).to_owned()),
+                    _ => Some(ts_node_text(source_code, type_node).to_owned()),
+                };
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::Go).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
@@ -64,7 +134,7 @@ func greet() {
     x := 1
 }
 ";
-        assert_eq!(find(src, 4, 5), Some("greet".to_string()));
+        assert_eq!(find(src, 4, 5), ef("greet", "main.greet"));
     }
 
     #[test]
@@ -78,7 +148,21 @@ func (s *Server) Handle() {
     x := 1
 }
 ";
-        assert_eq!(find(src, 6, 5), Some("Handle".to_string()));
+        assert_eq!(find(src, 6, 5), ef("Handle", "main.Server.Handle"));
+    }
+
+    #[test]
+    fn value_receiver() {
+        let src = "\
+package myapp
+
+type Counter struct{}
+
+func (c Counter) Increment() {
+    x := 1
+}
+";
+        assert_eq!(find(src, 5, 5), ef("Increment", "myapp.Counter.Increment"));
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost function or method enclosing the given source position,
+/// or `None` if the position is not inside any function.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "function_declaration" | "method_declaration" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::Go).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_function() {
+        let src = "\
+package main
+
+func greet() {
+    x := 1
+}
+";
+        assert_eq!(find(src, 4, 5), Some("greet".to_string()));
+    }
+
+    #[test]
+    fn inside_method_with_receiver() {
+        let src = "\
+package main
+
+type Server struct{}
+
+func (s *Server) Handle() {
+    x := 1
+}
+";
+        assert_eq!(find(src, 6, 5), Some("Handle".to_string()));
+    }
+
+    #[test]
+    fn top_level_var() {
+        let src = "\
+package main
+
+var x = 1
+";
+        assert_eq!(find(src, 3, 5), None);
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/methods.rs
@@ -3,10 +3,22 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost function or method enclosing the given source position,
 /// or `None` if the position is not inside any function.
-pub fn find_enclosing_function(
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::Go)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost function or method enclosing the given source position.
+/// See [`find_enclosing_function`] for documentation.
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -34,13 +46,13 @@ pub fn find_enclosing_function(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::Go).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/java.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java.rs
@@ -4,3 +4,4 @@
 
 mod imports;
 pub use imports::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -14,7 +14,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Java)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -48,7 +52,10 @@ pub fn find_enclosing_function_with_tree(
                     .child_by_field_name("name")
                     .map(|n| ts_node_text(source_code, n).to_owned())?;
                 let fully_qualified_name = build_fqn(source_code, tree, node, &name);
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             _ => {}
         }
@@ -68,9 +75,12 @@ fn build_fqn(
 ) -> String {
     let root = tree.root_node();
     let package = find_package(source_code, root);
-    let class_kinds = &["class_declaration", "interface_declaration", "enum_declaration"];
-    let class_name =
-        enclosing_class_name(source_code, method_node, class_kinds);
+    let class_kinds = &[
+        "class_declaration",
+        "interface_declaration",
+        "enum_declaration",
+    ];
+    let class_name = enclosing_class_name(source_code, method_node, class_kinds);
 
     let fqn_class = match (package.as_deref(), class_name) {
         (Some(pkg), Some(cls)) => format!("{pkg}.{cls}"),
@@ -103,10 +113,14 @@ fn build_fqn(
 /// Returns the package name declared at the top of the compilation unit, if any.
 fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
     for i in 0..root.named_child_count() {
-        let Some(child) = root.named_child(i) else { continue };
+        let Some(child) = root.named_child(i) else {
+            continue;
+        };
         if child.kind() == "package_declaration" {
             for j in 0..child.named_child_count() {
-                let Some(pkg_child) = child.named_child(j) else { continue };
+                let Some(pkg_child) = child.named_child(j) else {
+                    continue;
+                };
                 if matches!(pkg_child.kind(), "scoped_identifier" | "identifier") {
                     return Some(ts_node_text(source_code, pkg_child).to_owned());
                 }
@@ -121,13 +135,19 @@ fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
 fn build_import_map(source_code: &str, root: tree_sitter::Node) -> HashMap<String, String> {
     let mut map = HashMap::new();
     for i in 0..root.named_child_count() {
-        let Some(child) = root.named_child(i) else { continue };
+        let Some(child) = root.named_child(i) else {
+            continue;
+        };
         if child.kind() != "import_declaration" {
             continue;
         }
         let text = ts_node_text(source_code, child);
         // Strip "import " prefix and ";" suffix, then trim whitespace
-        let body = text.trim_start_matches("import").trim().trim_end_matches(';').trim();
+        let body = text
+            .trim_start_matches("import")
+            .trim()
+            .trim_end_matches(';')
+            .trim();
         // Skip static and wildcard imports — they can't be resolved without a classpath
         if body.starts_with("static ") || body.ends_with('*') {
             continue;
@@ -215,7 +235,11 @@ fn resolve_type(
 
 /// Resolves a simple class name to its fully qualified form using explicit imports and
 /// the well-known `java.lang` package that is always implicitly available.
-fn resolve_class_name(name: &str, import_map: &HashMap<String, String>, _package: Option<&str>) -> String {
+fn resolve_class_name(
+    name: &str,
+    import_map: &HashMap<String, String>,
+    _package: Option<&str>,
+) -> String {
     if let Some(fqn) = import_map.get(name) {
         return fqn.clone();
     }
@@ -235,7 +259,9 @@ fn extract_param_types(
 ) -> Vec<String> {
     let mut types = vec![];
     for i in 0..params_node.named_child_count() {
-        let Some(child) = params_node.named_child(i) else { continue };
+        let Some(child) = params_node.named_child(i) else {
+            continue;
+        };
         match child.kind() {
             "formal_parameter" => {
                 if let Some(type_node) = child.child_by_field_name("type") {
@@ -304,7 +330,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]
@@ -341,7 +370,10 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 4, 9), ef("doSomething", "com.example.Foo#doSomething():void"));
+        assert_eq!(
+            find(src, 4, 9),
+            ef("doSomething", "com.example.Foo#doSomething():void")
+        );
     }
 
     #[test]
@@ -354,7 +386,10 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), ef("handle", "Foo#handle(java.lang.String):void"));
+        assert_eq!(
+            find(src, 3, 9),
+            ef("handle", "Foo#handle(java.lang.String):void")
+        );
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost method or constructor enclosing the given source position,
+/// or `None` if the position is not inside any method.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "method_declaration" | "constructor_declaration" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::Java).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_method() {
+        let src = "\
+class Foo {
+    public void doSomething() {
+        int x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("doSomething".to_string()));
+    }
+
+    #[test]
+    fn inside_constructor() {
+        let src = "\
+class Foo {
+    public Foo() {
+        this.x = 0;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("Foo".to_string()));
+    }
+
+    #[test]
+    fn inside_method_with_throws() {
+        let src = "\
+class Foo {
+    public void parse() throws IOException {
+        int x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("parse".to_string()));
+    }
+
+    #[test]
+    fn top_level_field() {
+        let src = "\
+class Foo {
+    int x = 1;
+}
+";
+        assert_eq!(find(src, 2, 9), None);
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -132,7 +132,7 @@ fn build_import_map(source_code: &str, root: tree_sitter::Node) -> HashMap<Strin
         if body.starts_with("static ") || body.ends_with('*') {
             continue;
         }
-        let simple_name = body.split('.').last().unwrap_or("").to_string();
+        let simple_name = body.split('.').next_back().unwrap_or("").to_string();
         if !simple_name.is_empty() {
             map.insert(simple_name, body.to_string());
         }

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -3,10 +3,22 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost method or constructor enclosing the given source position,
 /// or `None` if the position is not inside any method.
-pub fn find_enclosing_function(
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::Java)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost method or constructor enclosing the given source position.
+/// See [`find_enclosing_function`] for documentation.
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -34,13 +46,13 @@ pub fn find_enclosing_function(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::Java).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -2,28 +2,38 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::analysis::languages::ts_node_text;
+use std::collections::HashMap;
+
+use crate::analysis::languages::{enclosing_class_name, ts_node_text};
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost method or constructor enclosing the given source position,
-/// or `None` if the position is not inside any method.
+/// Returns the enclosing method or constructor for the given source position, or `None` if the
+/// position is not inside any method.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Java)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost method or constructor enclosing the given source position.
+/// Returns the enclosing method or constructor for the given source position.
 /// See [`find_enclosing_function`] for documentation.
+///
+/// The `fullyQualifiedName` follows the standard Java FQN format:
+///   `package.ClassName#methodName(ParamType1, ParamType2):ReturnType`
+///
+/// Types are resolved to fully qualified names using the file's import declarations.
+/// Types from `java.lang` (String, Integer, etc.) are always resolved. Types only
+/// reachable via wildcard imports are returned as simple names.
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -34,9 +44,11 @@ pub fn find_enclosing_function_with_tree(
     loop {
         match node.kind() {
             "method_declaration" | "constructor_declaration" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let fully_qualified_name = build_fqn(source_code, tree, node, &name);
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             _ => {}
         }
@@ -44,15 +56,255 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
+/// Builds the fully qualified method name in the format:
+///   `package.ClassName#methodName(ParamType1, ParamType2):ReturnType`
+///
+/// Constructors have no return type and omit the `:ReturnType` suffix.
+fn build_fqn(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    method_node: tree_sitter::Node,
+    method_name: &str,
+) -> String {
+    let root = tree.root_node();
+    let package = find_package(source_code, root);
+    let class_kinds = &["class_declaration", "interface_declaration", "enum_declaration"];
+    let class_name =
+        enclosing_class_name(source_code, method_node, class_kinds);
+
+    let fqn_class = match (package.as_deref(), class_name) {
+        (Some(pkg), Some(cls)) => format!("{pkg}.{cls}"),
+        (None, Some(cls)) => cls.to_string(),
+        (Some(pkg), None) => pkg.to_string(),
+        (None, None) => String::new(),
+    };
+
+    let import_map = build_import_map(source_code, root);
+    let pkg = package.as_deref();
+
+    // method_declaration has a `type` field; constructor_declaration does not.
+    let return_type = method_node
+        .child_by_field_name("type")
+        .map(|t| resolve_type(source_code, t, &import_map, pkg));
+
+    let param_types = method_node
+        .child_by_field_name("parameters")
+        .map(|p| extract_param_types(source_code, p, &import_map, pkg))
+        .unwrap_or_default();
+
+    let params_str = param_types.join(", ");
+
+    match return_type {
+        Some(rt) => format!("{fqn_class}#{method_name}({params_str}):{rt}"),
+        None => format!("{fqn_class}#{method_name}({params_str})"),
+    }
+}
+
+/// Returns the package name declared at the top of the compilation unit, if any.
+fn find_package(source_code: &str, root: tree_sitter::Node) -> Option<String> {
+    for i in 0..root.named_child_count() {
+        let Some(child) = root.named_child(i) else { continue };
+        if child.kind() == "package_declaration" {
+            for j in 0..child.named_child_count() {
+                let Some(pkg_child) = child.named_child(j) else { continue };
+                if matches!(pkg_child.kind(), "scoped_identifier" | "identifier") {
+                    return Some(ts_node_text(source_code, pkg_child).to_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Builds a map of simple class name → fully qualified name from explicit (non-wildcard,
+/// non-static) import declarations in the file.
+fn build_import_map(source_code: &str, root: tree_sitter::Node) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for i in 0..root.named_child_count() {
+        let Some(child) = root.named_child(i) else { continue };
+        if child.kind() != "import_declaration" {
+            continue;
+        }
+        let text = ts_node_text(source_code, child);
+        // Strip "import " prefix and ";" suffix, then trim whitespace
+        let body = text.trim_start_matches("import").trim().trim_end_matches(';').trim();
+        // Skip static and wildcard imports — they can't be resolved without a classpath
+        if body.starts_with("static ") || body.ends_with('*') {
+            continue;
+        }
+        let simple_name = body.split('.').last().unwrap_or("").to_string();
+        if !simple_name.is_empty() {
+            map.insert(simple_name, body.to_string());
+        }
+    }
+    map
+}
+
+/// Resolves a tree-sitter type node to a fully qualified type name where possible.
+///
+/// - Explicit imports: `MultipartFile` → `org.springframework.web.multipart.MultipartFile`
+/// - java.lang types: `String` → `java.lang.String`
+/// - Everything else: returned as the simple name from source
+fn resolve_type(
+    source_code: &str,
+    type_node: tree_sitter::Node,
+    import_map: &HashMap<String, String>,
+    package: Option<&str>,
+) -> String {
+    match type_node.kind() {
+        // Primitives and void — always use as-is
+        "void_type" | "integral_type" | "floating_point_type" | "boolean_type" => {
+            ts_node_text(source_code, type_node).to_owned()
+        }
+        // Simple class name reference
+        "type_identifier" => {
+            resolve_class_name(ts_node_text(source_code, type_node), import_map, package)
+        }
+        // Already fully qualified in source (rare)
+        "scoped_type_identifier" => ts_node_text(source_code, type_node).to_owned(),
+        // Generic type: List<String> → java.util.List<java.lang.String>
+        "generic_type" => {
+            let base = type_node
+                .named_child(0)
+                .map(|n| resolve_type(source_code, n, import_map, package))
+                .unwrap_or_default();
+            let type_args = type_node
+                .named_child(1)
+                .filter(|n| n.kind() == "type_arguments");
+            match type_args {
+                Some(args_node) => {
+                    let args: Vec<String> = (0..args_node.named_child_count())
+                        .filter_map(|i| args_node.named_child(i))
+                        .map(|n| resolve_type(source_code, n, import_map, package))
+                        .collect();
+                    if args.is_empty() {
+                        base
+                    } else {
+                        format!("{base}<{}>", args.join(", "))
+                    }
+                }
+                None => base,
+            }
+        }
+        // Array type: String[] — resolve element type and keep dimensions
+        "array_type" => {
+            let element = type_node
+                .child_by_field_name("element")
+                .map(|n| resolve_type(source_code, n, import_map, package))
+                .unwrap_or_default();
+            let dims = type_node
+                .child_by_field_name("dimensions")
+                .map(|n| ts_node_text(source_code, n))
+                .unwrap_or("[]");
+            format!("{element}{dims}")
+        }
+        // Annotated type: @NotNull String — strip annotation and resolve the underlying type
+        "annotated_type" => {
+            // The last named child is the actual type
+            let count = type_node.named_child_count();
+            type_node
+                .named_child(count.saturating_sub(1))
+                .map(|n| resolve_type(source_code, n, import_map, package))
+                .unwrap_or_else(|| ts_node_text(source_code, type_node).to_owned())
+        }
+        // Wildcard (? extends Foo, ? super Bar) — keep as raw text
+        "wildcard" => ts_node_text(source_code, type_node).to_owned(),
+        _ => ts_node_text(source_code, type_node).to_owned(),
+    }
+}
+
+/// Resolves a simple class name to its fully qualified form using explicit imports and
+/// the well-known `java.lang` package that is always implicitly available.
+fn resolve_class_name(name: &str, import_map: &HashMap<String, String>, _package: Option<&str>) -> String {
+    if let Some(fqn) = import_map.get(name) {
+        return fqn.clone();
+    }
+    if JAVA_LANG_TYPES.contains(&name) {
+        return format!("java.lang.{name}");
+    }
+    name.to_owned()
+}
+
+/// Extracts the ordered list of parameter types from a `formal_parameters` node.
+/// Annotations and variable names are excluded; only the type is kept.
+fn extract_param_types(
+    source_code: &str,
+    params_node: tree_sitter::Node,
+    import_map: &HashMap<String, String>,
+    package: Option<&str>,
+) -> Vec<String> {
+    let mut types = vec![];
+    for i in 0..params_node.named_child_count() {
+        let Some(child) = params_node.named_child(i) else { continue };
+        match child.kind() {
+            "formal_parameter" => {
+                if let Some(type_node) = child.child_by_field_name("type") {
+                    types.push(resolve_type(source_code, type_node, import_map, package));
+                }
+            }
+            "spread_parameter" => {
+                // Varargs: `Type... name` — type field exists on spread_parameter too
+                if let Some(type_node) = child.child_by_field_name("type") {
+                    let t = resolve_type(source_code, type_node, import_map, package);
+                    types.push(format!("{t}..."));
+                }
+            }
+            _ => {}
+        }
+    }
+    types
+}
+
+// Types always in scope from java.lang.* (implicit import in every Java file)
+const JAVA_LANG_TYPES: &[&str] = &[
+    "AutoCloseable",
+    "Boolean",
+    "Byte",
+    "CharSequence",
+    "Character",
+    "Class",
+    "ClassLoader",
+    "Cloneable",
+    "Comparable",
+    "Double",
+    "Enum",
+    "Error",
+    "Exception",
+    "Float",
+    "Integer",
+    "Iterable",
+    "Long",
+    "Math",
+    "Number",
+    "Object",
+    "Process",
+    "Runnable",
+    "Runtime",
+    "RuntimeException",
+    "Short",
+    "String",
+    "StringBuffer",
+    "StringBuilder",
+    "System",
+    "Thread",
+    "Throwable",
+    "Void",
+];
+
 #[cfg(test)]
 mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::Java).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
@@ -64,7 +316,7 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("doSomething".to_string()));
+        assert_eq!(find(src, 3, 9), ef("doSomething", "Foo#doSomething():void"));
     }
 
     #[test]
@@ -76,11 +328,93 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("Foo".to_string()));
+        assert_eq!(find(src, 3, 9), ef("Foo", "Foo#Foo()"));
     }
 
     #[test]
-    fn inside_method_with_throws() {
+    fn with_package() {
+        let src = "\
+package com.example;
+class Foo {
+    public void doSomething() {
+        int x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 4, 9), ef("doSomething", "com.example.Foo#doSomething():void"));
+    }
+
+    #[test]
+    fn java_lang_type_resolved() {
+        // String is in java.lang and always resolved without an explicit import
+        let src = "\
+class Foo {
+    public void handle(String s) {
+        int x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), ef("handle", "Foo#handle(java.lang.String):void"));
+    }
+
+    #[test]
+    fn explicit_import_resolved() {
+        let src = "\
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.ui.Model;
+class Foo {
+    public String process(MultipartFile file, Model model) {
+        return \"ok\";
+    }
+}
+";
+        assert_eq!(
+            find(src, 4, 9),
+            ef(
+                "process",
+                "Foo#process(org.springframework.web.multipart.MultipartFile, org.springframework.ui.Model):java.lang.String"
+            )
+        );
+    }
+
+    #[test]
+    fn full_fqn_with_package_and_imports() {
+        let src = "\
+package org.hdivsamples.controllers;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.ui.Model;
+class DashboardController {
+    public String processSimple(MultipartFile file, Model model) {
+        return \"ok\";
+    }
+}
+";
+        assert_eq!(
+            find(src, 5, 9),
+            ef(
+                "processSimple",
+                "org.hdivsamples.controllers.DashboardController#processSimple(org.springframework.web.multipart.MultipartFile, org.springframework.ui.Model):java.lang.String"
+            )
+        );
+    }
+
+    #[test]
+    fn annotations_not_in_fqn() {
+        // Method and parameter annotations are excluded from the FQN
+        let src = "\
+class Foo {
+    @Override
+    public void doSomething() {
+        int x = 1;
+    }
+}
+";
+        assert_eq!(find(src, 4, 9), ef("doSomething", "Foo#doSomething():void"));
+    }
+
+    #[test]
+    fn throws_not_in_fqn() {
+        // throws clause is not part of the standard Java FQN
         let src = "\
 class Foo {
     public void parse() throws IOException {
@@ -88,7 +422,7 @@ class Foo {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("parse".to_string()));
+        assert_eq!(find(src, 3, 9), ef("parse", "Foo#parse():void"));
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/methods.rs
@@ -293,7 +293,7 @@ const JAVA_LANG_TYPES: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
-    use super::{find_enclosing_function, find_enclosing_function_with_tree};
+    use super::find_enclosing_function_with_tree;
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
     use crate::model::violation::EnclosingFunction;

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript.rs
@@ -4,3 +4,4 @@
 
 mod imports;
 pub use imports::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
@@ -3,9 +3,21 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost function or method enclosing the given source position,
 /// or `None` if the position is not inside any named function.
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::JavaScript)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost function or method enclosing the given source position.
+/// See [`find_enclosing_function`] for documentation.
 ///
 /// Handles:
 /// - `function foo() {}` → `"foo"`
@@ -14,7 +26,7 @@ use crate::analysis::languages::ts_node_text;
 /// - `const foo = () => {}` → `"foo"` (name from the variable declarator)
 /// - `const foo = function bar() {}` → `"bar"` (explicit name takes priority)
 /// - Anonymous functions and arrow functions not assigned to a variable → `None`
-pub fn find_enclosing_function(
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -78,13 +90,13 @@ fn name_from_variable_declarator_parent<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::JavaScript).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
@@ -12,7 +12,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::JavaScript)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -46,7 +50,10 @@ pub fn find_enclosing_function_with_tree(
                     .child_by_field_name("name")
                     .map(|n| ts_node_text(source_code, n).to_owned())?;
                 let fully_qualified_name = name.clone();
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             "method_definition" => {
                 let name = node
@@ -58,7 +65,10 @@ pub fn find_enclosing_function_with_tree(
                         Some(cls) => format!("{cls}.{name}"),
                         None => name.clone(),
                     };
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             // tree-sitter-javascript uses "function" for both anonymous and named function
             // expressions. "function_declaration" is used only for statement-level `function foo() {}`.
@@ -67,7 +77,10 @@ pub fn find_enclosing_function_with_tree(
                     // Named function expression: `const x = function myName() {}`
                     let name = ts_node_text(source_code, name_node).to_owned();
                     let fully_qualified_name = name.clone();
-                    return Some(EnclosingFunction { name, fully_qualified_name });
+                    return Some(EnclosingFunction {
+                        name,
+                        fully_qualified_name,
+                    });
                 }
                 // Anonymous function assigned to a variable: `const foo = function() {}`
                 return enclosing_function_from_declarator_parent(source_code, node);
@@ -92,7 +105,10 @@ fn enclosing_function_from_declarator_parent(
     if parent.kind() == "variable_declarator" {
         let name = ts_node_text(source_code, parent.child_by_field_name("name")?).to_owned();
         let fully_qualified_name = name.clone();
-        Some(EnclosingFunction { name, fully_qualified_name })
+        Some(EnclosingFunction {
+            name,
+            fully_qualified_name,
+        })
     } else {
         None
     }
@@ -111,7 +127,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
@@ -2,36 +2,36 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::analysis::languages::ts_node_text;
+use crate::analysis::languages::{enclosing_class_name, ts_node_text};
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost function or method enclosing the given source position,
-/// or `None` if the position is not inside any named function.
+/// Returns the enclosing function or method for the given source position, or `None` if the
+/// position is not inside any named function.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::JavaScript)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost function or method enclosing the given source position.
+/// Returns the enclosing function or method for the given source position.
 /// See [`find_enclosing_function`] for documentation.
 ///
-/// Handles:
-/// - `function foo() {}` → `"foo"`
-/// - `class C { foo() {} }` → `"foo"`
-/// - `const foo = function() {}` → `"foo"` (name from the variable declarator)
-/// - `const foo = () => {}` → `"foo"` (name from the variable declarator)
-/// - `const foo = function bar() {}` → `"bar"` (explicit name takes priority)
-/// - Anonymous functions and arrow functions not assigned to a variable → `None`
+/// The `fullyQualifiedName` follows the JavaScript/V8 convention:
+///   - Top-level function: `functionName`
+///   - Class instance method: `ClassName.methodName`
+///   - Class static method: `ClassName.methodName`
+///   - Arrow/anonymous function assigned to a variable: `variableName`
+///   - Anonymous functions not assigned to a variable → `None`
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -42,30 +42,39 @@ pub fn find_enclosing_function_with_tree(
     loop {
         match node.kind() {
             "function_declaration" | "generator_function_declaration" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let fully_qualified_name = name.clone();
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             "method_definition" => {
-                // Class method: `foo() {}` or `async foo() {}`
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let class_kinds = &["class_declaration", "class_expression"];
+                let fully_qualified_name =
+                    match enclosing_class_name(source_code, node, class_kinds) {
+                        Some(cls) => format!("{cls}.{name}"),
+                        None => name.clone(),
+                    };
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
-            // tree-sitter-javascript uses "function" for both anonymous function expressions
-            // (`const f = function() {}`) and named function expressions (`const f = function g() {}`).
-            // "function_declaration" is used only for statement-level `function foo() {}`.
+            // tree-sitter-javascript uses "function" for both anonymous and named function
+            // expressions. "function_declaration" is used only for statement-level `function foo() {}`.
             "function" | "generator_function" => {
-                // Named function expression: `const x = function myName() {}`
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    return Some(ts_node_text(source_code, name_node).to_owned());
+                    // Named function expression: `const x = function myName() {}`
+                    let name = ts_node_text(source_code, name_node).to_owned();
+                    let fully_qualified_name = name.clone();
+                    return Some(EnclosingFunction { name, fully_qualified_name });
                 }
                 // Anonymous function assigned to a variable: `const foo = function() {}`
-                return name_from_variable_declarator_parent(source_code, node);
+                return enclosing_function_from_declarator_parent(source_code, node);
             }
             "arrow_function" => {
                 // Arrow function assigned to a variable: `const foo = () => {}`
-                return name_from_variable_declarator_parent(source_code, node);
+                return enclosing_function_from_declarator_parent(source_code, node);
             }
             _ => {}
         }
@@ -73,16 +82,17 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
-/// If `node`'s parent is a `variable_declarator`, returns the declarator's name.
-fn name_from_variable_declarator_parent<'a>(
-    source_code: &'a str,
-    node: tree_sitter::Node<'a>,
-) -> Option<String> {
+/// If `node`'s parent is a `variable_declarator`, returns an `EnclosingFunction` whose name and
+/// `fullyQualifiedName` are taken from the declarator's variable name.
+fn enclosing_function_from_declarator_parent(
+    source_code: &str,
+    node: tree_sitter::Node,
+) -> Option<EnclosingFunction> {
     let parent = node.parent()?;
     if parent.kind() == "variable_declarator" {
-        parent
-            .child_by_field_name("name")
-            .map(|n| ts_node_text(source_code, n).to_owned())
+        let name = ts_node_text(source_code, parent.child_by_field_name("name")?).to_owned();
+        let fully_qualified_name = name.clone();
+        Some(EnclosingFunction { name, fully_qualified_name })
     } else {
         None
     }
@@ -93,10 +103,15 @@ mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::JavaScript).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
@@ -106,7 +121,7 @@ function greet() {
     const x = 1;
 }
 ";
-        assert_eq!(find(src, 2, 5), Some("greet".to_string()));
+        assert_eq!(find(src, 2, 5), ef("greet", "greet"));
     }
 
     #[test]
@@ -118,7 +133,7 @@ class MyClass {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+        assert_eq!(find(src, 3, 9), ef("compute", "MyClass.compute"));
     }
 
     #[test]
@@ -128,7 +143,7 @@ const handleEvent = () => {
     const x = 1;
 };
 ";
-        assert_eq!(find(src, 2, 5), Some("handleEvent".to_string()));
+        assert_eq!(find(src, 2, 5), ef("handleEvent", "handleEvent"));
     }
 
     #[test]
@@ -138,7 +153,7 @@ const process = function() {
     const x = 1;
 };
 ";
-        assert_eq!(find(src, 2, 5), Some("process".to_string()));
+        assert_eq!(find(src, 2, 5), ef("process", "process"));
     }
 
     #[test]
@@ -148,7 +163,7 @@ const x = function myFn() {
     const y = 1;
 };
 ";
-        assert_eq!(find(src, 2, 5), Some("myFn".to_string()));
+        assert_eq!(find(src, 2, 5), ef("myFn", "myFn"));
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
@@ -100,7 +100,7 @@ fn enclosing_function_from_declarator_parent(
 
 #[cfg(test)]
 mod tests {
-    use super::{find_enclosing_function, find_enclosing_function_with_tree};
+    use super::find_enclosing_function_with_tree;
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
     use crate::model::violation::EnclosingFunction;

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/methods.rs
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost function or method enclosing the given source position,
+/// or `None` if the position is not inside any named function.
+///
+/// Handles:
+/// - `function foo() {}` → `"foo"`
+/// - `class C { foo() {} }` → `"foo"`
+/// - `const foo = function() {}` → `"foo"` (name from the variable declarator)
+/// - `const foo = () => {}` → `"foo"` (name from the variable declarator)
+/// - `const foo = function bar() {}` → `"bar"` (explicit name takes priority)
+/// - Anonymous functions and arrow functions not assigned to a variable → `None`
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "function_declaration" | "generator_function_declaration" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            "method_definition" => {
+                // Class method: `foo() {}` or `async foo() {}`
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            // tree-sitter-javascript uses "function" for both anonymous function expressions
+            // (`const f = function() {}`) and named function expressions (`const f = function g() {}`).
+            // "function_declaration" is used only for statement-level `function foo() {}`.
+            "function" | "generator_function" => {
+                // Named function expression: `const x = function myName() {}`
+                if let Some(name_node) = node.child_by_field_name("name") {
+                    return Some(ts_node_text(source_code, name_node).to_owned());
+                }
+                // Anonymous function assigned to a variable: `const foo = function() {}`
+                return name_from_variable_declarator_parent(source_code, node);
+            }
+            "arrow_function" => {
+                // Arrow function assigned to a variable: `const foo = () => {}`
+                return name_from_variable_declarator_parent(source_code, node);
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+/// If `node`'s parent is a `variable_declarator`, returns the declarator's name.
+fn name_from_variable_declarator_parent<'a>(
+    source_code: &'a str,
+    node: tree_sitter::Node<'a>,
+) -> Option<String> {
+    let parent = node.parent()?;
+    if parent.kind() == "variable_declarator" {
+        parent
+            .child_by_field_name("name")
+            .map(|n| ts_node_text(source_code, n).to_owned())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::JavaScript).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_function_declaration() {
+        let src = "\
+function greet() {
+    const x = 1;
+}
+";
+        assert_eq!(find(src, 2, 5), Some("greet".to_string()));
+    }
+
+    #[test]
+    fn inside_class_method() {
+        let src = "\
+class MyClass {
+    compute() {
+        return 42;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+    }
+
+    #[test]
+    fn inside_arrow_function_assigned_to_const() {
+        let src = "\
+const handleEvent = () => {
+    const x = 1;
+};
+";
+        assert_eq!(find(src, 2, 5), Some("handleEvent".to_string()));
+    }
+
+    #[test]
+    fn inside_anonymous_function_assigned_to_var() {
+        let src = "\
+const process = function() {
+    const x = 1;
+};
+";
+        assert_eq!(find(src, 2, 5), Some("process".to_string()));
+    }
+
+    #[test]
+    fn named_function_expression_uses_explicit_name() {
+        let src = "\
+const x = function myFn() {
+    const y = 1;
+};
+";
+        assert_eq!(find(src, 2, 5), Some("myFn".to_string()));
+    }
+
+    #[test]
+    fn top_level_code() {
+        let src = "const x = 1;\n";
+        assert_eq!(find(src, 1, 1), None);
+    }
+
+    #[test]
+    fn anonymous_arrow_not_assigned() {
+        let src = "\
+[1, 2].map(() => {
+    return 0;
+});
+";
+        assert_eq!(find(src, 2, 5), None);
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/python.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python.rs
@@ -4,3 +4,4 @@
 
 mod imports;
 pub use imports::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
@@ -12,7 +12,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Python)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -47,7 +51,10 @@ pub fn find_enclosing_function_with_tree(
                         Some(cls) => format!("{cls}.{name}"),
                         None => name.clone(),
                     };
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             _ => {}
         }
@@ -72,7 +79,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost function or method enclosing the given source position,
+/// or `None` if the position is not inside any function.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "function_definition" | "async_function_definition" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::Python).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_function() {
+        let src = "\
+def my_func():
+    x = 1
+";
+        assert_eq!(find(src, 2, 5), Some("my_func".to_string()));
+    }
+
+    #[test]
+    fn inside_async_function() {
+        let src = "\
+async def handle_request():
+    pass
+";
+        assert_eq!(find(src, 2, 5), Some("handle_request".to_string()));
+    }
+
+    #[test]
+    fn inside_method() {
+        let src = "\
+class MyClass:
+    def compute(self):
+        return 42
+";
+        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+    }
+
+    #[test]
+    fn top_level_code() {
+        let src = "x = 1\n";
+        assert_eq!(find(src, 1, 1), None);
+    }
+
+    #[test]
+    fn nested_function_returns_inner() {
+        let src = "\
+def outer():
+    def inner():
+        pass
+";
+        assert_eq!(find(src, 3, 9), Some("inner".to_string()));
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
@@ -2,28 +2,33 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::analysis::languages::ts_node_text;
+use crate::analysis::languages::{enclosing_class_name, ts_node_text};
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost function or method enclosing the given source position,
-/// or `None` if the position is not inside any function.
+/// Returns the enclosing function for the given source position, or `None` if the position
+/// is not inside any function.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::Python)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost function or method enclosing the given source position.
+/// Returns the enclosing function for the given source position.
 /// See [`find_enclosing_function`] for documentation.
+///
+/// The `fullyQualifiedName` follows Python's `__qualname__` convention:
+///   - Module-level function: `function_name`
+///   - Method inside a class: `ClassName.method_name`
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -34,9 +39,15 @@ pub fn find_enclosing_function_with_tree(
     loop {
         match node.kind() {
             "function_definition" | "async_function_definition" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let fully_qualified_name =
+                    match enclosing_class_name(source_code, node, &["class_definition"]) {
+                        Some(cls) => format!("{cls}.{name}"),
+                        None => name.clone(),
+                    };
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             _ => {}
         }
@@ -49,32 +60,37 @@ mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::Python).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
-    fn find_no_tree(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find_no_tree(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         find_enclosing_function(source, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
     fn inside_function() {
         let src = "\
-def my_func():
+def greet():
     x = 1
 ";
-        assert_eq!(find(src, 2, 5), Some("my_func".to_string()));
+        assert_eq!(find(src, 2, 5), ef("greet", "greet"));
     }
 
     #[test]
-    fn inside_async_function() {
+    fn inside_function_no_tree() {
         let src = "\
-async def handle_request():
-    pass
+def greet():
+    x = 1
 ";
-        assert_eq!(find(src, 2, 5), Some("handle_request".to_string()));
+        assert_eq!(find_no_tree(src, 2, 5), ef("greet", "greet"));
     }
 
     #[test]
@@ -84,31 +100,40 @@ class MyClass:
     def compute(self):
         return 42
 ";
-        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+        assert_eq!(find(src, 3, 9), ef("compute", "MyClass.compute"));
+    }
+
+    #[test]
+    fn inside_async_function() {
+        let src = "\
+async def fetch(url):
+    return url
+";
+        assert_eq!(find(src, 2, 5), ef("fetch", "fetch"));
+    }
+
+    #[test]
+    fn with_return_type_annotation() {
+        let src = "\
+def greet(x: int) -> str:
+    return str(x)
+";
+        assert_eq!(find(src, 2, 5), ef("greet", "greet"));
+    }
+
+    #[test]
+    fn nested_function_resolves_innermost() {
+        let src = "\
+def outer():
+    def inner():
+        x = 1
+";
+        assert_eq!(find(src, 3, 9), ef("inner", "inner"));
     }
 
     #[test]
     fn top_level_code() {
         let src = "x = 1\n";
         assert_eq!(find(src, 1, 1), None);
-    }
-
-    #[test]
-    fn nested_function_returns_inner() {
-        let src = "\
-def outer():
-    def inner():
-        pass
-";
-        assert_eq!(find(src, 3, 9), Some("inner".to_string()));
-    }
-
-    #[test]
-    fn no_tree_variant_matches_with_tree() {
-        let src = "\
-def my_func():
-    x = 1
-";
-        assert_eq!(find(src, 2, 5), find_no_tree(src, 2, 5));
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python/methods.rs
@@ -3,10 +3,22 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost function or method enclosing the given source position,
 /// or `None` if the position is not inside any function.
-pub fn find_enclosing_function(
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::Python)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost function or method enclosing the given source position.
+/// See [`find_enclosing_function`] for documentation.
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -34,13 +46,17 @@ pub fn find_enclosing_function(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::Python).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn find_no_tree(source: &str, line: u32, col: u32) -> Option<String> {
+        find_enclosing_function(source, line, col)
     }
 
     #[test]
@@ -85,5 +101,14 @@ def outer():
         pass
 ";
         assert_eq!(find(src, 3, 9), Some("inner".to_string()));
+    }
+
+    #[test]
+    fn no_tree_variant_matches_with_tree() {
+        let src = "\
+def my_func():
+    x = 1
+";
+        assert_eq!(find(src, 2, 5), find_no_tree(src, 2, 5));
     }
 }

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript.rs
@@ -4,3 +4,4 @@
 
 mod imports;
 pub use imports::*;
+pub mod methods;

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
@@ -96,7 +96,7 @@ fn enclosing_function_from_declarator_parent(
 
 #[cfg(test)]
 mod tests {
-    use super::{find_enclosing_function, find_enclosing_function_with_tree};
+    use super::find_enclosing_function_with_tree;
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
     use crate::model::violation::EnclosingFunction;

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
@@ -2,35 +2,37 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024 Datadog, Inc.
 
-use crate::analysis::languages::ts_node_text;
+use crate::analysis::languages::{enclosing_class_name, ts_node_text};
 use crate::analysis::tree_sitter::get_tree;
 use crate::model::common::Language;
+use crate::model::violation::EnclosingFunction;
 
-/// Returns the name of the innermost function or method enclosing the given source position,
-/// or `None` if the position is not inside any named function.
+/// Returns the enclosing function or method for the given source position, or `None` if the
+/// position is not inside any named function.
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::TypeScript)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
 
-/// Returns the name of the innermost function or method enclosing the given source position.
+/// Returns the enclosing function or method for the given source position.
 /// See [`find_enclosing_function`] for documentation.
 ///
-/// The TypeScript grammar (tree-sitter-typescript / TSX) shares all JavaScript function node
-/// types and additionally introduces:
-/// - `public_field_definition` (class fields with arrow initializers, not a function body)
+/// The TypeScript grammar shares all JavaScript function node types and additionally introduces
+/// `method_signature` (interface members). The `fullyQualifiedName` follows the same convention
+/// as JavaScript (V8/tooling standard): no type annotations, no modifiers.
 ///
-/// Arrow functions and anonymous functions assigned to variables are handled the same way as in
-/// JavaScript: the name is inferred from the surrounding `variable_declarator`.
+///   - Top-level function: `functionName`
+///   - Class method / interface method: `ClassName.methodName`
+///   - Arrow/anonymous function assigned to a variable: `variableName`
 pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
     col: u32,
-) -> Option<String> {
+) -> Option<EnclosingFunction> {
     let point = tree_sitter::Point {
         row: line.saturating_sub(1) as usize,
         column: col.saturating_sub(1) as usize,
@@ -41,25 +43,36 @@ pub fn find_enclosing_function_with_tree(
     loop {
         match node.kind() {
             "function_declaration" | "generator_function_declaration" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let fully_qualified_name = name.clone();
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             "method_definition" | "method_signature" => {
-                return node
+                let name = node
                     .child_by_field_name("name")
-                    .map(|n| ts_node_text(source_code, n).to_owned());
+                    .map(|n| ts_node_text(source_code, n).to_owned())?;
+                let class_kinds = &["class_declaration", "class_expression"];
+                let fully_qualified_name =
+                    match enclosing_class_name(source_code, node, class_kinds) {
+                        Some(cls) => format!("{cls}.{name}"),
+                        None => name.clone(),
+                    };
+                return Some(EnclosingFunction { name, fully_qualified_name });
             }
             // tree-sitter-typescript (TSX) uses "function" for both anonymous and named function
             // expressions, same as tree-sitter-javascript.
             "function" | "generator_function" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
-                    return Some(ts_node_text(source_code, name_node).to_owned());
+                    let name = ts_node_text(source_code, name_node).to_owned();
+                    let fully_qualified_name = name.clone();
+                    return Some(EnclosingFunction { name, fully_qualified_name });
                 }
-                return name_from_variable_declarator_parent(source_code, node);
+                return enclosing_function_from_declarator_parent(source_code, node);
             }
             "arrow_function" => {
-                return name_from_variable_declarator_parent(source_code, node);
+                return enclosing_function_from_declarator_parent(source_code, node);
             }
             _ => {}
         }
@@ -67,15 +80,15 @@ pub fn find_enclosing_function_with_tree(
     }
 }
 
-fn name_from_variable_declarator_parent<'a>(
-    source_code: &'a str,
-    node: tree_sitter::Node<'a>,
-) -> Option<String> {
+fn enclosing_function_from_declarator_parent(
+    source_code: &str,
+    node: tree_sitter::Node,
+) -> Option<EnclosingFunction> {
     let parent = node.parent()?;
     if parent.kind() == "variable_declarator" {
-        parent
-            .child_by_field_name("name")
-            .map(|n| ts_node_text(source_code, n).to_owned())
+        let name = ts_node_text(source_code, parent.child_by_field_name("name")?).to_owned();
+        let fully_qualified_name = name.clone();
+        Some(EnclosingFunction { name, fully_qualified_name })
     } else {
         None
     }
@@ -86,10 +99,15 @@ mod tests {
     use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
+    use crate::model::violation::EnclosingFunction;
 
-    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+    fn find(source: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
         let tree = get_tree(source, &Language::TypeScript).unwrap();
         find_enclosing_function_with_tree(source, &tree, line, col)
+    }
+
+    fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
+        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
     }
 
     #[test]
@@ -99,7 +117,7 @@ function greet(): void {
     const x = 1;
 }
 ";
-        assert_eq!(find(src, 2, 5), Some("greet".to_string()));
+        assert_eq!(find(src, 2, 5), ef("greet", "greet"));
     }
 
     #[test]
@@ -111,7 +129,7 @@ class MyService {
     }
 }
 ";
-        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+        assert_eq!(find(src, 3, 9), ef("compute", "MyService.compute"));
     }
 
     #[test]
@@ -121,7 +139,7 @@ const handler = (req: Request): void => {
     const x = 1;
 };
 ";
-        assert_eq!(find(src, 2, 5), Some("handler".to_string()));
+        assert_eq!(find(src, 2, 5), ef("handler", "handler"));
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024 Datadog, Inc.
+
+use crate::analysis::languages::ts_node_text;
+
+/// Returns the name of the innermost function or method enclosing the given source position,
+/// or `None` if the position is not inside any named function.
+///
+/// The TypeScript grammar (tree-sitter-typescript / TSX) shares all JavaScript function node
+/// types and additionally introduces:
+/// - `public_field_definition` (class fields with arrow initializers, not a function body)
+///
+/// Arrow functions and anonymous functions assigned to variables are handled the same way as in
+/// JavaScript: the name is inferred from the surrounding `variable_declarator`.
+pub fn find_enclosing_function(
+    source_code: &str,
+    tree: &tree_sitter::Tree,
+    line: u32,
+    col: u32,
+) -> Option<String> {
+    let point = tree_sitter::Point {
+        row: line.saturating_sub(1) as usize,
+        column: col.saturating_sub(1) as usize,
+    };
+    let mut node = tree
+        .root_node()
+        .named_descendant_for_point_range(point, point)?;
+    loop {
+        match node.kind() {
+            "function_declaration" | "generator_function_declaration" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            "method_definition" | "method_signature" => {
+                return node
+                    .child_by_field_name("name")
+                    .map(|n| ts_node_text(source_code, n).to_owned());
+            }
+            // tree-sitter-typescript (TSX) uses "function" for both anonymous and named function
+            // expressions, same as tree-sitter-javascript.
+            "function" | "generator_function" => {
+                if let Some(name_node) = node.child_by_field_name("name") {
+                    return Some(ts_node_text(source_code, name_node).to_owned());
+                }
+                return name_from_variable_declarator_parent(source_code, node);
+            }
+            "arrow_function" => {
+                return name_from_variable_declarator_parent(source_code, node);
+            }
+            _ => {}
+        }
+        node = node.parent()?;
+    }
+}
+
+fn name_from_variable_declarator_parent<'a>(
+    source_code: &'a str,
+    node: tree_sitter::Node<'a>,
+) -> Option<String> {
+    let parent = node.parent()?;
+    if parent.kind() == "variable_declarator" {
+        parent
+            .child_by_field_name("name")
+            .map(|n| ts_node_text(source_code, n).to_owned())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_enclosing_function;
+    use crate::analysis::tree_sitter::get_tree;
+    use crate::model::common::Language;
+
+    fn find(source: &str, line: u32, col: u32) -> Option<String> {
+        let tree = get_tree(source, &Language::TypeScript).unwrap();
+        find_enclosing_function(source, &tree, line, col)
+    }
+
+    #[test]
+    fn inside_function_declaration() {
+        let src = "\
+function greet(): void {
+    const x = 1;
+}
+";
+        assert_eq!(find(src, 2, 5), Some("greet".to_string()));
+    }
+
+    #[test]
+    fn inside_class_method() {
+        let src = "\
+class MyService {
+    compute(): number {
+        return 42;
+    }
+}
+";
+        assert_eq!(find(src, 3, 9), Some("compute".to_string()));
+    }
+
+    #[test]
+    fn inside_arrow_function() {
+        let src = "\
+const handler = (req: Request): void => {
+    const x = 1;
+};
+";
+        assert_eq!(find(src, 2, 5), Some("handler".to_string()));
+    }
+
+    #[test]
+    fn top_level_code() {
+        let src = "const x: number = 1;\n";
+        assert_eq!(find(src, 1, 1), None);
+    }
+}

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
@@ -12,7 +12,11 @@ use crate::model::violation::EnclosingFunction;
 ///
 /// This function parses the source code from scratch.
 /// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
-pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<EnclosingFunction> {
+pub fn find_enclosing_function(
+    source_code: &str,
+    line: u32,
+    col: u32,
+) -> Option<EnclosingFunction> {
     get_tree(source_code, &Language::TypeScript)
         .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
 }
@@ -47,7 +51,10 @@ pub fn find_enclosing_function_with_tree(
                     .child_by_field_name("name")
                     .map(|n| ts_node_text(source_code, n).to_owned())?;
                 let fully_qualified_name = name.clone();
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             "method_definition" | "method_signature" => {
                 let name = node
@@ -59,7 +66,10 @@ pub fn find_enclosing_function_with_tree(
                         Some(cls) => format!("{cls}.{name}"),
                         None => name.clone(),
                     };
-                return Some(EnclosingFunction { name, fully_qualified_name });
+                return Some(EnclosingFunction {
+                    name,
+                    fully_qualified_name,
+                });
             }
             // tree-sitter-typescript (TSX) uses "function" for both anonymous and named function
             // expressions, same as tree-sitter-javascript.
@@ -67,7 +77,10 @@ pub fn find_enclosing_function_with_tree(
                 if let Some(name_node) = node.child_by_field_name("name") {
                     let name = ts_node_text(source_code, name_node).to_owned();
                     let fully_qualified_name = name.clone();
-                    return Some(EnclosingFunction { name, fully_qualified_name });
+                    return Some(EnclosingFunction {
+                        name,
+                        fully_qualified_name,
+                    });
                 }
                 return enclosing_function_from_declarator_parent(source_code, node);
             }
@@ -88,7 +101,10 @@ fn enclosing_function_from_declarator_parent(
     if parent.kind() == "variable_declarator" {
         let name = ts_node_text(source_code, parent.child_by_field_name("name")?).to_owned();
         let fully_qualified_name = name.clone();
-        Some(EnclosingFunction { name, fully_qualified_name })
+        Some(EnclosingFunction {
+            name,
+            fully_qualified_name,
+        })
     } else {
         None
     }
@@ -107,7 +123,10 @@ mod tests {
     }
 
     fn ef(name: &str, sig: &str) -> Option<EnclosingFunction> {
-        Some(EnclosingFunction { name: name.to_string(), fully_qualified_name: sig.to_string() })
+        Some(EnclosingFunction {
+            name: name.to_string(),
+            fully_qualified_name: sig.to_string(),
+        })
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/typescript/methods.rs
@@ -3,9 +3,21 @@
 // Copyright 2024 Datadog, Inc.
 
 use crate::analysis::languages::ts_node_text;
+use crate::analysis::tree_sitter::get_tree;
+use crate::model::common::Language;
 
 /// Returns the name of the innermost function or method enclosing the given source position,
 /// or `None` if the position is not inside any named function.
+///
+/// This function parses the source code from scratch.
+/// If you already have a parsed tree, use [`find_enclosing_function_with_tree`].
+pub fn find_enclosing_function(source_code: &str, line: u32, col: u32) -> Option<String> {
+    get_tree(source_code, &Language::TypeScript)
+        .and_then(|tree| find_enclosing_function_with_tree(source_code, &tree, line, col))
+}
+
+/// Returns the name of the innermost function or method enclosing the given source position.
+/// See [`find_enclosing_function`] for documentation.
 ///
 /// The TypeScript grammar (tree-sitter-typescript / TSX) shares all JavaScript function node
 /// types and additionally introduces:
@@ -13,7 +25,7 @@ use crate::analysis::languages::ts_node_text;
 ///
 /// Arrow functions and anonymous functions assigned to variables are handled the same way as in
 /// JavaScript: the name is inferred from the surrounding `variable_declarator`.
-pub fn find_enclosing_function(
+pub fn find_enclosing_function_with_tree(
     source_code: &str,
     tree: &tree_sitter::Tree,
     line: u32,
@@ -71,13 +83,13 @@ fn name_from_variable_declarator_parent<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::find_enclosing_function;
+    use super::{find_enclosing_function, find_enclosing_function_with_tree};
     use crate::analysis::tree_sitter::get_tree;
     use crate::model::common::Language;
 
     fn find(source: &str, line: u32, col: u32) -> Option<String> {
         let tree = get_tree(source, &Language::TypeScript).unwrap();
-        find_enclosing_function(source, &tree, line, col)
+        find_enclosing_function_with_tree(source, &tree, line, col)
     }
 
     #[test]

--- a/crates/static-analysis-kernel/src/model/violation.rs
+++ b/crates/static-analysis-kernel/src/model/violation.rs
@@ -4,6 +4,16 @@ use common::model::position::{Position, Region};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+/// The function or method that encloses a violation.
+#[derive(Deserialize, Debug, Serialize, Clone, PartialEq)]
+pub struct EnclosingFunction {
+    /// Simple identifier (e.g. `handle`, `doSomething`).
+    pub name: String,
+    /// Service-definition qualified name: `ClassName.methodName` when the function belongs to a
+    /// class or struct, or just `methodName` for top-level functions.
+    pub fully_qualified_name: String,
+}
+
 #[derive(Copy, Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub enum EditType {
     #[serde(rename = "ADD")]
@@ -42,8 +52,8 @@ pub struct Violation {
     #[serde(default)]
     #[builder(default)]
     pub is_suppressed: bool,
-    /// The name of the method or function enclosing this violation, if any.
+    /// The function or method enclosing this violation, if any.
     #[serde(default)]
     #[builder(default)]
-    pub method_name: Option<String>,
+    pub enclosing_function: Option<EnclosingFunction>,
 }

--- a/crates/static-analysis-kernel/src/model/violation.rs
+++ b/crates/static-analysis-kernel/src/model/violation.rs
@@ -42,4 +42,8 @@ pub struct Violation {
     #[serde(default)]
     #[builder(default)]
     pub is_suppressed: bool,
+    /// The name of the method or function enclosing this violation, if any.
+    #[serde(default)]
+    #[builder(default)]
+    pub method_name: Option<String>,
 }

--- a/misc/integration-test-method-name.sh
+++ b/misc/integration-test-method-name.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# Integration test: verify that method names are populated in SARIF logicalLocations
+# for languages that implement enclosing-function detection.
+#
+# Each language block:
+#   1. Clones a representative repo
+#   2. Runs the analyzer with relevant rulesets
+#   3. Asserts that at least one violation has a logicalLocations entry (i.e. method_name was resolved)
+#
+# If this test fails for a previously-passing language, it means enclosing-function
+# detection broke for that language.  If a newly-supported language never appears here,
+# add it so that coverage is enforced going forward.
+
+set -euo pipefail
+
+ANALYZER="./target/release-dev/datadog-static-analyzer"
+
+cargo fetch
+cargo build --locked --profile release-dev --bin datadog-static-analyzer
+
+# ---------------------------------------------------------------------------
+# Helper: count results that carry at least one logicalLocations entry.
+# ---------------------------------------------------------------------------
+count_with_method() {
+    local results_file="$1"
+    jq '[.runs[0].results[] |
+        select(any(.locations[]?; (.logicalLocations // []) | length > 0))
+       ] | length' "${results_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Python – django-realworld-example-app
+# ---------------------------------------------------------------------------
+echo "=== Python: method-name detection ==="
+PY_DIR=$(mktemp -d)
+git clone --depth=1 https://github.com/gothinkster/django-realworld-example-app.git "${PY_DIR}"
+
+cat > "${PY_DIR}/code-security.datadog.yaml" <<'YAML'
+schema-version: v1.0
+sast:
+  use-default-rulesets: false
+  use-rulesets:
+    - python-security
+    - python-best-practices
+    - python-django
+YAML
+
+"${ANALYZER}" --directory "${PY_DIR}" -o "${PY_DIR}/results.json" -f sarif
+
+TOTAL=$(jq '.runs[0].results | length' "${PY_DIR}/results.json")
+WITH_METHOD=$(count_with_method "${PY_DIR}/results.json")
+
+echo "Python: ${WITH_METHOD}/${TOTAL} violations have a method name"
+
+if [ "${TOTAL}" -lt 1 ]; then
+    echo "FAIL: no Python violations found – ruleset may be empty or repo changed"
+    exit 1
+fi
+if [ "${WITH_METHOD}" -lt 1 ]; then
+    echo "FAIL: no Python violations carry a logicalLocations/method name"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript – juice-shop
+# ---------------------------------------------------------------------------
+echo "=== JavaScript/TypeScript: method-name detection ==="
+JS_DIR=$(mktemp -d)
+git clone --depth=1 https://github.com/juice-shop/juice-shop.git "${JS_DIR}"
+
+cat > "${JS_DIR}/code-security.datadog.yaml" <<'YAML'
+schema-version: v1.0
+sast:
+  use-default-rulesets: false
+  use-rulesets:
+    - javascript-best-practices
+    - typescript-best-practices
+    - javascript-common-security
+    - typescript-common-security
+    - javascript-node-security
+    - typescript-node-security
+YAML
+
+"${ANALYZER}" --directory "${JS_DIR}" -o "${JS_DIR}/results.json" -f sarif
+
+TOTAL=$(jq '.runs[0].results | length' "${JS_DIR}/results.json")
+WITH_METHOD=$(count_with_method "${JS_DIR}/results.json")
+
+echo "JS/TS: ${WITH_METHOD}/${TOTAL} violations have a method name"
+
+if [ "${TOTAL}" -lt 1 ]; then
+    echo "FAIL: no JS/TS violations found – ruleset may be empty or repo changed"
+    exit 1
+fi
+if [ "${WITH_METHOD}" -lt 1 ]; then
+    echo "FAIL: no JS/TS violations carry a logicalLocations/method name"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Java – OWASP Benchmark
+# ---------------------------------------------------------------------------
+echo "=== Java: method-name detection ==="
+JAVA_DIR=$(mktemp -d)
+git clone --depth=1 https://github.com/OWASP-Benchmark/BenchmarkJava.git "${JAVA_DIR}"
+
+cat > "${JAVA_DIR}/code-security.datadog.yaml" <<'YAML'
+schema-version: v1.0
+sast:
+  use-default-rulesets: false
+  use-rulesets:
+    - java-security
+    - java-best-practices
+YAML
+
+"${ANALYZER}" --directory "${JAVA_DIR}" -o "${JAVA_DIR}/results.json" -f sarif
+
+TOTAL=$(jq '.runs[0].results | length' "${JAVA_DIR}/results.json")
+WITH_METHOD=$(count_with_method "${JAVA_DIR}/results.json")
+
+echo "Java: ${WITH_METHOD}/${TOTAL} violations have a method name"
+
+if [ "${TOTAL}" -lt 1 ]; then
+    echo "FAIL: no Java violations found – ruleset may be empty or repo changed"
+    exit 1
+fi
+if [ "${WITH_METHOD}" -lt 1 ]; then
+    echo "FAIL: no Java violations carry a logicalLocations/method name"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Go – github-mcp-server
+# ---------------------------------------------------------------------------
+echo "=== Go: method-name detection ==="
+GO_DIR=$(mktemp -d)
+git clone --depth=1 https://github.com/github/github-mcp-server.git "${GO_DIR}"
+
+cat > "${GO_DIR}/code-security.datadog.yaml" <<'YAML'
+schema-version: v1.0
+sast:
+  use-default-rulesets: false
+  use-rulesets:
+    - go-security
+    - go-best-practices
+YAML
+
+"${ANALYZER}" --directory "${GO_DIR}" -o "${GO_DIR}/results.json" -f sarif
+
+TOTAL=$(jq '.runs[0].results | length' "${GO_DIR}/results.json")
+WITH_METHOD=$(count_with_method "${GO_DIR}/results.json")
+
+echo "Go: ${WITH_METHOD}/${TOTAL} violations have a method name"
+
+if [ "${TOTAL}" -lt 1 ]; then
+    echo "FAIL: no Go violations found – ruleset may be empty or repo changed"
+    exit 1
+fi
+if [ "${WITH_METHOD}" -lt 1 ]; then
+    echo "FAIL: no Go violations carry a logicalLocations/method name"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# C# – unity-mcp
+# ---------------------------------------------------------------------------
+echo "=== C#: method-name detection ==="
+CS_DIR=$(mktemp -d)
+git clone --depth=1 https://github.com/CoplayDev/unity-mcp.git "${CS_DIR}"
+
+cat > "${CS_DIR}/code-security.datadog.yaml" <<'YAML'
+schema-version: v1.0
+sast:
+  use-default-rulesets: false
+  use-rulesets:
+    - csharp-security
+    - csharp-best-practices
+YAML
+
+"${ANALYZER}" --directory "${CS_DIR}" -o "${CS_DIR}/results.json" -f sarif
+
+TOTAL=$(jq '.runs[0].results | length' "${CS_DIR}/results.json")
+WITH_METHOD=$(count_with_method "${CS_DIR}/results.json")
+
+echo "C#: ${WITH_METHOD}/${TOTAL} violations have a method name"
+
+if [ "${TOTAL}" -lt 1 ]; then
+    echo "FAIL: no C# violations found – ruleset may be empty or repo changed"
+    exit 1
+fi
+if [ "${WITH_METHOD}" -lt 1 ]; then
+    echo "FAIL: no C# violations carry a logicalLocations/method name"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo "All method-name integration tests passed"
+exit 0


### PR DESCRIPTION
## What problem are you trying to solve?
SARIF violations only report file, line and column. There is no information about which method or function contains the violation, which makes it harder for consumers to attribute findings to specific code constructs.

## What is your solution?
  - Add a method_name and fully_qualified_name fields to Violation
  - Implement per-language enclosing function detection using tree-sitter AST traversal for Python, Java, Go, JavaScript, TypeScript and C#
  - Populate method_name and fully_qualified_name in execute_rule after violations are converted from JS to Rust, reusing the already-parsed tree
  - Export the method name and the fully qualified name in the SARIF output under locations[].logicalLocations with kind: "function"     

```json
{
  "locations": [
    {
      "logicalLocations": [
        {
          "fullyQualifiedName": "full name",
          "kind": "function",
          "name": "name"
        }
      ],
      "physicalLocation": {
        "artifactLocation": {
          "uri": "file_path"
        },
        "region": {
          "endColumn": x,
          "endLine": x,
          "startColumn": y,
          "startLine": y
        }
      }
    }
  ]
}
```

| Language   | Format                                                           | Example                                                                              |
|------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------|
| Java       | package.ClassName#methodName(ParamType1, ParamType2):ReturnType  | org.example.DashboardController#processSimple(MultipartFile, Model):java.lang.String |
| Python     | module.ClassName.method_name                                     | controllers.dashboard.MyClass.compute                                                |
| Go         | package.TypeName.MethodName                                      | main.Server.Handle                                                                   |
| C#         | Namespace.ClassName.MethodName(ParamType1, ParamType2)           | MyApp.Controllers.Foo.Handle(string, int)                                            |
| JavaScript | ClassName.methodName                                             | MyClass.compute                                                                      |
| TypeScript | ClassName.methodName                                             | MyService.compute                                                                    |

## Alternatives considered
A generic approach using a shared list of function node types across all languages. Rejected because different languages have edge cases that require specific handling (e.g. async def in Python, constructors in Java and C#, arrow functions assigned to variables in JavaScript).

## What the reviewer should know
- Each language module (python/methods.rs, java/methods.rs, etc.) follows the same structure as the existing import parsers
- Two variants are exposed: find_enclosing_function (parses from scratch) and find_enclosing_function_with_tree (reuses an existing tree), consistent with the parse_imports / parse_imports_with_tree pattern
- runtime.rs uses the _with_tree variant since the tree is always available at that point
- Languages not yet covered will return None by now. They can be added incrementally