### PR TITLE
Create a new Config parse endpoint for the IDEs

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
 
 use crate::datadog_static_analyzer_server::ide::configuration_file::models::{
-    CanOnboardRequest, GetRulesetsRequest,
+    CanOnboardRequest, GetRulesetsRequest, ParseConfigRequest, ParseConfigResponse,
+    SastParsedConfig,
 };
 
 use super::error::ConfigFileError;
 use super::models::{AddRuleSetsRequest, IgnoreRuleRequest};
-use super::static_analysis_config_file::StaticAnalysisConfigFile;
+use super::static_analysis_config_file::{Base64String, StaticAnalysisConfigFile};
 use kernel::utils::encode_base64_string;
 use rocket::http::Status;
 use rocket::response::status::Custom;
@@ -37,19 +38,20 @@ pub fn post_ignore_rule(
         ..
     } = request.into_inner();
     tracing::debug!(rule, content = &configuration_base64);
-    let result = StaticAnalysisConfigFile::with_ignored_rule(rule.into(), configuration_base64);
+    let result = StaticAnalysisConfigFile::with_ignored_rule(
+        rule.into(),
+        Base64String(configuration_base64),
+    );
     to_response_result(result, encoded)
 }
 
 /// Checks if onboarding is allowed for the configuration file (deprecated).
 ///
-/// # Deprecation
-/// Deprecated: Use [`post_can_onboard_v2`] instead.
-///
 /// # Arguments
 /// * `content` - The path to the configuration file.
 #[instrument()]
 #[rocket::get("/v1/config/can-onboard/<content..>")]
+#[deprecated(note = "IDEs stopped supporting onboarding")]
 pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFileError>> {
     let content_str = content.to_string_lossy().into_owned();
     can_onboard(content_str)
@@ -65,6 +67,7 @@ pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFile
     format = "application/json",
     data = "<request>"
 )]
+#[deprecated(note = "IDEs stopped supporting onboarding")]
 pub fn post_can_onboard_v2(
     request: Json<CanOnboardRequest>,
 ) -> Result<Json<bool>, Custom<ConfigFileError>> {
@@ -77,19 +80,23 @@ pub fn post_can_onboard_v2(
 
 /// Gets the rulesets from the static analysis configuration file (deprecated).
 ///
-/// # Deprecation
-/// Deprecated: Use [`post_get_rulesets_v2`] instead.
+/// Best-effort: returns `[]` on any parse or decode failure to preserve the wire
+/// contract for older IDE clients. Strict parsing lives in [`post_parse_config`].
 ///
 /// # Arguments
 /// * `content` - The path to the configuration file.
 #[instrument()]
 #[rocket::get("/v1/config/rulesets/<content..>")]
+#[deprecated(note = "Use post_parse_config")]
 pub fn get_get_rulesets(content: PathBuf) -> Json<Vec<String>> {
     let content_str = content.to_string_lossy().into_owned();
     get_rulesets(content_str)
 }
 
 /// Gets the rulesets from the static analysis configuration file (v2).
+///
+/// Best-effort: returns `[]` on any parse or decode failure to preserve the wire
+/// contract for older IDE clients. Strict parsing lives in [`post_parse_config`].
 ///
 /// # Arguments
 /// * `request` - The request containing the configuration file (base64).
@@ -99,6 +106,7 @@ pub fn get_get_rulesets(content: PathBuf) -> Json<Vec<String>> {
     format = "application/json",
     data = "<request>"
 )]
+#[deprecated(note = "Use post_parse_config")]
 pub fn post_get_rulesets_v2(request: Json<GetRulesetsRequest>) -> Json<Vec<String>> {
     let GetRulesetsRequest {
         configuration_base64,
@@ -107,15 +115,33 @@ pub fn post_get_rulesets_v2(request: Json<GetRulesetsRequest>) -> Json<Vec<Strin
     get_rulesets(configuration_base64)
 }
 
-/// Adds rulesets to the static analysis configuration file (deprecated).
+/// Parses the static analysis configuration YAML and returns per-product fields.
 ///
-/// # Deprecation
-/// Deprecated: Use [`post_add_rulesets_v2`] instead.
+/// # Arguments
+/// * `request` - The request containing the raw YAML string.
+#[instrument()]
+#[rocket::post("/v2/config/parse", format = "application/json", data = "<request>")]
+pub fn post_parse_config(
+    request: Json<ParseConfigRequest>,
+) -> Result<Json<ParseConfigResponse>, Custom<ConfigFileError>> {
+    let ParseConfigRequest { configuration } = request.into_inner();
+    tracing::debug!(%configuration);
+    let config = StaticAnalysisConfigFile::try_from(configuration)
+        .map_err(|e| Custom(Status::InternalServerError, e))?;
+    Ok(Json(ParseConfigResponse {
+        sast: SastParsedConfig {
+            rulesets: config.sast_rulesets(),
+        },
+    }))
+}
+
+/// Adds rulesets to the static analysis configuration file (deprecated).
 ///
 /// # Arguments
 /// * `request` - The request containing rulesets and configuration file (base64).
 #[instrument()]
 #[rocket::post("/v1/config/rulesets", format = "application/json", data = "<request>")]
+#[deprecated(note = "Use post_parse_config")]
 pub fn post_add_rulesets(
     request: Json<AddRuleSetsRequest>,
 ) -> Result<String, Custom<ConfigFileError>> {
@@ -132,6 +158,7 @@ pub fn post_add_rulesets(
     format = "application/json",
     data = "<request>"
 )]
+#[deprecated(note = "IDEs stopped supporting this flow")]
 pub fn post_add_rulesets_v2(
     request: Json<AddRuleSetsRequest>,
 ) -> Result<String, Custom<ConfigFileError>> {
@@ -155,11 +182,21 @@ fn add_rulesets(request: Json<AddRuleSetsRequest>) -> Result<String, Custom<Conf
         rulesets=?&rulesets,
         content=&configuration_base64
     );
-    let result = StaticAnalysisConfigFile::with_added_rulesets(&rulesets, configuration_base64);
+    let result = StaticAnalysisConfigFile::with_added_rulesets(
+        &rulesets,
+        configuration_base64.map(Base64String),
+    );
     to_response_result(result, encoded)
 }
 
-/// Extracts rulesets from the configuration file.
+/// Extracts rulesets from the configuration file (best-effort).
+///
+/// Returns an empty list on decode or parse failures. This preserves the legacy
+/// contract used by older IDE clients on the deprecated
+/// `/v1/config/rulesets/...` and `/v2/config/get-rulesets` routes — they must
+/// not surface a transport error for a malformed local config.
+///
+/// Strict parsing lives in [`post_parse_config`].
 ///
 /// # Arguments
 /// * `content` - The configuration file content (base64).
@@ -170,7 +207,13 @@ fn get_rulesets(mut content: String) -> Json<Vec<String>> {
         content = content.replace("\\", "/");
     }
     tracing::debug!(%content);
-    Json(StaticAnalysisConfigFile::to_rulesets(content))
+    let rulesets = StaticAnalysisConfigFile::try_from(Base64String(content))
+        .map(|config| config.sast_rulesets())
+        .unwrap_or_else(|e| {
+            tracing::error!(error = ?e, "Error trying to parse config file");
+            vec![]
+        });
+    Json(rulesets)
 }
 
 /// Checks if onboarding is allowed for the configuration file.
@@ -184,7 +227,7 @@ fn can_onboard(mut content: String) -> Result<Json<bool>, Custom<ConfigFileError
         content = content.replace("\\", "/");
     }
     tracing::debug!(%content);
-    let config = StaticAnalysisConfigFile::try_from(content)
+    let config = StaticAnalysisConfigFile::try_from(Base64String(content))
         .map_err(|e| Custom(Status::InternalServerError, e))?;
     let can_onboard = config.is_onboarding_allowed();
     Ok(Json(can_onboard))

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -127,7 +127,7 @@ pub fn post_parse_config(
     let ParseConfigRequest { configuration } = request.into_inner();
     tracing::debug!(%configuration);
     let config = StaticAnalysisConfigFile::try_from(configuration)
-        .map_err(|e| Custom(Status::InternalServerError, e))?;
+        .map_err(|e| Custom(Status::BadRequest, e))?;
     Ok(Json(ParseConfigResponse {
         sast: SastParsedConfig {
             rulesets: config.sast_rulesets(),

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/models.rs
@@ -27,3 +27,18 @@ pub struct CanOnboardRequest {
     #[serde(rename = "configuration")]
     pub configuration_base64: String,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct ParseConfigRequest {
+    pub configuration: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct ParseConfigResponse {
+    pub sast: SastParsedConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct SastParsedConfig {
+    pub rulesets: Vec<String>,
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -60,6 +60,31 @@ impl TryFrom<String> for StaticAnalysisConfigFile {
     }
 }
 
+/// Returns a vec representing an ignored path (via the `**` glob).
+fn create_ignored_path() -> Vec<String> {
+    vec![WILDCARD_IGNORE.to_string()]
+}
+
+fn create_ignored_pattern() -> Vec<PathPattern> {
+    create_ignored_path()
+        .into_iter()
+        .map(|path_str| PathPattern {
+            prefix: std::path::PathBuf::from(path_str),
+            glob: None,
+        })
+        .collect()
+}
+
+fn create_ignored_rule() -> RuleConfig {
+    RuleConfig {
+        paths: PathConfig {
+            ignore: create_ignored_pattern(),
+            only: None,
+        },
+        ..Default::default()
+    }
+}
+
 impl StaticAnalysisConfigFile {
     /// Parses a raw YAML configuration string (not base64-encoded) into a [`StaticAnalysisConfigFile`].
     fn from_yaml_content(content: String) -> Result<Self, ConfigFileError> {
@@ -91,34 +116,7 @@ impl StaticAnalysisConfigFile {
             original_content: Some(content),
         })
     }
-}
 
-/// Returns a vec representing an ignored path (via the `**` glob).
-fn create_ignored_path() -> Vec<String> {
-    vec![WILDCARD_IGNORE.to_string()]
-}
-
-fn create_ignored_pattern() -> Vec<PathPattern> {
-    create_ignored_path()
-        .into_iter()
-        .map(|path_str| PathPattern {
-            prefix: std::path::PathBuf::from(path_str),
-            glob: None,
-        })
-        .collect()
-}
-
-fn create_ignored_rule() -> RuleConfig {
-    RuleConfig {
-        paths: PathConfig {
-            ignore: create_ignored_pattern(),
-            only: None,
-        },
-        ..Default::default()
-    }
-}
-
-impl StaticAnalysisConfigFile {
     /// Ignores a specific rule in the static analysis configuration file.
     ///
     /// # Parameters

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -38,12 +38,32 @@ impl From<file_legacy::ConfigFile> for StaticAnalysisConfigFile {
     }
 }
 
+/// Soft deprecated, used for when older routes still pass Base64 encoded configuration file
+///
+#[derive(Debug)]
+pub struct Base64String(pub String);
+
+impl TryFrom<Base64String> for StaticAnalysisConfigFile {
+    type Error = ConfigFileError;
+
+    fn try_from(base64_str: Base64String) -> Result<Self, Self::Error> {
+        let decoded = decode_base64_string(base64_str.0)?;
+        StaticAnalysisConfigFile::try_from(decoded)
+    }
+}
+
 impl TryFrom<String> for StaticAnalysisConfigFile {
     type Error = ConfigFileError;
 
-    fn try_from(base64_str: String) -> Result<Self, Self::Error> {
+    fn try_from(content: String) -> Result<Self, Self::Error> {
+        Self::from_yaml_content(content)
+    }
+}
+
+impl StaticAnalysisConfigFile {
+    /// Parses a raw YAML configuration string (not base64-encoded) into a [`StaticAnalysisConfigFile`].
+    fn from_yaml_content(content: String) -> Result<Self, ConfigFileError> {
         use serde::de::Error;
-        let content = decode_base64_string(base64_str)?;
         if content.trim().is_empty() {
             return Ok(Self::default());
         }
@@ -108,7 +128,7 @@ impl StaticAnalysisConfigFile {
     ///
     /// # Returns
     ///
-    /// If successful, this function returns a `Result` containing a `String`. The `String` is the updated content of the static analysis configuration file with the specified rule ignored. If the `config_content_base64` is `None`. A default `StaticAnalysisConfigFile` will be used.
+    /// If successful, this function returns a `Result` containing a `String`. The `String` is the updated content of the static analysis configuration file with the specified rule ignored.
     ///
     /// # Errors
     ///
@@ -121,7 +141,7 @@ impl StaticAnalysisConfigFile {
     ///
     /// ```no_run
     /// let rule = "RULE_TO_IGNORE".into();
-    /// let config_content_base64 = kernel::utils::encode_base64_string("...".to_string());
+    /// let config_content_base64 = Base64String(kernel::utils::encode_base64_string("...".to_string()));
     /// let result = StaticAnalysisConfigFile::with_ignored_rule(rule, config_content_base64);
     /// match result {
     ///     Ok(updated_config) => println!("Updated config: {}", updated_config),
@@ -131,7 +151,7 @@ impl StaticAnalysisConfigFile {
     #[instrument]
     pub fn with_ignored_rule(
         rule: Cow<str>,
-        config_content_base64: String,
+        config_content_base64: Base64String,
     ) -> Result<String, ConfigFileError> {
         let mut config = Self::try_from(config_content_base64).map_err(|e| {
             tracing::error!(error =?e, "Error trying to parse config file");
@@ -145,6 +165,12 @@ impl StaticAnalysisConfigFile {
         })
     }
 
+    /// Ignores a specific rule in the static analysis configuration file.
+    ///
+    /// # Parameters
+    ///
+    /// * `rule`: The rule to be ignored.
+    ///
     #[instrument(skip(self))]
     pub fn ignore_rule(&mut self, rule: Cow<str>) {
         let Some((ruleset_name, rule_name)) = rule.split_once('/') else {
@@ -207,7 +233,7 @@ impl StaticAnalysisConfigFile {
     ///
     /// ```no_run
     /// let rulesets = vec!["RULESET_TO_ADD".to_string()];
-    /// let config_content_base64 = kernel::utils::encode_base64_string("...".to_string());
+    /// let config_content_base64 = Base64String(kernel::utils::encode_base64_string("...".to_string()));
     /// let result = StaticAnalysisConfigFile::with_added_rulesets(&rulesets, Some(config_content_base64));
     /// match result {
     ///     Ok(updated_config) => println!("Updated config: {}", updated_config),
@@ -215,9 +241,10 @@ impl StaticAnalysisConfigFile {
     /// }
     /// ```
     #[instrument]
+    #[allow(deprecated)]
     pub fn with_added_rulesets(
         rulesets: &[impl AsRef<str> + Debug],
-        config_content_base64: Option<String>,
+        config_content_base64: Option<Base64String>,
     ) -> Result<String, ConfigFileError> {
         let mut config = config_content_base64.map_or(Ok(Self::default()), |content| {
             Self::try_from(content).map_err(|e| {
@@ -234,6 +261,7 @@ impl StaticAnalysisConfigFile {
     }
 
     #[instrument(skip(self))]
+    #[deprecated(note = "IDEs stopped adding new rule sets, remove when endpoint is removed")]
     pub fn add_rulesets(&mut self, rulesets: &[impl AsRef<str> + Debug]) {
         match &mut self.config_file {
             WithVersion::Legacy(config) => {
@@ -251,35 +279,10 @@ impl StaticAnalysisConfigFile {
         }
     }
 
-    /// Parses the content of a static analysis configuration file and returns the list of rulesets.
-    ///
-    /// # Parameters
-    ///
-    /// * `config_content_base64`: The base64-encoded content of the static analysis configuration file.
-    ///
-    /// # Returns
-    ///
-    /// This function returns a `Vec<String>`, where each `String` is a ruleset from the configuration file.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// let config_content_base64 = kernel::utils::encode_base64_string("...".to_string());
-    /// let rulesets = StaticAnalysisConfigFile::to_rulesets(config_content_base64);
-    /// for ruleset in rulesets {
-    ///     println!("Ruleset: {}", ruleset);
-    /// }
-    /// ```
-    #[instrument]
-    pub fn to_rulesets(config_content_base64: String) -> Vec<String> {
-        let parsed = match Self::try_from(config_content_base64) {
-            Ok(config) => config,
-            Err(e) => {
-                tracing::error!(error =?e, "Error trying to parse config file");
-                return vec![];
-            }
-        };
-        match parsed.config_file {
+    /// Extracts the list of SAST rulesets from this configuration.
+    #[instrument(skip(self))]
+    pub fn sast_rulesets(&self) -> Vec<String> {
+        match &self.config_file {
             WithVersion::Legacy(config) => config.rulesets.iter().map(|rs| rs.0.clone()).collect(),
             WithVersion::CodeSecurity(config) => config
                 .sast
@@ -355,9 +358,10 @@ impl StaticAnalysisConfigFile {
 mod tests {
 
     use kernel::utils::encode_base64_string;
+    use crate::datadog_static_analyzer_server::ide::configuration_file::static_analysis_config_file::Base64String;
 
-    fn to_encoded_content(content: &'static str) -> String {
-        encode_base64_string(content.to_owned())
+    fn to_encoded_content(content: &'static str) -> Base64String {
+        Base64String(encode_base64_string(content.to_owned()))
     }
 
     mod get_rulesets {
@@ -374,7 +378,8 @@ rulesets:
 - java-1
 ",
             );
-            let rulesets = StaticAnalysisConfigFile::to_rulesets(content);
+            let config = StaticAnalysisConfigFile::try_from(content).unwrap();
+            let rulesets = config.sast_rulesets();
             assert_eq!(rulesets, vec!["java-security", "java-1"]);
         }
 
@@ -396,12 +401,13 @@ rulesets:
           - "**"
 "#,
             );
-            let rulesets = StaticAnalysisConfigFile::to_rulesets(content);
+            let config = StaticAnalysisConfigFile::try_from(content).unwrap();
+            let rulesets = config.sast_rulesets();
             assert_eq!(rulesets, vec!["java-security", "java-1", "ruleset1"]);
         }
 
         #[test]
-        fn it_returns_empty_array_if_bad_format() {
+        fn it_returns_error_if_bad_format() {
             let content = to_encoded_content(
                 r"
 schema-version: v1
@@ -418,12 +424,12 @@ rulesets:
                 - '**'
 ",
             );
-            let rulesets = StaticAnalysisConfigFile::to_rulesets(content);
-            assert!(rulesets.is_empty());
+            let err = StaticAnalysisConfigFile::try_from(content).unwrap_err();
+            assert_eq!(err.code(), 1);
         }
 
         #[test]
-        fn it_returns_empty_array_if_wrong_version() {
+        fn it_returns_error_if_wrong_version() {
             let content = to_encoded_content(
                 r"
 schema-version: v354
@@ -432,8 +438,8 @@ rulesets:
 - java-1
 ",
             );
-            let rulesets = StaticAnalysisConfigFile::to_rulesets(content);
-            assert!(rulesets.is_empty());
+            let err = StaticAnalysisConfigFile::try_from(content).unwrap_err();
+            assert_eq!(err.code(), 1);
         }
     }
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -3,6 +3,7 @@
 mod configuration_file;
 use rocket::Route;
 
+#[allow(deprecated)]
 pub fn ide_routes() -> Vec<Route> {
     rocket::routes![
         configuration_file::endpoints::post_ignore_rule,
@@ -10,6 +11,7 @@ pub fn ide_routes() -> Vec<Route> {
         configuration_file::endpoints::post_can_onboard_v2,
         configuration_file::endpoints::get_get_rulesets,
         configuration_file::endpoints::post_get_rulesets_v2,
+        configuration_file::endpoints::post_parse_config,
         configuration_file::endpoints::post_add_rulesets,
         configuration_file::endpoints::post_add_rulesets_v2,
     ]
@@ -261,7 +263,7 @@ rulesets:
             ))
             .header(ContentType::JSON)
             .body(format!(
-                r#"{{ 
+                r#"{{
                 "configuration": "{config}"
             }}"#
             ))
@@ -271,6 +273,92 @@ rulesets:
 
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.into_string().unwrap(), expected);
+    }
+
+    /// Legacy contract: the deprecated v1 route must return `[]` with HTTP 200
+    /// on an unparseable config instead of surfacing a 500. Older IDE clients
+    /// rely on this best-effort behavior.
+    #[test]
+    fn get_rulesets_v1_returns_empty_on_parse_error() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+        let config = encode_base64_string(PARSE_ERROR_CONFIGURATION.to_string());
+
+        let uri = uri!(super::configuration_file::endpoints::get_get_rulesets(
+            PathBuf::from(config)
+        ));
+
+        let response = client.get(uri).dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().unwrap(), "[]");
+    }
+
+    /// Legacy contract: the deprecated v2 route must return `[]` with HTTP 200
+    /// on an unparseable config instead of surfacing a 500. Older IDE clients
+    /// rely on this best-effort behavior.
+    #[test]
+    fn get_rulesets_v2_returns_empty_on_parse_error() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+        let config = encode_base64_string(PARSE_ERROR_CONFIGURATION.to_string());
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_get_rulesets_v2
+            ))
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{
+                "configuration": "{config}"
+            }}"#
+            ))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().unwrap(), "[]");
+    }
+
+    #[test]
+    fn parse_config_returns_sast_rulesets() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": NORMAL_CONFIGURATION,
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        let expected = r#"{"sast":{"rulesets":["java-1","java-security"]}}"#;
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().unwrap(), expected);
+    }
+
+    #[test]
+    fn parse_config_returns_error_on_parse_failure() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": PARSE_ERROR_CONFIGURATION,
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        assert_eq!(response.status(), Status::InternalServerError);
+        assert!(response.into_string().contains("Error parsing yaml file"));
     }
 
     #[test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -357,7 +357,7 @@ rulesets:
             )
             .dispatch();
 
-        assert_eq!(response.status(), Status::InternalServerError);
+        assert_eq!(response.status(), Status::BadRequest);
         assert!(response.into_string().contains("Error parsing yaml file"));
     }
 


### PR DESCRIPTION
## What problem are you trying to solve?
The IDEs current call `get_rulesets` but this doesn't scale to the new unified format file where we may need to extract out multiple fields from the config file. Instead we will add a new config/parse API that returns a JSON object with per-product top level keys.

## What is your solution?
* Create a new route to parse the config file that returns a structured output so we can add more products to output
* Make APIs aware of Base64 encoded String vs raw YAML String since new API does not encode the payload

## Alternatives considered

## What the reviewer should know
Starting to implement https://docs.google.com/document/d/1PpSy12I1xMGmxOOA3qAdw05DFveUUqmETK7pnTjpnS0/