### PR TITLE
[SDS]: bump dd-sds version to 51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "dd-sds"
 version = "0.1.2"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=924c77a3036a31b5e36335c31f7daaf0ba90e00f#924c77a3036a31b5e36335c31f7daaf0ba90e00f"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253#51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253"
 dependencies = [
  "ahash",
  "aws-sign-v4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "dd-sds"
 version = "0.1.2"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=5ccd2861b8daca861bc8409999b46710ff9bd910#5ccd2861b8daca861bc8409999b46710ff9bd910"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=924c77a3036a31b5e36335c31f7daaf0ba90e00f#924c77a3036a31b5e36335c31f7daaf0ba90e00f"
 dependencies = [
  "ahash",
  "aws-sign-v4",
@@ -1137,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2020,7 +2020,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2411,7 +2411,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2876,7 +2876,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2913,9 +2913,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3346,7 +3346,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4095,7 +4095,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4910,7 +4910,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,5 +15,5 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "5ccd2861b8daca861bc8409999b46710ff9bd910" }
+dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "924c77a3036a31b5e36335c31f7daaf0ba90e00f" }
 strum = "0.25.0"

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,5 +15,5 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "924c77a3036a31b5e36335c31f7daaf0ba90e00f" }
+dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253" }
 strum = "0.25.0"


### PR DESCRIPTION
This PR bumps the `dd-sds` version from [5ccd2861b8daca861bc8409999b46710ff9bd910](https://github.com/DataDog/dd-sensitive-data-scanner/commits/5ccd2861b8daca861bc8409999b46710ff9bd910) to [51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253](https://github.com/DataDog/dd-sensitive-data-scanner/commits/51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253).

The changes include:
- https://github.com/DataDog/dd-sensitive-data-scanner/pull/354
- https://github.com/DataDog/dd-sensitive-data-scanner/pull/353
- https://github.com/DataDog/dd-sensitive-data-scanner/pull/352
- https://github.com/DataDog/dd-sensitive-data-scanner/pull/355
