### PR TITLE
[fix] Redact secret value from validation error messages

### DIFF
--- a/crates/secrets/src/model/secret_result.rs
+++ b/crates/secrets/src/model/secret_result.rs
@@ -16,32 +16,33 @@ pub enum SecretValidationStatus {
     NotAvailable,
 }
 
-impl From<&MatchStatus> for SecretValidationStatus {
-    fn from(value: &MatchStatus) -> Self {
-        match value {
+impl SecretValidationStatus {
+    pub fn from(status: &MatchStatus, match_value: Option<&str>) -> Self {
+        match status {
             MatchStatus::NotChecked => SecretValidationStatus::NotValidated,
             MatchStatus::Valid => SecretValidationStatus::Valid,
             MatchStatus::Invalid => SecretValidationStatus::Invalid,
             MatchStatus::ValidationError(validation_errors) => {
-                // Convert all validation errors to ValidationErrorInfo
                 let error_infos: Vec<ValidationErrorInfo> = validation_errors
                     .iter()
                     .map(|error| match error {
                         dd_sds::ValidationError::HttpError(http_error) => ValidationErrorInfo {
                             error_type: ValidationErrorType::HttpError,
                             status_code: http_error.status_code,
-                            message: http_error.message.clone(),
+                            message: redact_secret(&http_error.message, match_value),
                         },
                         dd_sds::ValidationError::UnknownResponseType(unknown_response) => {
-                            let message = format!(
-                                "Unknown response type (body_length: {}, body_prefix: '{}')",
-                                unknown_response.body_length,
-                                unknown_response.body_prefix.as_deref().unwrap_or("")
-                            );
                             ValidationErrorInfo {
                                 error_type: ValidationErrorType::UnknownResponseType,
                                 status_code: unknown_response.status_code,
-                                message,
+                                message: format!(
+                                    "Unknown response type (body_length: {}, body_prefix: '{}')",
+                                    unknown_response.body_length,
+                                    redact_secret(
+                                        unknown_response.body_prefix.as_deref().unwrap_or(""),
+                                        match_value
+                                    ),
+                                ),
                             }
                         }
                     })
@@ -99,10 +100,33 @@ impl ValidationErrorType {
     }
 }
 
+fn redact_secret(message: &str, secret: Option<&str>) -> String {
+    match secret {
+        Some(secret) if !secret.is_empty() => message.replace(secret, "[REDACTED]"),
+        _ => message.to_owned(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json;
+
+    #[test]
+    fn test_redact_secret_replaces_match_value() {
+        let msg = "Error making HTTP request: connection refused for MY_SECRET123";
+        let redacted = redact_secret(msg, Some("MY_SECRET123"));
+        assert_eq!(
+            redacted,
+            "Error making HTTP request: connection refused for [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn test_redact_secret_no_match_value() {
+        let msg = "Error making HTTP request: connection refused";
+        assert_eq!(redact_secret(msg, None), msg);
+    }
 
     #[test]
     fn test_serialize_validation_error_info() {

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -79,7 +79,10 @@ pub fn find_secrets(
                 rule_index: sds_match.rule_index,
                 start,
                 end,
-                validation_status: SecretValidationStatus::from(&sds_match.match_status),
+                validation_status: SecretValidationStatus::from(
+                    &sds_match.match_status,
+                    sds_match.match_value.as_deref(),
+                ),
             })
         })
         .chunk_by(|v| v.rule_index)


### PR DESCRIPTION
## What

Validation error messages stored in the SARIF output could include the secret being validated:

- `HttpError` messages from reqwest include the full validation URL, which may contain the secret as a query parameter.
- `UnknownResponseType` messages included `body_prefix` (first bytes of the response body), which may echo the secret back from the validation endpoint.

## Why

Logging these messages verbatim leaks the secret. Even outside of logs, the messages end up in the SARIF `datadogSecretValidationErrors` property, which downstream consumers may log or store.

## How

Added a `redact_secret(message, secret)` helper that replaces the matched secret value with `[REDACTED]`. The `SecretValidationStatus::from(status, secret)` constructor now takes the matched value (already available via `match_value` on `RuleMatch`) and applies redaction to both error message types before storing them.