### PR TITLE
Pre-filter rules by required `#eq?` literals

### DIFF
--- a/crates/static-analysis-kernel/src/analysis/analyze.rs
+++ b/crates/static-analysis-kernel/src/analysis/analyze.rs
@@ -196,6 +196,25 @@ where
     rules
         .into_iter()
         .filter(|rule| rule_config.rule_is_enabled(&rule.borrow().name))
+        .filter(|rule| {
+            // Content pre-filter: when the rule's tree-sitter query has
+            // `#eq?` predicates whose required literals are absent from the
+            // file's text, no match can possibly satisfy those predicates.
+            // We can skip running the rule entirely — saving the tree-sitter
+            // query traversal, the JS context setup, and the JS dispatch.
+            //
+            // Extraction is conservative (see
+            // `crate::model::rule::extract_required_literals`), so rules
+            // with `[]` alternatives, `?` optional, or `*`/`+` repeats yield
+            // no literals here and run unchanged — preserving correctness.
+            let r = rule.borrow();
+            if r.required_literals.is_empty() {
+                return true;
+            }
+            r.required_literals
+                .iter()
+                .all(|lit| code.contains(lit.as_str()))
+        })
         .map(|rule| {
             let rule = rule.borrow();
             if analysis_option.use_debug {
@@ -362,6 +381,7 @@ function visit(captures) {
                 language,
                 code: rule_code.to_string(),
                 tree_sitter_query,
+                required_literals: Vec::new(),
             };
 
             let results = analyze_with(
@@ -469,6 +489,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -525,6 +546,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code1.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
         let rule2 = RuleInternal {
             name: "myrule2".to_string(),
@@ -535,6 +557,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code2.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -632,6 +655,7 @@ for(var i = 0; i <= 10; i--){}
             language: Language::JavaScript,
             code: rule_code1.to_string(),
             tree_sitter_query: get_query(tree_sitter_query, &Language::JavaScript).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -683,6 +707,7 @@ def foo():
             language: Language::Python,
             code: rule_code1.to_string(),
             tree_sitter_query: get_query(tree_sitter_query, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -730,6 +755,7 @@ def foo(arg1):
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -788,6 +814,7 @@ def foo2(arg1):
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -855,6 +882,7 @@ function visit(captures) {
             language: Language::Java,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(ts_query, &Language::Java).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -1024,6 +1052,7 @@ function visit(node, filename, code) {
             language: Language::Go,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(query, &Language::Go).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions {
@@ -1180,6 +1209,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
         let rule2 = RuleInternal {
             name: "rs/rule2".to_string(),
@@ -1190,6 +1220,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let local_config: file_v1::ConfigFile = parse_any_schema_yaml(
@@ -1255,6 +1286,7 @@ function visit(query, filename, code) {
             language: Language::Starlark,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Starlark).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions::default();
@@ -1301,6 +1333,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
         let rule2 = RuleInternal {
             name: "rs/rule2".to_string(),
@@ -1311,6 +1344,7 @@ function visit(node, filename, code) {
             language: Language::Python,
             code: rule_code.to_string(),
             tree_sitter_query: get_query(QUERY_CODE, &Language::Python).unwrap(),
+            required_literals: Vec::new(),
         };
 
         let analysis_options = AnalysisOptions {

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -1685,6 +1685,7 @@ function visit(captures) {
             language: Language::JavaScript,
             code: rule_code.to_string(),
             tree_sitter_query: ts_query,
+            required_literals: Vec::new(),
         };
         let err = rt.execute_rule(
             &source_text,

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/test_utils.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/test_utils.rs
@@ -368,6 +368,7 @@ pub(crate) fn shorthand_execute_rule(
         language,
         code: js_code.to_string(),
         tree_sitter_query: query,
+        required_literals: Vec::new(),
     };
 
     runtime.execute_rule(&source_text, &tree, &filename, &rule, &arguments, timeout)

--- a/crates/static-analysis-kernel/src/model/rule.rs
+++ b/crates/static-analysis-kernel/src/model/rule.rs
@@ -12,6 +12,157 @@ use sha2::Digest;
 use std::fmt;
 use std::path::Path;
 
+/// Conservatively extract substrings that **must** appear in any source file
+/// that could match `query_source`. The result is used as a cheap content
+/// pre-filter: if a file's text contains none of these literals, we can skip
+/// running the rule entirely without affecting correctness.
+///
+/// We only extract literals from `(#eq? @capture "literal")` predicates that
+/// appear at the *outer* level of the query — i.e. not inside any optional
+/// (`?`), repeated (`*`/`+`), or alternative (`[ ... ]`) construct. Those
+/// constructs make a capture (and therefore the predicate) optional, so the
+/// literal isn't strictly required for the rule to fire. When in doubt, we
+/// return an empty `Vec`, which preserves historical behaviour exactly.
+///
+/// Why this is safe: `#eq?` is a tree-sitter predicate that filters matches
+/// where the captured node's text is byte-for-byte equal to the literal.
+/// If the file does not contain that literal anywhere, no node's text could
+/// possibly equal it, so no match could pass the predicate.
+///
+/// References:
+/// - tree-sitter query syntax: https://tree-sitter.github.io/tree-sitter/using-parsers/queries/1-syntax.html
+/// - the `#eq?` predicate is built-in and string-literal-only
+pub fn extract_required_literals(query_source: &str) -> Vec<String> {
+    // 1. Strip line comments (`;` to end of line) so quantifier / bracket
+    //    detection ignores commentary.
+    let mut clean = String::with_capacity(query_source.len());
+    for line in query_source.lines() {
+        let body = match line.find(';') {
+            Some(idx) => &line[..idx],
+            None => line,
+        };
+        clean.push_str(body);
+        clean.push('\n');
+    }
+
+    // 2. Bail out if the query uses any construct that could make a capture
+    //    optional. We're intentionally conservative; missing a possible
+    //    pre-filter is fine (we just don't optimise that rule), but a false
+    //    positive (skipping a file we should have scanned) would silently
+    //    lose findings.
+    //
+    //    The veto characters are:
+    //    - `[` `]`  : alternative groups
+    //    - `?` `*` `+` when used as a *quantifier*. These quantifiers always
+    //      attach to a node pattern, so they immediately follow `)`, `_`,
+    //      or `]` (possibly across whitespace). A `?` that follows a word
+    //      character like `q` in `#eq?` or `#match?` is part of the
+    //      predicate name and must be ignored.
+    let bytes = clean.as_bytes();
+    let mut in_string = false;
+    let mut escape = false;
+    let mut prev_non_ws: u8 = 0;
+    for &b in bytes {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if in_string {
+            match b {
+                b'\\' => escape = true,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match b {
+            b'"' => {
+                in_string = true;
+                prev_non_ws = b;
+            }
+            b'[' | b']' => return Vec::new(),
+            b'?' | b'*' | b'+' => {
+                // Quantifier only when attached to a closing pattern token.
+                if matches!(prev_non_ws, b')' | b'_' | b']') {
+                    return Vec::new();
+                }
+                // Otherwise this `?` is part of `#eq?` / `#match?` /
+                // `#any-of?` etc. — not a quantifier. Don't update
+                // `prev_non_ws` because the next token is what matters.
+            }
+            _ => {
+                if !b.is_ascii_whitespace() {
+                    prev_non_ws = b;
+                }
+            }
+        }
+    }
+
+    // 3. Scan for `(#eq? @<cap> "<literal>")` predicates and collect the
+    //    string literals.
+    let mut out: Vec<String> = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(rel) = clean[search_from..].find("#eq?") {
+        let abs = search_from + rel + "#eq?".len();
+        search_from = abs;
+        // Skip whitespace, then expect `@<name>`.
+        let rest = clean[abs..].trim_start();
+        if !rest.starts_with('@') {
+            continue;
+        }
+        // Skip the capture name.
+        let after_at = &rest[1..];
+        let name_end = after_at
+            .find(|c: char| c.is_whitespace() || c == ')' || c == '"')
+            .unwrap_or(after_at.len());
+        let after_name = after_at[name_end..].trim_start();
+        // Expect a string literal.
+        if !after_name.starts_with('"') {
+            continue;
+        }
+        let literal_body = &after_name[1..];
+        // Find the closing quote, honouring `\` escapes.
+        let mut end_idx = None;
+        let mut iter = literal_body.char_indices();
+        while let Some((i, c)) = iter.next() {
+            if c == '\\' {
+                // Skip the next char.
+                let _ = iter.next();
+                continue;
+            }
+            if c == '"' {
+                end_idx = Some(i);
+                break;
+            }
+        }
+        let Some(end) = end_idx else { continue };
+        // We can't easily un-escape into a borrowed slice; do it explicitly.
+        let raw = &literal_body[..end];
+        let mut unescaped = String::with_capacity(raw.len());
+        let mut chars = raw.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                if let Some(next) = chars.next() {
+                    let mapped = match next {
+                        'n' => '\n',
+                        't' => '\t',
+                        'r' => '\r',
+                        other => other,
+                    };
+                    unescaped.push(mapped);
+                }
+            } else {
+                unescaped.push(c);
+            }
+        }
+        // Empty literals don't filter anything out.
+        if !unescaped.is_empty() {
+            out.push(unescaped);
+        }
+    }
+    out
+}
+
 /// In the RuleCategory, we keep unknown. Old rules keep putting
 /// whatever they want as category. As a matter of fact, old rules that
 /// use old values (e.g. DEPLOYMENT) will fail deserialization. We then match
@@ -180,6 +331,17 @@ pub struct RuleInternal {
     pub language: Language,
     pub code: String,
     pub tree_sitter_query: TSQuery,
+    /// Conservatively extracted required substrings from the rule's tree-sitter
+    /// query. If any of these literals is **not** present anywhere in a source
+    /// file's content, the rule cannot possibly match that file — we can skip
+    /// running the rule entirely (no tree-sitter query traversal, no JS
+    /// dispatch).
+    ///
+    /// Extraction is intentionally conservative: see
+    /// [`extract_required_literals`] in this module. Empty means "no
+    /// pre-filter" (i.e. always run the rule, identical to historical
+    /// behaviour).
+    pub required_literals: Vec<String>,
 }
 
 // This error is meant to be used when we try to convert a Rule to a RuleInternal
@@ -268,7 +430,7 @@ impl Rule {
             })
             .transpose()?;
 
-        let tree_sitter_query = String::from_utf8(
+        let tree_sitter_query_source = String::from_utf8(
             general_purpose::STANDARD
                 .decode(
                     self.tree_sitter_query_base64
@@ -277,7 +439,8 @@ impl Rule {
                 )
                 .map_err(|e| RuleInternalError::InvalidBase64(e.to_string()))?,
         )?;
-        let tree_sitter_query = get_query(&tree_sitter_query, &self.language)
+        let required_literals = extract_required_literals(&tree_sitter_query_source);
+        let tree_sitter_query = get_query(&tree_sitter_query_source, &self.language)
             .map_err(|e| RuleInternalError::InvalidTreeSitterQuery(Box::new(e)))?;
 
         Ok(RuleInternal {
@@ -289,6 +452,7 @@ impl Rule {
             language: self.language,
             code,
             tree_sitter_query,
+            required_literals,
         })
     }
 


### PR DESCRIPTION
## Motivation

Found via a `pi-autoresearch` run optimising `datadog-static-analyzer` scan time on the dd-source monorepo (271k files, 63 rules). For most rules, only a tiny fraction of files contain the literal substrings the rule's tree-sitter query requires. Running the full query and JS dispatch on every file is wasted work. This change is the single biggest win from the experiment so far.

## Changes

 - Add `extract_required_literals` to conservatively pull required string literals out of a rule's tree-sitter query. Only `(#eq? @cap "literal")` predicates at the outer level are extracted. Queries containing `[]` alternatives or `?`/`*`/`+` quantifiers that could make a capture optional are vetoed and yield no literals.
 - Add a `required_literals: Vec<String>` field to `RuleInternal`, populated when a `Rule` is converted via `to_rule_internal`.
 - In `analyze_with`, skip running a rule on a file when any of the rule's required literals is absent from the file's text.

When extraction returns an empty `Vec` (the conservative default for any non-trivial query), behaviour is identical to today, so any rule the extractor cannot reason about runs unchanged.

## Testing

Verified end-to-end via the autoresearch iteration that produced this commit, scanning the dd-source monorepo.

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `analysis_s` (best of 3) | 58.69s | 48.59s | **-10.10s, -17.2%** |
| `wall_s` | 80.65s | 70.88s | -9.77s |
| `peak_rss_mb` | 988.6 | 990.8 | +0.2% |
| `total_violations` | 19,245 | 19,245 | identical |
| `unique_sigs` | 19,252 | 19,252 | identical |
| `files_scanned` | 269,379 | 269,379 | identical |

Correctness was verified by the experiment's regression gate, which diffs `(rule_id, uri, line, column)` tuples between the baseline SARIF and the new SARIF. Zero per-file mismatches across files present in both runs.

Local test suite was not run to avoid CPU contention with the still-active autoresearch experiment, will run once the experiment completes. CI will exercise the full test suite.

## Considerations

The extractor is intentionally conservative, so any rule whose query uses optionals, repeats, or alternative groups opts out and runs as before. False negatives in extraction are safe (a rule simply runs unconditionally), false positives would silently lose findings. The conservative quantifier veto is the main correctness guard.

Follow-up extensions to handle `(#any-of? @cap ...)` predicates and simple alternation `(#match? @cap "a|b|c")` regexes are kept out of this PR to keep the surface small.
