### PR TITLE
ci(regressions): restore column-aware SARIF comparison after byte→UTF-16 transition

### DIFF
--- a/.github/scripts/check-regressions.js
+++ b/.github/scripts/check-regressions.js
@@ -22,33 +22,7 @@ const parseFile = (filepath) => {
       const current = {};
       current.message = i.message;
       current.ruleId = i.ruleId;
-      // ------------------------------------------------------------------
-      // IMPORTANT (TEMPORARY): strip `startColumn` / `endColumn` from the region.
-      //
-      // PR #914 changes the kernel from emitting 1-based UTF-8 byte columns to
-      // 1-based UTF-16 code-unit columns (matching LSP / VS Code / SARIF v2.1).
-      //
-      // While that PR is in review, `main` still emits byte columns and the
-      // feature branch emits UTF-16 columns. The regression check compares
-      // results as JSON strings, so it would flag every violation that lives
-      // on a line containing a non-ASCII character as a "removed + added"
-      // pair — same file, same rule, same line; only the column number drifts
-      // by N (where N is the number of multibyte chars before the position).
-      //
-      // To unblock CI for #914 we compare by
-      //     (file, ruleId, message, startLine, endLine)
-      // and intentionally ignore columns. This is a one-shot loosening for
-      // the byte→UTF-16 transition. A stacked follow-up PR will restore
-      // `startColumn` / `endColumn` to the comparison key once #914 lands on
-      // `main` (at which point both runs are on UTF-16 columns again and
-      // column-level regression detection becomes meaningful again).
-      // ------------------------------------------------------------------
-      const { startColumn: _startCol, endColumn: _endCol, ...regionWithoutColumns } =
-        i.locations[0].physicalLocation.region;
-      current.physicalLocation = {
-        ...i.locations[0].physicalLocation,
-        region: regionWithoutColumns,
-      };
+      current.physicalLocation = i.locations[0].physicalLocation;
       results.push(current);
     }
 
@@ -81,16 +55,13 @@ const main = async () => {
     let table1 = [];
 
     if (count1 > 0 || count2 > 0) {
-      // Location display only shows `startLine-endLine`. Columns are
-      // intentionally omitted to match the comparison key (see `parseFile`
-      // above for the full rationale on the byte→UTF-16 transition).
       for (const item of diff1) {
         const json = JSON.parse(item);
         table1.push([
           { data: json.physicalLocation.artifactLocation.uri },
           { data: json.message.text },
           { data: json.ruleId },
-          { data: `${json.physicalLocation.region.startLine}-${json.physicalLocation.region.endLine}` },
+          { data: `${json.physicalLocation.region.startLine}:${json.physicalLocation.region.startColumn}-${json.physicalLocation.region.endLine}:${json.physicalLocation.region.endColumn}` },
           { data: dupes1[json.ruleId] },
         ]);
       }
@@ -103,7 +74,7 @@ const main = async () => {
           { data: json.physicalLocation.artifactLocation.uri },
           { data: json.message.text },
           { data: json.ruleId },
-          { data: `${json.physicalLocation.region.startLine}-${json.physicalLocation.region.endLine}` },
+          { data: `${json.physicalLocation.region.startLine}:${json.physicalLocation.region.startColumn}-${json.physicalLocation.region.endLine}:${json.physicalLocation.region.endColumn}` },
           { data: dupes2[json.ruleId] },
         ]);
       }


### PR DESCRIPTION
### Context

PR [#914](https://github.com/DataDog/datadog-static-analyzer/pull/914) changed the static-analysis kernel from emitting **1-based UTF-8 byte columns** to **1-based UTF-16 code-unit columns** (matching LSP, VS Code, and the SARIF v2.1 default encoding).

While that PR was open, the regression workflow (`.github/scripts/check-regressions.js`) compared two SARIF runs as JSON strings:

- **before** = analyzer built from `main` → byte columns
- **after**  = analyzer built from the PR branch → UTF-16 columns

For every violation on a line containing a non-ASCII character, the column numbers drift by *N* (where *N* is the number of multibyte characters before the violation position). The string-equality comparison saw those as `"violation X removed"` + `"violation Y added"` pairs, even though the rule, the file, and the line were identical.

**Example** from `numpy/_core/tests/test_strings.py` line 1284:

```python
("λ" * 5 + "μ" * 2, "μ"),
```

| Build | `startColumn` | `endColumn` |
|---|---|---|
| main  (byte cols)   | 14 | 32 |
| #914  (UTF-16 cols) | 14 | 31 |

→ same violation, two different rows in the diff.

To unblock #914's CI, commit [`329df0cc`](https://github.com/DataDog/datadog-static-analyzer/pull/914/commits/329df0cc) **temporarily** dropped `startColumn` / `endColumn` from both the comparison key and the summary location string, comparing by `(file, ruleId, message, startLine, endLine)` instead. That commit was explicitly marked as a one-shot loosening and called out a stacked follow-up PR to restore the original behaviour. **This is that follow-up.**

### What this PR does

- Restores the comparison key to the full `physicalLocation` (including `startColumn` and `endColumn`).
- Restores the summary table location string to its original `startLine:startColumn-endLine:endColumn` format.
- Effectively reverts the JS-only change introduced in `329df0cc`. No other files touched.

### Why this is safe to land

Once #914 is merged into `main`, both sides of the regression check run with UTF-16 columns:

- **before** = `main` (post-#914) → UTF-16 columns
- **after**  = any feature branch  → UTF-16 columns

…so column-aware diffing becomes meaningful again and the false "removed + added" pairs disappear. Verified locally on `_core/tests/test_strings.py`:

| Comparison logic | "Removed" diffs | "Added" diffs |
|---|---|---|
| Column-aware (this PR) on `main`-vs-`main` baselines | 0 | 0 |

### Merge order

This PR depends on #914 landing first. It is opened against the `rob/fix/tree-sitter-byte-column-bug-IDE-6037` branch as a stacked PR — GitHub will automatically retarget it to `main` once #914 is merged.

### What we get back

Column-level regression detection, on top of the file / rule / line / message protection we kept throughout. The workflow can again catch column-shift bugs introduced by future tree-sitter or grammar updates, off-by-one regressions in rule code, etc.

Closes IDE-6037 follow-up.

