### PR TITLE
[K9VULN-15513] Add rust as a default ruleset language

### DIFF
--- a/crates/cli/src/datadog_utils.rs
+++ b/crates/cli/src/datadog_utils.rs
@@ -41,6 +41,7 @@ const DEFAULT_RULESETS_LANGUAGES: &[&str] = &[
     "KOTLIN",
     "PYTHON",
     "RUBY",
+    "RUST",
     "TYPESCRIPT",
     "PHP",
     "YAML",


### PR DESCRIPTION
## What problem are you trying to solve?
`Rust` is not yet a default ruleset

## What is your solution?
Adding `Rust` as a language to the default rules

## Testing
Uploaded a SARIF via `datadog-ci` and verified findings populated correctly [here](https://dd.datad0g.com/security/code-security/repositories/github.com%2Fdatadog%2Fdatadog-static-analyzer-test-repo/jdelgo%2Frust-testing/00075f18412dea192bef0d493dc678b4e47c9611/code-quality?query=%40git.repository.id%3Agithub.com%2Fdatadog%2Fdatadog-static-analyzer-test-repo%20%40git.branch%3Ajdelgo%2Frust-testing%20%40git.commit.sha%3A00075f18412dea192bef0d493dc678b4e47c9611%20-%40static_analysis.result.category%3Asecurity%20%40static_analysis.result.item_type%3Astatic_analysis_violation%20-%40static_analysis.result.confidence%3Alow%20-%40static_analysis.result.is_suppressed%3Atrue%20%40static_analysis.result.language%3Arust&fromUser=false&index=cicodescan&start=1780517299995&end=1780603889005&paused=false)