### PR TITLE
Bump dd-sds to 5ccd2861b8daca861bc8409999b46710ff9bd910

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "dd-sds"
 version = "0.1.2"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=485df55c5bfd51036386aa3bb37336ec38e828fb#485df55c5bfd51036386aa3bb37336ec38e828fb"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=5ccd2861b8daca861bc8409999b46710ff9bd910#5ccd2861b8daca861bc8409999b46710ff9bd910"
 dependencies = [
  "ahash",
  "aws-sign-v4",

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,5 +15,5 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "485df55c5bfd51036386aa3bb37336ec38e828fb" }
+dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "5ccd2861b8daca861bc8409999b46710ff9bd910" }
 strum = "0.25.0"


### PR DESCRIPTION
# SDS Bump changelog

##  New or updated OOTB rules

###  PII rules

  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/327
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/328
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/334
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/336

###  Credential rules

  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/349

##  SDS library improvements

  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/323
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/339
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/340
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/344
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/346
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/347
  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/348

##  CI & infrastructure

  - https://github.com/DataDog/dd-sensitive-data-scanner/pull/338