### PR TITLE
[SDSP-327] Add SDS rule config field for is_supporting_rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,170 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -102,6 +275,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -216,6 +395,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
 dependencies = [
  "simd-abstraction",
+]
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
 ]
 
 [[package]]
@@ -347,6 +537,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -494,6 +697,15 @@ dependencies = [
  "bstr",
  "derive_builder",
  "serde",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1095,6 +1307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1148,6 +1369,33 @@ checksum = "ecbcc1770d1b2e3fb83915c80c47a10efbe1964544a40e0211fe40274f8363c8"
 dependencies = [
  "serde",
  "sha3",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1208,6 +1456,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -1308,6 +1562,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1453,6 +1720,18 @@ dependencies = [
  "log",
  "regex-automata 0.4.14",
  "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1676,6 +1955,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,7 +2078,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2020,7 +2327,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2028,6 +2335,15 @@ name = "iso_iec_7064"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50ce82efa43b36f28a91b8769a458f6f1c0a7e4c493011a1664834147ed6ff5"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2102,6 +2418,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.8.10",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.14",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2468,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -2210,6 +2572,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loom"
@@ -2387,6 +2752,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,7 +2782,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2541,6 +2912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +3025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +3073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,10 +3111,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2752,6 +3170,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_yaml"
@@ -2876,7 +3300,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2913,9 +3337,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3346,7 +3770,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3528,6 +3952,7 @@ dependencies = [
  "common",
  "dd-sds",
  "futures",
+ "httpmock",
  "itertools 0.14.0",
  "lazy_static",
  "serde",
@@ -3647,6 +4072,16 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -3795,6 +4230,12 @@ checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -3951,6 +4392,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "stringcase"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,7 +4547,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4699,6 +5152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4910,7 +5369,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -212,6 +212,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         let secret_rule2 = SecretRule {
@@ -228,6 +229,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         let cli_configuration_base = CliConfiguration {

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -381,6 +381,7 @@ pub struct SecretRuleApiAttributes {
     /// PairedValidator active checker — sent as a standalone field with no `type` discriminator.
     pub paired_validator_config: Option<SecretRulePairedValidatorConfig>,
     pub pattern_capture_groups: Option<Vec<String>>,
+    pub is_supporting_rule: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -424,6 +425,7 @@ impl TryFrom<SecretRuleApiType> for SecretRule {
                 .map(|v| v.into_iter().map(|validator| validator.into()).collect()),
             match_validation,
             pattern_capture_groups: val.attributes.pattern_capture_groups.unwrap_or_default(),
+            is_supporting_rule: val.attributes.is_supporting_rule.unwrap_or(false),
         })
     }
 }
@@ -579,6 +581,7 @@ mod tests {
                 match_validation_v2: None,
                 paired_validator_config: None,
                 pattern_capture_groups: None,
+                is_supporting_rule: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -616,12 +619,51 @@ mod tests {
                 match_validation_v2: None,
                 paired_validator_config: None,
                 pattern_capture_groups: None,
+                is_supporting_rule: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
             api_secret_rule_invalid_match_validation_type,
         );
-        assert!(converted.is_ok());
+        let converted = converted.expect("convert SecretRule");
+        assert!(!converted.is_supporting_rule);
+    }
+
+    #[test]
+    fn convert_secrets_rules_from_api_to_lib_supporting_rule_true() {
+        let api_rule = SecretRuleApiType {
+            id: "secret_type".to_string(),
+            attributes: SecretRuleApiAttributes {
+                name: "secret_rule_name".to_string(),
+                description: "secret_rule_description".to_string(),
+                pattern: "pattern".to_string(),
+                priority: "medium".to_string(),
+                default_included_keywords: None,
+                default_excluded_keywords: None,
+                look_ahead_character_count: None,
+                sds_id: "71A7A0ED-DD03-45C5-9C2E-56B30CB566E0".to_string(),
+                validators: None,
+                validators_v2: None,
+                match_validation: Some(SecretRuleApiMatchValidation {
+                    r#type: SecretRuleApiMatchValidation::CUSTOM_HTTP_STRING.to_string(),
+                    endpoint: Some("endpoint".to_string()),
+                    hosts: Some(vec!["endpoint".to_string()]),
+                    request_headers: None,
+                    http_method: Some(Get),
+                    timeout_seconds: None,
+                    valid_http_status_code: None,
+                    invalid_http_status_code: None,
+                }),
+                match_validation_v2: None,
+                paired_validator_config: None,
+                pattern_capture_groups: None,
+                is_supporting_rule: Some(true),
+            },
+        };
+
+        let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(api_rule)
+            .expect("convert SecretRule");
+        assert!(converted.is_supporting_rule);
     }
 
     #[test]
@@ -652,6 +694,7 @@ mod tests {
                 match_validation_v2: None,
                 paired_validator_config: None,
                 pattern_capture_groups: None,
+                is_supporting_rule: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -694,6 +737,7 @@ mod tests {
                 match_validation_v2: None,
                 paired_validator_config: None,
                 pattern_capture_groups: None,
+                is_supporting_rule: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -736,6 +780,7 @@ mod tests {
                 match_validation_v2: None,
                 paired_validator_config: None,
                 pattern_capture_groups: None,
+                is_supporting_rule: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -993,5 +1038,60 @@ mod tests {
             rule.match_validation,
             Some(SecretRuleMatchValidation::CustomHttpV2(_))
         ));
+    }
+
+    #[test]
+    fn is_supporting_rule_deserialized_from_api() {
+        let json_data = json!({
+            "data": [
+                {
+                    "id": "secrets/rule-id", // is_supporting_rule is omitted from the API, should default to false
+                    "type": "secret_rule",
+                    "attributes": {
+                        "name": "rule-name",
+                        "description": "rule-description",
+                        "pattern": "FOO",
+                        "priority": "medium",
+                        "sds_id": "sds-123"
+                    }
+                },
+                {
+                    "id": "secrets/rule-id-2", // is_supporting_rule is set to false
+                    "type": "secret_rule",
+                    "attributes": {
+                        "name": "rule-name",
+                        "description": "rule-description",
+                        "pattern": "FOO",
+                        "priority": "medium",
+                        "sds_id": "sds-123",
+                        "is_supporting_rule": false
+                    }
+                },
+                {
+                    "id": "secrets/supporting-rule-id", // is_supporting_rule is set to true
+                    "type": "secret_rule",
+                    "attributes": {
+                        "name": "supporting-rule-name",
+                        "description": "supporting-rule-description",
+                        "pattern": "FOO",
+                        "priority": "medium",
+                        "sds_id": "sds-supporting-123",
+                        "is_supporting_rule": true
+                    }
+                }
+            ]
+        });
+
+        let api_response: StaticAnalysisSecretsAPIResponse =
+            serde_json::from_value(json_data).expect("Failed to deserialize JSON");
+
+        for rule in api_response.data {
+            let rule: SecretRule = rule.clone().try_into().expect("Failed to convert rule");
+            if rule.id == "secrets/supporting-rule-id" {
+                assert!(rule.is_supporting_rule);
+            } else {
+                assert!(!rule.is_supporting_rule);
+            }
+        }
     }
 }

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -625,8 +625,7 @@ mod tests {
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
             api_secret_rule_invalid_match_validation_type,
         );
-        let converted = converted.expect("convert SecretRule");
-        assert!(!converted.is_supporting_rule);
+        assert!(converted.is_ok());
     }
 
     #[test]

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1476,6 +1476,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         #[rustfmt::skip]
@@ -1614,6 +1615,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         let secret_results = vec![SecretResult {
@@ -1702,6 +1704,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         let secret_results = vec![SecretResult {
@@ -1800,6 +1803,7 @@ mod tests {
                 validators_v2: None,
                 match_validation: None,
                 pattern_capture_groups: vec![],
+                is_supporting_rule: false,
             };
             let expected_level = get_level_from_severity(map_priority_to_severity(rule.priority));
 
@@ -2133,6 +2137,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         };
 
         let secret_results = vec![SecretResult {

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -17,3 +17,6 @@ lazy_static = "1.5.0"
 # remote
 dd-sds = { git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "51fc3d11b6b24c9b1b1d74f8285b47c3d7faa253" }
 strum = "0.25.0"
+
+[dev-dependencies]
+httpmock = "0.7.0"

--- a/crates/secrets/src/model/secret_rule.rs
+++ b/crates/secrets/src/model/secret_rule.rs
@@ -472,6 +472,8 @@ pub struct SecretRule {
     pub match_validation: Option<SecretRuleMatchValidation>,
     pub sds_id: String,
     pub pattern_capture_groups: Vec<String>,
+    #[serde(default)]
+    pub is_supporting_rule: bool,
 }
 
 impl SecretRule {
@@ -528,8 +530,9 @@ impl SecretRule {
                 regex_rule_config.with_pattern_capture_groups(self.pattern_capture_groups.clone());
         }
 
-        let mut rule_config =
-            RootRuleConfig::new(regex_rule_config).match_action(MatchAction::None);
+        let mut rule_config = RootRuleConfig::new(regex_rule_config)
+            .match_action(MatchAction::None)
+            .is_supporting_rule(self.is_supporting_rule);
 
         if let Some(match_validation) = &self.match_validation {
             if let Ok(mvt) = match_validation.try_into() {
@@ -635,6 +638,7 @@ mod tests {
             }]),
             match_validation: None,
             pattern_capture_groups: vec!["sds_match".to_string()],
+            is_supporting_rule: false,
         };
 
         // Validates that convert_to_sds_ruleconfig doesn't panic and returns a valid config.

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -513,6 +513,94 @@ mod tests {
         mock.assert();
     }
 
+    /// With `disable_validation`, SDS must not run HTTP active checkers — the mock receives no requests.
+    #[test]
+    fn test_custom_http_validation_not_called_when_disable_validation() {
+        use httpmock::Method::GET;
+        use httpmock::MockServer;
+        use std::collections::BTreeMap;
+
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/validate")
+                .query_param("secret", "api_key_abc123");
+            then.status(200);
+        });
+
+        let rule = SecretRule {
+            id: "primary".to_string(),
+            sds_id: "sds_id_primary".to_string(),
+            name: "primary".to_string(),
+            description: "primary".to_string(),
+            pattern: "\\bapi_key_[a-z0-9]+\\b".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: Some(SecretRuleMatchValidation::CustomHttpV2(
+                SecretRuleMatchValidationHttpV2 {
+                    match_pairing: None,
+                    provides: None,
+                    calls: vec![SecretRuleHttpCallConfig {
+                        request: SecretRuleHttpRequestConfig {
+                            endpoint: format!("{}/validate?secret=$MATCH", server.base_url()),
+                            method: SecretRuleMatchValidationHttpMethod::Get,
+                            hosts: vec![],
+                            headers: BTreeMap::new(),
+                            body: None,
+                            timeout_seconds: Some(3),
+                        },
+                        response: SecretRuleHttpResponseConfig {
+                            conditions: vec![SecretRuleResponseCondition {
+                                condition_type: SecretRuleResponseConditionType::Valid,
+                                status_code: Some(SecretRuleStatusCodeMatcher::Single {
+                                    single: 200,
+                                }),
+                                raw_body: None,
+                                body: None,
+                            }],
+                        },
+                    }],
+                },
+            )),
+            pattern_capture_groups: vec![],
+            is_supporting_rule: false,
+        };
+
+        let rules = vec![rule];
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+
+        let options = AnalysisOptions {
+            disable_validation: true,
+            ..Default::default()
+        };
+        let results = find_secrets(
+            &scanner,
+            rules.as_slice(),
+            "myfile",
+            "key: api_key_abc123\n",
+            &options,
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].rule_id, "primary");
+        assert_eq!(results[0].matches.len(), 1);
+        assert_eq!(
+            results[0].matches[0].validation_status,
+            SecretValidationStatus::NotValidated
+        );
+
+        assert_eq!(
+            mock.hits(),
+            0,
+            "HTTP validation must be skipped when disable_validation is true"
+        );
+    }
+
     #[test]
     fn test_find_secrets_all_ignored() {
         let rules: Vec<SecretRule> = vec![SecretRule {

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -231,38 +231,6 @@ mod tests {
     }
 
     #[test]
-    fn test_find_secrets_only_supporting_rule_returns_no_results() {
-        let rules: Vec<SecretRule> = vec![SecretRule {
-            id: "supporting".to_string(),
-            sds_id: "sds_id_supporting".to_string(),
-            name: "supporting".to_string(),
-            description: "supporting".to_string(),
-            pattern: "FOOBAR".to_string(),
-            default_included_keywords: vec![],
-            default_excluded_keywords: vec![],
-            look_ahead_character_count: Some(30),
-            priority: RulePriority::Medium,
-            validators: Some(vec![]),
-            validators_v2: None,
-            match_validation: None,
-            pattern_capture_groups: vec![],
-            is_supporting_rule: true,
-        }];
-
-        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
-        let text = "FOOBAR\n";
-        let results = find_secrets(
-            &scanner,
-            rules.as_slice(),
-            "myfile",
-            text,
-            &AnalysisOptions::default(),
-        );
-
-        assert!(results.is_empty());
-    }
-
-    #[test]
     fn test_find_secrets_with_ignore_directive() {
         let rules: Vec<SecretRule> = vec![SecretRule {
             id: "secret_rule".to_string(),

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -9,7 +9,7 @@ use anyhow::Error;
 use common::analysis_options::AnalysisOptions;
 use common::model::position::Position;
 use common::utils::position_utils::get_position_in_string;
-use dd_sds::{RootRuleConfig, RuleConfig, Scanner};
+use dd_sds::{RootRuleConfig, RuleConfig, ScanOptionBuilder, Scanner};
 use itertools::Itertools;
 use std::sync::Arc;
 
@@ -47,7 +47,12 @@ pub fn find_secrets(
     let lines_to_ignore = get_lines_to_ignore(code);
 
     let mut codemut = code.to_owned();
-    let mut matches = match scanner.scan(&mut codemut) {
+
+    let scan_options = ScanOptionBuilder::new()
+        .with_validate_matching(!options.disable_validation)
+        .build();
+
+    let matches = match scanner.scan_with_options(&mut codemut, scan_options) {
         Ok(m) => m,
         Err(e) => {
             if options.use_debug {
@@ -62,10 +67,6 @@ pub fn find_secrets(
 
     if matches.is_empty() {
         return vec![];
-    }
-
-    if !options.disable_validation {
-        scanner.validate_matches(&mut matches);
     }
 
     matches
@@ -107,7 +108,14 @@ pub fn find_secrets(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::secret_rule::RulePriority;
+    use crate::model::secret_result::SecretValidationStatus;
+    use crate::model::secret_rule::{
+        RulePriority, SecretRuleHttpCallConfig, SecretRuleHttpRequestConfig,
+        SecretRuleHttpResponseConfig, SecretRuleMatchPairingConfig, SecretRuleMatchValidation,
+        SecretRuleMatchValidationHttpMethod, SecretRuleMatchValidationHttpV2,
+        SecretRulePairedValidatorConfig, SecretRuleResponseCondition,
+        SecretRuleResponseConditionType, SecretRuleStatusCodeMatcher,
+    };
 
     #[test]
     fn test_get_position_in_string() {
@@ -139,6 +147,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";
@@ -170,6 +179,90 @@ mod tests {
     }
 
     #[test]
+    fn test_find_secrets_discards_supporting_rule_matches() {
+        let supporting_rule = SecretRule {
+            id: "supporting".to_string(),
+            sds_id: "sds_id_supporting".to_string(),
+            name: "supporting".to_string(),
+            description: "supporting".to_string(),
+            pattern: "FOOBAR".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+            is_supporting_rule: true,
+        };
+        let primary_rule = SecretRule {
+            id: "primary".to_string(),
+            sds_id: "sds_id_primary".to_string(),
+            name: "primary".to_string(),
+            description: "primary".to_string(),
+            pattern: "FOOBAZ".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+            is_supporting_rule: false,
+        };
+
+        let rules = vec![supporting_rule, primary_rule];
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+        let text = "FOOBAR\nFOOBAZ\n";
+
+        let results = find_secrets(
+            &scanner,
+            rules.as_slice(),
+            "myfile",
+            text,
+            &AnalysisOptions::default(),
+        );
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].rule_id, "primary");
+        assert_eq!(results[0].matches.len(), 1);
+    }
+
+    #[test]
+    fn test_find_secrets_only_supporting_rule_returns_no_results() {
+        let rules: Vec<SecretRule> = vec![SecretRule {
+            id: "supporting".to_string(),
+            sds_id: "sds_id_supporting".to_string(),
+            name: "supporting".to_string(),
+            description: "supporting".to_string(),
+            pattern: "FOOBAR".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+            is_supporting_rule: true,
+        }];
+
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+        let text = "FOOBAR\n";
+        let results = find_secrets(
+            &scanner,
+            rules.as_slice(),
+            "myfile",
+            text,
+            &AnalysisOptions::default(),
+        );
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
     fn test_find_secrets_with_ignore_directive() {
         let rules: Vec<SecretRule> = vec![SecretRule {
             id: "secret_rule".to_string(),
@@ -185,6 +278,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Line 1: FOOBAR - should be found
@@ -223,6 +317,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Line 1: FOOBAR - should be found
@@ -271,6 +366,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";
@@ -289,6 +385,134 @@ mod tests {
         }
     }
 
+    /// A supporting rule's match must be excluded from `find_secrets` output, but its value
+    /// must still be used to populate template variables for the main rule's HTTP validation call.
+    #[test]
+    fn test_supporting_rule_excluded_from_output_but_used_for_match_pairing() {
+        use httpmock::Method::GET;
+        use httpmock::MockServer;
+        use std::collections::BTreeMap;
+
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/validate")
+                .query_param("secret", "api_key_abc123")
+                .query_param("subdomain", "acme_corp");
+            then.status(200);
+        });
+
+        let supporting_rule = SecretRule {
+            id: "supporting".to_string(),
+            sds_id: "sds_id_supporting".to_string(),
+            name: "supporting".to_string(),
+            description: "supporting".to_string(),
+            pattern: "\\b[a-z_]+_corp\\b".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: Some(SecretRuleMatchValidation::CustomHttpV2(
+                SecretRuleMatchValidationHttpV2 {
+                    provides: Some(vec![SecretRulePairedValidatorConfig {
+                        kind: "vendor_xyz".to_string(),
+                        name: "client_subdomain".to_string(),
+                    }]),
+                    calls: vec![],
+                    match_pairing: None,
+                },
+            )),
+            pattern_capture_groups: vec![],
+            is_supporting_rule: true,
+        };
+
+        let mut parameters = BTreeMap::new();
+        parameters.insert("client_subdomain".to_string(), "$SUBDOMAIN".to_string());
+
+        let primary_rule = SecretRule {
+            id: "primary".to_string(),
+            sds_id: "sds_id_primary".to_string(),
+            name: "primary".to_string(),
+            description: "primary".to_string(),
+            pattern: "\\bapi_key_[a-z0-9]+\\b".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: Some(SecretRuleMatchValidation::CustomHttpV2(
+                SecretRuleMatchValidationHttpV2 {
+                    match_pairing: Some(SecretRuleMatchPairingConfig {
+                        kind: "vendor_xyz".to_string(),
+                        parameters,
+                    }),
+                    provides: None,
+                    calls: vec![SecretRuleHttpCallConfig {
+                        request: SecretRuleHttpRequestConfig {
+                            endpoint: format!(
+                                "{}/validate?secret=$MATCH&subdomain=$SUBDOMAIN",
+                                server.base_url()
+                            ),
+                            method: SecretRuleMatchValidationHttpMethod::Get,
+                            hosts: vec![],
+                            headers: BTreeMap::new(),
+                            body: None,
+                            timeout_seconds: Some(3),
+                        },
+                        response: SecretRuleHttpResponseConfig {
+                            conditions: vec![SecretRuleResponseCondition {
+                                condition_type: SecretRuleResponseConditionType::Valid,
+                                status_code: Some(SecretRuleStatusCodeMatcher::Single {
+                                    single: 200,
+                                }),
+                                raw_body: None,
+                                body: None,
+                            }],
+                        },
+                    }],
+                },
+            )),
+            pattern_capture_groups: vec![],
+            is_supporting_rule: false,
+        };
+
+        let rules = vec![supporting_rule, primary_rule];
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+
+        let results = find_secrets(
+            &scanner,
+            rules.as_slice(),
+            "myfile",
+            "subdomain: acme_corp, key: api_key_abc123\n",
+            &AnalysisOptions::default(),
+        );
+
+        // The supporting rule match must not appear in output
+        assert!(
+            results.iter().all(|r| r.rule_id != "supporting"),
+            "supporting rule should not appear in output"
+        );
+
+        // The main rule match must appear with Valid status
+        let main_result = results
+            .iter()
+            .find(|r| r.rule_id == "primary")
+            .expect("main rule should have a match");
+        assert_eq!(main_result.matches.len(), 1);
+        assert_eq!(
+            main_result.matches[0].validation_status,
+            SecretValidationStatus::Valid
+        );
+
+        // The HTTP mock was called, proving the template variable was resolved from the
+        // supporting rule's match even though that match is not in the output
+        mock.assert();
+    }
+
     #[test]
     fn test_find_secrets_all_ignored() {
         let rules: Vec<SecretRule> = vec![SecretRule {
@@ -305,6 +529,7 @@ mod tests {
             validators_v2: None,
             match_validation: None,
             pattern_capture_groups: vec![],
+            is_supporting_rule: false,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Directive on line 1 means ignore entire file


### PR DESCRIPTION
## What problem are you trying to solve?
The SDS library supports a concept of "supporting rules" which are rules that exist solely to supply context (ex. a subdomain or client ID) to a primary rule's active validation call via match pairing. This PR allows rules to be configured as is_supporting_rule from the static-analysis-api config and pass that to the SDS library.

Additionally, the previous `scanner.scan()` + `scanner.validate_matches()` two-step approach could not support supporting rules: matches would have to be retained between the two calls for validation, making it impossible to suppress them cleanly. Moving to `scan_with_options` lets the dd-sds library handle both validation and supporting rule match suppression in a single pass.

## What is your solution?
- Added `is_supporting_rule: bool` to the `SecretRule` model (with #[serde(default)] so omission from the API defaults to false)
- Added `is_supporting_rule` to `SecretRuleApiAttributes` and wired it through the `TryFrom<SecretRuleApiType>` conversion
- Passed `is_supporting_rule` to dd-sds via .is_supporting_rule(...) on `RootRuleConfig` during scanner construction, so the library knows to suppress those matches from output while still using them for template variable resolution in HTTP validation calls
- Replaced the `scanner.scan()` + `scanner.validate_matches()` two-step with a single `scanner.scan_with_options()` call, passing `disable_validation` through `ScanOptionBuilder`

## Alternatives considered
Filtering out supporting rule matches in the static analyzer after `scan()` returns was considered, but rejected in favor of having dd-sds own the behavior. This approach keeps the static analyzer's responsibility limited to passing the flag through from the API.

## What the reviewer should know
- Unit test coverage was added to verify setting `is_supporting_rule=true` correctly drops the matches from the SDS lib
- A test for `disable_validation=true` confirms that `scan_with_options` correctly skips HTTP calls when validation is disabled