### PR TITLE
Revert "Temporarily support legacy schema return from the backend"

### DIFF
--- a/crates/cli/src/config_file.rs
+++ b/crates/cli/src/config_file.rs
@@ -95,11 +95,7 @@ pub fn get_config(
     let text = decode_base64_string(remote_config_base64)
         .context("error when decoding base64 remote config")?;
 
-    ////////
-    use kernel::config::common::{parse_any_schema_yaml, WithVersion};
-    // (There is temporary support for the backend returning a legacy schema -- this will be converted to
-    // `file_v1::parse_yaml` in a future minor version)
-    let res = parse_any_schema_yaml(&text).inspect_err(|err| {
+    let res = file_v1::parse_yaml(&text).inspect_err(|err| {
         if debug {
             eprintln!("Error when parsing remote config: {err:?}");
             eprintln!("Proceeding with local config");
@@ -108,10 +104,7 @@ pub fn get_config(
     let Ok(remote_yaml) = res else {
         return Ok(local_config.map(|c| (c, ConfigMethod::File)));
     };
-    let remote_config: file_v1::ConfigFile = match remote_yaml {
-        WithVersion::Legacy(legacy) => file_v1::YamlConfigFile::from(legacy).into(),
-        WithVersion::CodeSecurity(v1) => v1.into(),
-    };
+    let remote_config: file_v1::ConfigFile = remote_yaml.into();
 
     let config_method = if local_config.is_some() {
         ConfigMethod::RemoteConfigurationWithFile


### PR DESCRIPTION
# What this PR does

When the backend migrated to support the v1 configuration file, there was a manual override that allowed reverting back to the legacy file in case of unforeseen issues. 09c361e02c0122a0ddf90c86d1ef640c951159bd was thus added to gracefully handle that scenario. This override has since been removed from the backend, and so given the `?schema_version=v1` query param, the backend will always respond with a v1 configuration. Thus, this commit can be reverted now (as was originally intended)