### PR TITLE
Create a new IDE specific secret scanning route

### DIFF
--- a/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-git-hook.rs
@@ -421,6 +421,7 @@ fn main() -> Result<()> {
         use_debug,
         ignore_generated_files,
         timeout,
+        ..Default::default()
     };
 
     if should_verify_checksum {

--- a/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer-test-ruleset.rs
@@ -28,6 +28,7 @@ fn test_rule(runtime: &mut JsRuntime, rule: &Rule, test: &RuleTest) -> Result<St
         use_debug: true,
         ignore_generated_files: false,
         timeout: None,
+        ..Default::default()
     };
     let rules = vec![rule_internal];
     let analyze_result = analyze_with(

--- a/crates/bins/src/bin/datadog-static-analyzer.rs
+++ b/crates/bins/src/bin/datadog-static-analyzer.rs
@@ -458,6 +458,7 @@ fn main() -> Result<()> {
         use_debug,
         ignore_generated_files,
         timeout,
+        ..Default::default()
     };
 
     // check if we do a diff-aware scan

--- a/crates/bins/src/bin/datadog_static_analyzer_server/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/endpoints.rs
@@ -177,17 +177,18 @@ fn process_secret_scan_request(
         return Err("Invalid filename: path traversal detected".to_string());
     }
 
+    let parse_rules = |raw: &[Box<serde_json::value::RawValue>]| {
+        raw.iter()
+            .map(|r| serde_json::from_str(r.get()))
+            .collect::<Result<Vec<secrets::model::secret_rule::SecretRule>, _>>()
+            .map_err(|e| format!("Failed to parse rules: {}", e))
+    };
+
     // Get scanner + parsed rules (from cache or fresh build)
     let (scanner, rules) = if let Some(cache) = cache {
-        cache.get_or_build(&request.rules, request.use_debug)?
+        cache.get_or_build_with(&request.rules, request.use_debug, parse_rules)?
     } else {
-        // No cache - build from scratch
-        let rules: Vec<secrets::model::secret_rule::SecretRule> = request
-            .rules
-            .iter()
-            .map(|r| serde_json::from_str(r.get()))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to parse rules: {}", e))?;
+        let rules = parse_rules(&request.rules)?;
         let scanner = secrets::scanner::build_sds_scanner(&rules, request.use_debug)?;
         (std::sync::Arc::new(scanner), std::sync::Arc::new(rules))
     };

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 mod configuration_file;
+mod secrets;
 use rocket::Route;
 
 pub fn ide_routes() -> Vec<Route> {
@@ -12,6 +13,7 @@ pub fn ide_routes() -> Vec<Route> {
         configuration_file::endpoints::post_get_rulesets_v2,
         configuration_file::endpoints::post_add_rulesets,
         configuration_file::endpoints::post_add_rulesets_v2,
+        secrets::endpoints::post_scan_secrets,
     ]
 }
 
@@ -315,7 +317,7 @@ rulesets:
             ))
             .header(ContentType::JSON)
             .body(format!(
-                r#"{{ 
+                r#"{{
                 "rulesets": ["ruleset1", "ruleset2"],
                 "configuration": "{config}",
                 "encoded": false

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/requests.http
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/requests.http
@@ -1,4 +1,5 @@
-@host = http://localhost:49159
+@host = http://localhost:7777
+
 @configuration = c2NoZW1hLXZlcnNpb246IHYxCnJ1bGVzZXRzOgotIGphdmEtMQotIGphdmEtc2VjdXJpdHk=
 # schema-version: v1
 # rulesets:
@@ -10,7 +11,6 @@
 # rulesets:
 # - java-1
 # - java-security
-
 
 ### version
 GET {{host}}/version HTTP/1.1
@@ -143,6 +143,21 @@ Content-Type: application/json
 }
 
 
+### parse-config legacy
+POST {{host}}/ide/v2/config/parse HTTP/1.1
+Content-Type: application/json
+
+{
+  "configuration": "schema-version: v1\nruleaaasets:\n  - java-security\n  - java-1:\n    only:\n      - domains/project1"
+}
+
+### parse-config v1
+POST {{host}}/ide/v2/config/parse HTTP/1.1
+Content-Type: application/json
+
+{
+  "configuration": "schema-version: v1.0\nsast:\n  ruleset-configs:\n    java-1:\n      only-paths:\n        - domains/project1"
+}
 
 
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/requests.http
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/requests.http
@@ -1,5 +1,4 @@
-@host = http://localhost:7777
-
+@host = http://localhost:49159
 @configuration = c2NoZW1hLXZlcnNpb246IHYxCnJ1bGVzZXRzOgotIGphdmEtMQotIGphdmEtc2VjdXJpdHk=
 # schema-version: v1
 # rulesets:
@@ -11,6 +10,7 @@
 # rulesets:
 # - java-1
 # - java-security
+
 
 ### version
 GET {{host}}/version HTTP/1.1
@@ -142,7 +142,6 @@ Content-Type: application/json
   "encoded": false
 }
 
-
 ### parse-config legacy
 POST {{host}}/ide/v2/config/parse HTTP/1.1
 Content-Type: application/json
@@ -158,6 +157,3 @@ Content-Type: application/json
 {
   "configuration": "schema-version: v1.0\nsast:\n  ruleset-configs:\n    java-1:\n      only-paths:\n        - domains/project1"
 }
-
-
-

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/endpoints.rs
@@ -1,0 +1,76 @@
+use super::models::{ScanSecretsRequest, ScanSecretsResponse};
+use crate::SECRET_SCANNER_CACHE;
+use cli::model::datadog_api::SecretRuleApiType;
+use common::analysis_options::AnalysisOptions;
+use rocket::serde::json::{json, Json, Value};
+use secrets::model::secret_result::SecretResult;
+use secrets::model::secret_rule::SecretRule;
+use tracing::instrument;
+
+/// Scans source code for secrets from an IDE.
+///
+/// Validation is disabled for IDE requests so scans do not reach out to external
+/// services while a user is editing a file.
+#[instrument(skip(request))]
+#[rocket::post("/v1/secrets/scan", format = "application/json", data = "<request>")]
+pub async fn post_scan_secrets(request: Json<ScanSecretsRequest>) -> Value {
+    rocket::tokio::task::spawn_blocking(move || {
+        let request = request.into_inner();
+        let (rule_responses, errors) = match scan(request) {
+            Ok(r) => (r, vec![]),
+            Err(e) => (vec![], vec![e]),
+        };
+        json!(ScanSecretsResponse {
+            rule_responses,
+            errors,
+        })
+    })
+    .await
+    .unwrap_or_else(|e| {
+        json!(ScanSecretsResponse {
+            rule_responses: vec![],
+            errors: vec![format!("Internal error: {e}")],
+        })
+    })
+}
+
+fn scan(request: ScanSecretsRequest) -> Result<Vec<SecretResult>, String> {
+    let cache = SECRET_SCANNER_CACHE
+        .get()
+        .ok_or_else(|| "Secret scanner cache not initialized".to_string())?;
+
+    let (scanner, rules) = cache.get_or_build_with(&request.rules, request.use_debug, |raw| {
+        raw.iter()
+            .map(|r| {
+                let api_rule: SecretRuleApiType = serde_json::from_str(r.get())
+                    .map_err(|e| format!("Failed to parse secret rule: {e}"))?;
+                SecretRule::try_from(api_rule)
+                    .map_err(|e| format!("Failed to convert secret rule: {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()
+    })?;
+
+    let options = AnalysisOptions {
+        use_debug: request.use_debug,
+        disable_validation: true,
+        ..Default::default()
+    };
+
+    let results = secrets::scanner::find_secrets(
+        &scanner,
+        &rules,
+        &request.filename,
+        &request.code,
+        &options,
+    );
+
+    let results = results
+        .into_iter()
+        .filter_map(|mut r| {
+            r.matches.retain(|m| !m.is_suppressed);
+            (!r.matches.is_empty()).then_some(r)
+        })
+        .collect();
+
+    Ok(results)
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/endpoints.rs
@@ -37,7 +37,7 @@ pub async fn post_scan_secrets(request: Json<ScanSecretsRequest>) -> Value {
 fn scan(request: ScanSecretsRequest) -> Result<Vec<SecretResult>, String> {
     let cache = SECRET_SCANNER_CACHE
         .get()
-        .ok_or_else(|| "Secret scanner cache not initialized".to_string())?;
+        .expect("should have been initialized");
 
     let (scanner, rules) = cache.get_or_build_with(&request.rules, request.use_debug, |raw| {
         raw.iter()

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/mod.rs
@@ -1,0 +1,148 @@
+pub mod endpoints;
+mod models;
+
+#[cfg(test)]
+mod tests {
+    use crate::datadog_static_analyzer_server::ide::ide_routes;
+    use crate::datadog_static_analyzer_server::secret_scanner_cache::SecretScannerCache;
+    use crate::SECRET_SCANNER_CACHE;
+    use rocket::{
+        http::{ContentType, Status},
+        local::blocking::Client,
+        uri,
+    };
+    use serde_json::Value as JsonValue;
+
+    fn dispatch_scan(body: String) -> JsonValue {
+        SECRET_SCANNER_CACHE.get_or_init(SecretScannerCache::new);
+        let rocket = rocket::build().mount("/", ide_routes());
+        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let response = client
+            .post(uri!(super::endpoints::post_scan_secrets))
+            .header(ContentType::JSON)
+            .body(body)
+            .dispatch();
+        assert_eq!(response.status(), Status::Ok);
+        serde_json::from_str(&response.into_string().unwrap()).expect("valid JSON")
+    }
+
+    fn foo_bar_rule_json() -> &'static str {
+        r#"{
+            "id": "test-rule",
+            "attributes": {
+                "name": "Test Rule",
+                "description": "A test rule",
+                "pattern": "FOO(BAR|BAZ)",
+                "sds_id": "sds-123",
+                "priority": "medium"
+            }
+        }"#
+    }
+
+    fn scan_body(rule_json: &str) -> String {
+        format!(
+            r#"{{ "filename": "myfile", "code": "FOO\nFOOBAR\nFOOBAZ\nCAT", "rules": [{rule_json}] }}"#
+        )
+    }
+
+    /// End-to-end wiring: request deserializes, the API-type parser closure runs, and the
+    /// response serializes with `rule_id` / `filename` carried through.
+    #[test]
+    fn scan_secrets_happy_path() {
+        let response = dispatch_scan(scan_body(foo_bar_rule_json()));
+
+        assert!(response["errors"].as_array().unwrap().is_empty());
+        let rule_responses = response["rule_responses"].as_array().unwrap();
+        assert_eq!(rule_responses.len(), 1);
+        assert_eq!(rule_responses[0]["rule_id"], "test-rule");
+        assert_eq!(rule_responses[0]["filename"], "myfile");
+    }
+
+    /// Covers our `"Failed to parse secret rule"` wrapping on the `SecretRuleApiType`
+    /// deserialization branch.
+    #[test]
+    fn scan_secrets_reports_malformed_rule_json() {
+        let response = dispatch_scan(scan_body(r#"{"id": "x"}"#));
+
+        let errors = response["errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0]
+                .as_str()
+                .unwrap()
+                .contains("Failed to parse secret rule"),
+            "unexpected error: {}",
+            errors[0]
+        );
+    }
+
+    /// Covers our `"Failed to convert secret rule"` wrapping on the `TryFrom` branch —
+    /// proves the API-type → `SecretRule` conversion is actually invoked.
+    #[test]
+    fn scan_secrets_reports_invalid_priority() {
+        let rule = r#"{
+            "id": "bad-priority",
+            "attributes": {
+                "name": "x",
+                "description": "x",
+                "pattern": "FOO",
+                "sds_id": "sds-x",
+                "priority": "not-a-priority"
+            }
+        }"#;
+        let response = dispatch_scan(scan_body(rule));
+
+        let errors = response["errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0]
+                .as_str()
+                .unwrap()
+                .contains("Failed to convert secret rule"),
+            "unexpected error: {}",
+            errors[0]
+        );
+    }
+
+    /// Covers the `retain(|m| !m.is_suppressed)` in our response filter: suppressed matches
+    /// must not leak into the response, but the surrounding `SecretResult` still comes back
+    /// when at least one match survives.
+    #[test]
+    fn scan_secrets_strips_suppressed_matches_from_result() {
+        // Line 1: FOOBAR           (match, not suppressed)
+        // Line 2: #no-dd-secrets
+        // Line 3: FOOBAZ           (match, suppressed by directive on line 2)
+        let body = format!(
+            r##"{{ "filename": "myfile", "code": "FOOBAR\n#no-dd-secrets\nFOOBAZ", "rules": [{}] }}"##,
+            foo_bar_rule_json()
+        );
+        let response = dispatch_scan(body);
+
+        let rule_responses = response["rule_responses"].as_array().unwrap();
+        assert_eq!(rule_responses.len(), 1);
+        let matches = rule_responses[0]["matches"].as_array().unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0]["is_suppressed"], false,
+            "filter should have removed any match with is_suppressed=true"
+        );
+    }
+
+    /// Covers the `filter_map` in our response filter: a `SecretResult` whose matches are
+    /// all suppressed must be dropped from the response entirely.
+    #[test]
+    fn scan_secrets_drops_result_when_all_matches_suppressed() {
+        // Directive on line 1 suppresses line 2, which holds the only match.
+        let body = format!(
+            r##"{{ "filename": "myfile", "code": "#no-dd-secrets\nFOOBAR", "rules": [{}] }}"##,
+            foo_bar_rule_json()
+        );
+        let response = dispatch_scan(body);
+
+        assert!(response["errors"].as_array().unwrap().is_empty());
+        assert!(
+            response["rule_responses"].as_array().unwrap().is_empty(),
+            "result with no surviving matches should be dropped"
+        );
+    }
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/secrets/models.rs
@@ -1,0 +1,17 @@
+use secrets::model::secret_result::SecretResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScanSecretsRequest {
+    pub filename: String,
+    pub code: String,
+    pub rules: Vec<Box<serde_json::value::RawValue>>,
+    #[serde(default)]
+    pub use_debug: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScanSecretsResponse {
+    pub rule_responses: Vec<SecretResult>,
+    pub errors: Vec<String>,
+}

--- a/crates/bins/src/bin/datadog_static_analyzer_server/secret_scanner_cache.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/secret_scanner_cache.rs
@@ -34,11 +34,18 @@ impl SecretScannerCache {
     ///
     /// The expensive work (rule deserialization + scanner building) happens outside
     /// any lock to avoid blocking concurrent readers.
-    pub fn get_or_build(
+    /// Callers supply the parser used on cache miss. The hash key is the raw JSON bytes,
+    /// so callers that feed the same raw rules share the same cache entry regardless of
+    /// which parser they use.
+    pub fn get_or_build_with<F>(
         &self,
         raw_rules: &[Box<serde_json::value::RawValue>],
         use_debug: bool,
-    ) -> Result<(Arc<Scanner>, Arc<Vec<SecretRule>>), String> {
+        parse: F,
+    ) -> Result<(Arc<Scanner>, Arc<Vec<SecretRule>>), String>
+    where
+        F: FnOnce(&[Box<serde_json::value::RawValue>]) -> Result<Vec<SecretRule>, String>,
+    {
         let hash = Self::compute_rules_hash(raw_rules);
 
         // Fast path: read lock only (the common case in IDE usage)
@@ -52,11 +59,7 @@ impl SecretScannerCache {
         }
 
         // Slow path: cache miss - build scanner WITHOUT holding any lock
-        let rules: Vec<SecretRule> = raw_rules
-            .iter()
-            .map(|r| serde_json::from_str(r.get()))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to parse rules: {}", e))?;
+        let rules = parse(raw_rules)?;
         let scanner = build_sds_scanner(&rules, use_debug)?;
         let scanner = Arc::new(scanner);
         let rules = Arc::new(rules);
@@ -100,18 +103,29 @@ mod tests {
         )]
     }
 
+    fn parse_direct(raw: &[Box<serde_json::value::RawValue>]) -> Result<Vec<SecretRule>, String> {
+        raw.iter()
+            .map(|r| serde_json::from_str(r.get()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to parse rules: {}", e))
+    }
+
     #[test]
     fn test_cache_hit() {
         let cache = SecretScannerCache::new();
         let rules = sample_rules_json();
 
         // First call: cache miss, builds scanner
-        let (scanner1, parsed_rules1) = cache.get_or_build(&rules, false).unwrap();
+        let (scanner1, parsed_rules1) = cache
+            .get_or_build_with(&rules, false, parse_direct)
+            .unwrap();
         assert_eq!(parsed_rules1.len(), 1);
         assert_eq!(parsed_rules1[0].id, "test-rule");
 
         // Second call with same rules: cache hit
-        let (scanner2, parsed_rules2) = cache.get_or_build(&rules, false).unwrap();
+        let (scanner2, parsed_rules2) = cache
+            .get_or_build_with(&rules, false, parse_direct)
+            .unwrap();
         assert!(Arc::ptr_eq(&scanner1, &scanner2));
         assert!(Arc::ptr_eq(&parsed_rules1, &parsed_rules2));
     }
@@ -121,14 +135,18 @@ mod tests {
         let cache = SecretScannerCache::new();
         let rules1 = sample_rules_json();
 
-        let (scanner1, _) = cache.get_or_build(&rules1, false).unwrap();
+        let (scanner1, _) = cache
+            .get_or_build_with(&rules1, false, parse_direct)
+            .unwrap();
 
         // Different rules should cause a cache miss
         let rules2 = vec![raw(
             r#"{"id":"other-rule","sds_id":"sds-456","name":"Other Rule","description":"Another test rule","pattern":"SECRET_[A-Z]+","priority":"high","default_included_keywords":[],"default_excluded_keywords":[],"look_ahead_character_count":30,"validators":[],"pattern_capture_groups":[]}"#,
         )];
 
-        let (scanner2, parsed_rules2) = cache.get_or_build(&rules2, false).unwrap();
+        let (scanner2, parsed_rules2) = cache
+            .get_or_build_with(&rules2, false, parse_direct)
+            .unwrap();
         assert!(!Arc::ptr_eq(&scanner1, &scanner2));
         assert_eq!(parsed_rules2[0].id, "other-rule");
     }

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -323,10 +323,10 @@ impl TryFrom<SecretRuleApiMatchValidation> for SecretRuleMatchValidation {
             }
             SecretRuleApiMatchValidation::CUSTOM_HTTP_STRING => Ok(
                 SecretRuleMatchValidation::CustomHttp(SecretRuleMatchValidationHttp {
-                    endpoint: value.endpoint.expect("no endpoint"),
+                    endpoint: value.endpoint.ok_or("missing endpoint")?,
                     hosts: value.hosts.unwrap_or_default(),
                     request_headers: value.request_headers.unwrap_or_default(),
-                    http_method: value.http_method.expect("missing http method").into(),
+                    http_method: value.http_method.ok_or("missing http method")?.into(),
                     timeout_seconds: value.timeout_seconds,
                     valid_http_status_code: value
                         .valid_http_status_code

--- a/crates/common/src/analysis_options.rs
+++ b/crates/common/src/analysis_options.rs
@@ -8,6 +8,7 @@ pub struct AnalysisOptions {
     pub log_output: bool,
     pub use_debug: bool,
     pub ignore_generated_files: bool,
+    pub disable_validation: bool,
     pub timeout: Option<Duration>,
 }
 
@@ -17,6 +18,7 @@ impl Default for AnalysisOptions {
             log_output: false,
             use_debug: false,
             ignore_generated_files: true,
+            disable_validation: false,
             timeout: None,
         }
     }

--- a/crates/secrets/src/model/secret_rule.rs
+++ b/crates/secrets/src/model/secret_rule.rs
@@ -144,7 +144,10 @@ impl TryFrom<&SecretRuleMatchValidation> for MatchValidationType {
                     request_headers: custom_http.request_headers.clone(),
                     valid_http_status_code: valid_ports,
                     invalid_http_status_code: invalid_ports,
-                    timeout_seconds: custom_http.timeout_seconds.unwrap() as u32,
+                    timeout_seconds: custom_http
+                        .timeout_seconds
+                        .ok_or("missing timeout_seconds")?
+                        as u32,
                 }))
             }
             SecretRuleMatchValidation::CustomHttpV2(custom_http_v2) => {

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -256,6 +256,40 @@ mod tests {
     }
 
     #[test]
+    fn test_find_secrets_disable_validation() {
+        let rules: Vec<SecretRule> = vec![SecretRule {
+            id: "secret_rule".to_string(),
+            sds_id: "sds_id".to_string(),
+            name: "detect secrets".to_string(),
+            description: "super secret!".to_string(),
+            pattern: "FOO(BAR|BAZ)".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+        }];
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+        let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";
+
+        let options = AnalysisOptions {
+            disable_validation: true,
+            ..Default::default()
+        };
+        let matches = find_secrets(&scanner, rules.as_slice(), "myfile", text, &options);
+
+        assert_eq!(matches.len(), 1);
+        let result_matches = &matches.first().unwrap().matches;
+        assert_eq!(result_matches.len(), 2);
+        for m in result_matches {
+            assert_eq!(m.validation_status, SecretValidationStatus::NotAvailable);
+        }
+    }
+
+    #[test]
     fn test_find_secrets_all_ignored() {
         let rules: Vec<SecretRule> = vec![SecretRule {
             id: "secret_rule".to_string(),

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -64,7 +64,9 @@ pub fn find_secrets(
         return vec![];
     }
 
-    scanner.validate_matches(&mut matches);
+    if !options.disable_validation {
+        scanner.validate_matches(&mut matches);
+    }
 
     matches
         .iter()

--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -1313,6 +1313,7 @@ function visit(node, filename, code) {
             use_debug: false,
             ignore_generated_files: false,
             timeout: None,
+            ..Default::default()
         };
 
         let local_config: file_v1::ConfigFile = parse_any_schema_yaml(

--- a/crates/static-analysis-server/src/request.rs
+++ b/crates/static-analysis-server/src/request.rs
@@ -109,6 +109,7 @@ pub fn process_analysis_request<T: Borrow<RuleInternal>>(
                 .unwrap_or(false),
             ignore_generated_files: false,
             timeout,
+            ..Default::default()
         },
     );
 


### PR DESCRIPTION
## What problem are you trying to solve?

IDE-5981

Differences between the current route and new one:
* New route passes the JSON:API based format for the rule so the IDE is not in the job of translation. This allows the K9 team to evolve the rule inputs without involving the IDE team
* New route disables the secret validation inside of the binary instead of having the IDE drop the fields on the floor before passing the rules to the binary
* Some logic was removed like # of rules and file name validation. Both seemed out of the realm for the IDE route to enforce

Secret scanner cache changed to work with both routes by taking the JSON->SecretReule logic as a lambda.

