### PR TITLE
[K9VULN-14294] Update to tree-sitter 0.25.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,7 +3917,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "streaming-iterator",
  "thiserror 2.0.18",
  "tree-sitter",
  "v8",
@@ -4500,13 +4499,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "6d7b8994f367f16e6fa14b5aebbcb350de5d7cbea82dc5b00ae997dd71680dd2"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax 0.8.10",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ num_cpus = "1.17.0"
 thiserror = "2.0.16"
 tracing = "0.1.40"
 uuid = { version = "1.18.0", features = ["v4"] }
-tree-sitter = "0.24.7"
+tree-sitter = "=0.25.8"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -26,7 +26,6 @@ serde,https://github.com/serde-rs/serde,Apache-2.0,2015 David Tolnay and Serde c
 serde_json,https://github.com/serde-rs/json,Apache-2.0,2015 David Tolnay and Serde contributors
 serde_yaml,https://github.com/dtolnay/serde-yaml,Apache-2.0,2016 David Tolnay
 sha2,https://crates.io/crates/sha2,Apache-2.0,Copyright (c) 2006-2009 Graydon Hoare 2009-2013 Mozilla Foundation 2016 Artyom Pavlov
-streaming-iterator,https://crates.io/crates/streaming-iterator,MIT or Apache-2.0,Copyright (c) 2016 Steven Fackler
 tempfile,https://crates.io/crates/tempfile,Apache-2.0,Copyright (c) 2015 Steven Allen
 terminal-emoji,https://github.com/mainrs/terminal-emoji-rs,MIT,Copyright (c) 2020 SirWindfield
 thiserror,https://github.com/dtolnay/thiserror,MIT,Copyright (c) 2019 David Tolnay

--- a/crates/static-analysis-kernel/Cargo.toml
+++ b/crates/static-analysis-kernel/Cargo.toml
@@ -23,7 +23,6 @@ globset = "0.4.16"
 graphviz-rust = "0.9.6"
 sequence_trie = "0.3.6"
 serde_yaml = "0.9.21"
-streaming-iterator = "0.1.9"
 
 # We're experiencing issues with v8 130.0.8. Until we can resolve this, pin to the last-known-working.
 v8 = "=130.0.7"

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/bridge/query_match.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/bridge/query_match.rs
@@ -124,10 +124,7 @@ const ghi = 'hello' + ' world';
 )
 ";
         let query = TSQuery::try_new(&tree.language(), query).unwrap();
-        let matches = query
-            .cursor()
-            .matches(tree.root_node(), text, None)
-            .collect::<Vec<_>>();
+        let matches = query.cursor().matches(tree.root_node(), text, None);
         assert!(query_match_bridge.is_empty());
         assert!(ts_node_bridge.is_empty());
         query_match_bridge.set_data(scope, matches.clone(), &mut ts_node_bridge);
@@ -150,10 +147,7 @@ const ghi = 'hello' + ' world';
 const alpha = 'bravo';
 ";
         let tree = get_tree(text, &Language::JavaScript).unwrap();
-        let matches = query
-            .cursor()
-            .matches(tree.root_node(), text, None)
-            .collect::<Vec<_>>();
+        let matches = query.cursor().matches(tree.root_node(), text, None);
         query_match_bridge.set_data(scope, matches, &mut ts_node_bridge);
         assert_eq!(get_node_id_at_idx(&query_match_bridge, 0), 3);
         assert_eq!(ts_node_bridge.len(), 4);

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/context/file_tf.rs
@@ -3,7 +3,7 @@
 // Copyright 2024 Datadog, Inc.
 
 use deno_core::v8::{self, HandleScope};
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 use crate::analysis::ddsa_lib::common::{Class, DDSAJsRuntimeError};
 use crate::analysis::ddsa_lib::js;

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/js/ts_node.rs
@@ -106,7 +106,7 @@ mod tests {
     use crate::model::common::Language;
     use deno_core::v8;
     use std::marker::PhantomData;
-    use streaming_iterator::StreamingIterator;
+    use tree_sitter::StreamingIterator;
 
     #[test]
     fn js_properties_canary() {

--- a/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
+++ b/crates/static-analysis-kernel/src/analysis/ddsa_lib/runtime.rs
@@ -159,10 +159,9 @@ impl JsRuntime {
         let ts_query_cursor = Rc::clone(&self.ts_query_cursor);
         let mut ts_qc = ts_query_cursor.borrow_mut();
         let mut query_cursor = rule.tree_sitter_query.with_cursor(&mut ts_qc);
-        let query_matches = query_cursor
-            .matches(source_tree.root_node(), source_text.as_ref(), timeout)
-            .filter(|captures| !captures.is_empty())
-            .collect::<Vec<_>>();
+        let mut query_matches =
+            query_cursor.matches(source_tree.root_node(), source_text.as_ref(), timeout);
+        query_matches.retain(|captures| !captures.is_empty());
 
         let ts_query_time = now.elapsed();
 
@@ -661,9 +660,7 @@ mod tests {
         let filename: Arc<str> = Arc::from("some_filename.js");
 
         let mut curs = ts_query.cursor();
-        let q_matches = curs
-            .matches(tree.root_node(), source_text.as_ref(), None)
-            .collect::<Vec<_>>();
+        let q_matches = curs.matches(tree.root_node(), source_text.as_ref(), None);
         runtime.execute_rule_internal(
             source_text,
             tree,
@@ -697,9 +694,7 @@ mod tests {
 
         let now = Instant::now();
         let mut curs = ts_query.cursor();
-        let q_matches = curs
-            .matches(tree.root_node(), source_text.as_ref(), timeout)
-            .collect::<Vec<_>>();
+        let q_matches = curs.matches(tree.root_node(), source_text.as_ref(), timeout);
         let ts_query_time = now.elapsed();
 
         // It's possible that the TS query took about as long as the timeout itself, and since
@@ -1273,11 +1268,10 @@ function visit(captures) {
             let ts_query = "(identifier) @cap_name";
             let ts_lang = get_tree_sitter_language(&language);
             let ts_query = TSQuery::try_new(&ts_lang, ts_query).unwrap();
-            let captures = ts_query
+            let mut captures = ts_query
                 .cursor()
-                .matches(tree.root_node(), text.as_ref(), None)
-                .filter(|captures| !captures.is_empty())
-                .collect::<Vec<_>>();
+                .matches(tree.root_node(), text.as_ref(), None);
+            captures.retain(|captures| !captures.is_empty());
             let _ = rt.execute_rule_internal(
                 &text,
                 &tree,

--- a/crates/static-analysis-kernel/src/analysis/languages/csharp/using_directives.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/csharp/using_directives.rs
@@ -6,7 +6,7 @@ use crate::analysis::languages::ts_node_text;
 use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language};
 use crate::model::common::Language;
 use std::sync::LazyLock;
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 /// Structured information about a using directive import in a C# source file.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/static-analysis-kernel/src/analysis/languages/go/imports.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/go/imports.rs
@@ -6,7 +6,7 @@ use crate::analysis::languages::ts_node_text;
 use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language};
 use crate::model::common::Language;
 use std::sync::LazyLock;
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PackageImport<'a> {

--- a/crates/static-analysis-kernel/src/analysis/languages/java/imports.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/java/imports.rs
@@ -6,7 +6,7 @@ use crate::analysis::languages::ts_node_text;
 use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language};
 use crate::model::common::Language;
 use std::sync::LazyLock;
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 /// Structured information about an import in a Java source file.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/imports.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/imports.rs
@@ -7,7 +7,7 @@ use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language};
 use crate::model::common::Language;
 use std::borrow::Cow;
 use std::sync::LazyLock;
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 /// JavaScript module representation, which consists of a name and where it's imported from
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/static-analysis-kernel/src/analysis/languages/javascript/imports.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/javascript/imports.rs
@@ -31,20 +31,28 @@ pub(crate) const JS_IMPORTS_QUERY: &str = r#"
   source: (string (string_fragment) @name))
 
 ; import { <name> } from '<imported_from>'
+(import_statement
+  (import_clause
+    (named_imports
+      (import_specifier
+        .
+        name: (identifier) @name
+        .
+      )
+    )
+  )
+  "from"
+  source: (string (string_fragment) @imported_from)
+)
+
 ; import { _ as <name> } from '<imported_from>'
 (import_statement
   (import_clause
     (named_imports
       (import_specifier
         .
-        [
-          name: (identifier) @name
-          name: (
-            (_) @name_except_default
-            "as"
-          )
-        ]
-        .
+        name: (_) @name_except_default
+        "as"
       )
     )
   )

--- a/crates/static-analysis-kernel/src/analysis/languages/python/imports.rs
+++ b/crates/static-analysis-kernel/src/analysis/languages/python/imports.rs
@@ -6,7 +6,7 @@ use crate::analysis::languages::ts_node_text;
 use crate::analysis::tree_sitter::{get_tree, get_tree_sitter_language};
 use crate::model::common::Language;
 use std::sync::LazyLock;
-use streaming_iterator::StreamingIterator;
+use tree_sitter::StreamingIterator;
 
 //
 // Note: Dynamic imports like `__import__(...)` and `importlib.import_module(...)` have not been implemented.

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -744,4 +744,28 @@ SELECT * FROM table WHERE column = 'value';
         assert_eq!(None, superclasses.field_name);
         assert!(query_node.captures.contains_key("classname"));
     }
+
+    #[test]
+    fn ts_query_cursor_matches_timeout() {
+        let timeout = Duration::from_millis(500);
+        let source = "let x = 1234;\n".repeat(2000);
+
+        let tree = get_tree(&source, &Language::JavaScript).unwrap();
+        // (Combinatorial explosion query, which should take longer than the `timeout` duration).
+        let query = get_query("(((_)*) @one (_)* @two)", &Language::JavaScript).unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let num_captured = query
+                .cursor()
+                .matches(tree.root_node(), &source, Some(timeout))
+                .len();
+            tx.send(num_captured).unwrap();
+        });
+
+        let num_captured = rx
+            .recv_timeout(timeout * 2)
+            .expect("query callback should've halted execution");
+        assert!(num_captured > 0);
+    }
 }

--- a/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
+++ b/crates/static-analysis-kernel/src/analysis/tree_sitter.rs
@@ -4,9 +4,9 @@ use common::model::position::Position;
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
-use streaming_iterator::StreamingIterator;
-use tree_sitter::CaptureQuantifier;
+use std::time::{Duration, Instant};
+use tree_sitter::StreamingIterator;
+use tree_sitter::{CaptureQuantifier, QueryCursorOptions, QueryCursorState};
 
 pub fn get_tree_sitter_language(language: &Language) -> tree_sitter::Language {
     extern "C" {
@@ -171,23 +171,32 @@ enum MaybeOwnedMut<'a, T> {
 }
 
 impl<'a, 'tree> TSQueryCursor<'a, 'tree> {
-    /// Iterate over all the tree-sitter query matches in the order that they were found.
+    /// Returns all of the tree-sitter query matches in the order that they were found.
     ///
     /// ***Note:*** Because multiple patterns can match the same set of nodes, one match may contain captures
     /// that appear before _(i.e. the source text location)_ some of the captures from a previous match.
     pub fn matches(
-        &'a mut self,
+        &mut self,
         node: tree_sitter::Node<'tree>,
         text: &'tree str,
         timeout: Option<Duration>,
-    ) -> impl Iterator<Item = QueryMatch<tree_sitter::Node<'tree>>> + 'a {
+    ) -> Vec<QueryMatch<tree_sitter::Node<'tree>>> {
         let cursor = match &mut self.cursor {
             MaybeOwnedMut::Borrowed(cursor) => cursor,
             MaybeOwnedMut::Owned(cursor) => cursor,
         };
-        cursor.set_timeout_micros(timeout.map(|t| t.as_micros()).unwrap_or_default() as u64);
-        let matches = cursor.matches(self.query, node, text.as_bytes());
-        matches.map_deref(|q_match| {
+        let deadline = timeout.and_then(|t| Instant::now().checked_add(t));
+        let mut on_progress = move |_: &QueryCursorState| match deadline {
+            Some(d) => Instant::now() >= d,
+            None => false,
+        };
+        let mut options = QueryCursorOptions::new();
+        if deadline.is_some() {
+            options = options.progress_callback(&mut on_progress);
+        }
+
+        let m = cursor.matches_with_options(self.query, node, text.as_bytes(), options);
+        m.map_deref(|q_match| {
             for capture in q_match.captures {
                 self.captures_scratch
                     .entry(capture.index)
@@ -216,6 +225,7 @@ impl<'a, 'tree> TSQueryCursor<'a, 'tree> {
                 .map(|(_, query_capture)| query_capture)
                 .collect::<Vec<_>>()
         })
+        .collect::<Vec<_>>()
     }
 }
 


### PR DESCRIPTION
## What problem are you trying to solve?
We're using tree-sitter 0.24.7 (from January 2025). The latest version is 0.26.8 (March 2026), and it contains numerous bug fixes.

## What is your solution?

Update to tree-sitter 0.25.8
* 0.25.0 introduced a breaking change removing [`timeout_micros`](https://docs.rs/tree-sitter/0.24.7/tree_sitter/struct.QueryCursor.html#method.timeout_micros) from the `QueryCursor` API. This PR thus re-implements the same functionality using the new callback-based cancellation API.

**Why not 0.26.8**?

There was a non-trivial behavior change from 0.25.8 to 0.25.9 due to a bug in the query engine that was fixed with https://github.com/tree-sitter/tree-sitter/pull/4532. A good amount of our default rules are currently affected by this, and so going from 0.25.8 -> 0.25.9 introduces a regression in true positives/true negatives. It'll require its own migration.

## CI Failure
The "[check_regressions (golang, go)](https://github.com/DataDog/datadog-static-analyzer/actions/runs/25675180943/job/75456893247)" CI failure is expected. 0.25.0 fixes a false negative present in 0.24.7 with the [go-best-practices/superfluous-else](https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/go-best-practices/superfluous-else/) rule. This is due to a bug in how 0.24.7 dealt with alternations and anchors, which was fixed by https://github.com/tree-sitter/tree-sitter/pull/4067. This didn't cause any real regressions (i.e. no false positives or false negatives) within our default rulesets, though it is important to note it might affect a custom rule. I'll add a disclaimer in the release notes.

## Notes
* 3f3de56b3545fbe485fc9233130a698f6632f52e adapts a unit test that relied on the previous, buggy behavior for alternations/anchors referenced in "CI Failure" above.
