### PR TITLE
Update tree-sitter-dart

### DIFF
--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -259,7 +259,7 @@ fn main() {
             compilation_unit: "tree-sitter-dart".to_string(),
             repository: "https://github.com/UserNobody14/tree-sitter-dart".to_string(),
             build_dir: "src".into(),
-            commit_hash: "0fc19c3a57b1109802af41d2b8f60d8835c5da3a".to_string(),
+            commit_hash: "02e9bb191c7cb6c73cbd9e09a5d089e4496f9cff".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -257,11 +257,9 @@ fn main() {
         TreeSitterProject {
             name: "tree-sitter-dart".to_string(),
             compilation_unit: "tree-sitter-dart".to_string(),
-            // Fork of https://github.com/UserNobody14/tree-sitter-dart
-            repository: "https://github.com/muh-nee/tree-sitter-dart".to_string(),
+            repository: "https://github.com/UserNobody14/tree-sitter-dart".to_string(),
             build_dir: "src".into(),
-            // ABI 14 version of upstream 0fc19c3a57b1109802af41d2b8f60d8835c5da3a
-            commit_hash: "dfad3d21e451c9406bee9c44e4ffcd6d7fb44bb7".to_string(),
+            commit_hash: "0fc19c3a57b1109802af41d2b8f60d8835c5da3a".to_string(),
             files: vec!["parser.c".to_string(), "scanner.c".to_string()],
             cpp: false,
         },


### PR DESCRIPTION
* Updates the Dart grammar to https://github.com/UserNobody14/tree-sitter-dart/commit/02e9bb191c7cb6c73cbd9e09a5d089e4496f9cff

# Notes
* Before https://github.com/DataDog/datadog-static-analyzer/pull/909 landed, we only supported grammars compiled for ABI 14. https://github.com/DataDog/datadog-static-analyzer/pull/903 thus had to fork the repo and compile for 14 instead of the default 15. Now that we have proper support, we can switch to the official repo.