### PR TITLE
feat(ide/config): add unified config support to the static-analyzer server

### DIFF
--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -7,7 +7,9 @@ use crate::datadog_static_analyzer_server::ide::configuration_file::models::{
 
 use super::error::ConfigFileError;
 use super::models::{AddRuleSetsRequest, IgnoreRuleRequest};
-use super::static_analysis_config_file::{Base64String, StaticAnalysisConfigFile};
+use super::static_analysis_config_file::{
+    Base64String, ConfigFormat, StaticAnalysisConfigFile, WithHint,
+};
 use kernel::utils::encode_base64_string;
 use rocket::http::Status;
 use rocket::response::status::Custom;
@@ -35,12 +37,13 @@ pub fn post_ignore_rule(
         rule,
         configuration_base64,
         encoded,
-        ..
+        schema_version,
     } = request.into_inner();
     tracing::debug!(rule, content = &configuration_base64);
     let result = StaticAnalysisConfigFile::with_ignored_rule(
         rule.into(),
         Base64String(configuration_base64),
+        ConfigFormat::from(schema_version.as_deref()),
     );
     to_response_result(result, encoded)
 }
@@ -51,10 +54,18 @@ pub fn post_ignore_rule(
 /// * `content` - The path to the configuration file.
 #[instrument()]
 #[rocket::get("/v1/config/can-onboard/<content..>")]
-#[deprecated(note = "IDEs stopped supporting onboarding")]
 pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFileError>> {
-    let content_str = content.to_string_lossy().into_owned();
-    can_onboard(content_str)
+    // NOTE: this method is still used by Visual Studio.
+    let mut content_str = content.to_string_lossy().into_owned();
+    if cfg!(target_os = "windows") {
+        // NOTE: this is needed due to how Rocket works with multiple segment captures.
+        content_str = content_str.replace("\\", "/");
+    }
+    let config = StaticAnalysisConfigFile::try_from(WithHint(Base64String(content_str), None))
+        .map_err(|e| Custom(Status::InternalServerError, e))?;
+
+    let can_onboard = config.is_onboarding_allowed();
+    Ok(Json(can_onboard))
 }
 
 /// Checks if onboarding is allowed for the configuration file (v2).
@@ -67,15 +78,27 @@ pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFile
     format = "application/json",
     data = "<request>"
 )]
-#[deprecated(note = "IDEs stopped supporting onboarding")]
 pub fn post_can_onboard_v2(
     request: Json<CanOnboardRequest>,
 ) -> Result<Json<bool>, Custom<ConfigFileError>> {
     let CanOnboardRequest {
         configuration_base64,
-        ..
+        schema_version,
     } = request.into_inner();
-    can_onboard(configuration_base64)
+
+    let format = ConfigFormat::from(schema_version.as_deref());
+    let config = StaticAnalysisConfigFile::try_from(WithHint(
+        Base64String(configuration_base64),
+        Some(format),
+    ))
+    .map_err(|e| Custom(Status::InternalServerError, e))?;
+
+    config
+        .validate_format(format)
+        .map_err(|e| Custom(Status::InternalServerError, e))?;
+
+    let can_onboard = config.is_onboarding_allowed();
+    Ok(Json(can_onboard))
 }
 
 /// Gets the rulesets from the static analysis configuration file (deprecated).
@@ -117,6 +140,9 @@ pub fn post_get_rulesets_v2(request: Json<GetRulesetsRequest>) -> Json<Vec<Strin
 
 /// Parses the static analysis configuration YAML and returns per-product fields.
 ///
+/// Returns `400` when the content cannot be parsed or when the detected schema does not
+/// match the caller-declared `schema_version` — mirroring the CLI's filename-strict behavior.
+///
 /// # Arguments
 /// * `request` - The request containing the raw YAML string.
 #[instrument()]
@@ -124,9 +150,16 @@ pub fn post_get_rulesets_v2(request: Json<GetRulesetsRequest>) -> Json<Vec<Strin
 pub fn post_parse_config(
     request: Json<ParseConfigRequest>,
 ) -> Result<Json<ParseConfigResponse>, Custom<ConfigFileError>> {
-    let ParseConfigRequest { configuration } = request.into_inner();
+    let ParseConfigRequest {
+        configuration,
+        schema_version,
+    } = request.into_inner();
     tracing::debug!(%configuration);
-    let config = StaticAnalysisConfigFile::try_from(configuration)
+    let format = ConfigFormat::from(schema_version.as_deref());
+    let config = StaticAnalysisConfigFile::try_from(WithHint(configuration, Some(format)))
+        .map_err(|e| Custom(Status::BadRequest, e))?;
+    config
+        .validate_format(format)
         .map_err(|e| Custom(Status::BadRequest, e))?;
     Ok(Json(ParseConfigResponse {
         sast: SastParsedConfig {
@@ -169,22 +202,21 @@ pub fn post_add_rulesets_v2(
 
 /// Adds rulesets to the configuration file.
 ///
-/// # Arguments
-/// * `request` - The request containing rulesets and configuration file (base64).
+/// When no config content is supplied, creates a new file in the format implied by
+/// `schema_version` (unified when `"v1"`, legacy otherwise). When content is supplied,
+/// validates that the detected format matches the declared one before mutating.
 fn add_rulesets(request: Json<AddRuleSetsRequest>) -> Result<String, Custom<ConfigFileError>> {
     let AddRuleSetsRequest {
         rulesets,
         configuration_base64,
         encoded,
-        ..
+        schema_version,
     } = request.into_inner();
-    tracing::debug!(
-        rulesets=?&rulesets,
-        content=&configuration_base64
-    );
+    tracing::debug!(rulesets=?&rulesets, content=&configuration_base64);
     let result = StaticAnalysisConfigFile::with_added_rulesets(
         &rulesets,
         configuration_base64.map(Base64String),
+        ConfigFormat::from(schema_version.as_deref()),
     );
     to_response_result(result, encoded)
 }
@@ -207,30 +239,13 @@ fn get_rulesets(mut content: String) -> Json<Vec<String>> {
         content = content.replace("\\", "/");
     }
     tracing::debug!(%content);
-    let rulesets = StaticAnalysisConfigFile::try_from(Base64String(content))
+    let rulesets = StaticAnalysisConfigFile::try_from(WithHint(Base64String(content), None))
         .map(|config| config.sast_rulesets())
         .unwrap_or_else(|e| {
             tracing::error!(error = ?e, "Error trying to parse config file");
             vec![]
         });
     Json(rulesets)
-}
-
-/// Checks if onboarding is allowed for the configuration file.
-///
-/// # Arguments
-/// * `content` - The configuration file content (base64).
-fn can_onboard(mut content: String) -> Result<Json<bool>, Custom<ConfigFileError>> {
-    if cfg!(target_os = "windows") {
-        // NOTE: this is needed due to how Rocket works with multiple segment captures.
-        // we may get rid of this once v1 endpoints are no longer needed.
-        content = content.replace("\\", "/");
-    }
-    tracing::debug!(%content);
-    let config = StaticAnalysisConfigFile::try_from(Base64String(content))
-        .map_err(|e| Custom(Status::InternalServerError, e))?;
-    let can_onboard = config.is_onboarding_allowed();
-    Ok(Json(can_onboard))
 }
 
 /// Converts the result to a response string, optionally encoding it in base64.

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -160,7 +160,7 @@ pub fn post_parse_config(
         .map_err(|e| Custom(Status::BadRequest, e))?;
     config
         .validate_format(format)
-        .map_err(|e| Custom(Status::BadRequest, e))?;
+        .map_err(|e| Custom(Status::UnprocessableEntity, e))?;
     Ok(Json(ParseConfigResponse {
         sast: SastParsedConfig {
             rulesets: config.sast_rulesets(),
@@ -249,8 +249,8 @@ fn get_rulesets(mut content: String) -> Json<Vec<String>> {
 
 /// Converts the result to a response string, optionally encoding it in base64.
 ///
-/// `SchemaMismatch` is a client error and maps to `400 Bad Request`; all other
-/// failures map to `500 Internal Server Error`.
+/// `SchemaMismatch` maps to `422 Unprocessable Entity` (content is syntactically valid but
+/// semantically wrong); all other failures map to `500 Internal Server Error`.
 ///
 /// # Arguments
 /// * `result` - The result string or error.
@@ -263,7 +263,7 @@ fn to_response_result(
         .map(|r| if encode { encode_base64_string(r) } else { r })
         .map_err(|e| {
             let status = match e {
-                ConfigFileError::SchemaMismatch => Status::BadRequest,
+                ConfigFileError::SchemaMismatch => Status::UnprocessableEntity,
                 _ => Status::InternalServerError,
             };
             Custom(status, e)

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -61,8 +61,12 @@ pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFile
         // NOTE: this is needed due to how Rocket works with multiple segment captures.
         content_str = content_str.replace("\\", "/");
     }
+    // 400: any error here is a parse failure on client-supplied content (bad base64 or invalid
+    // YAML). SchemaMismatch cannot occur because no format is declared (None hint).
+    // Visual Studio — the only known caller of this deprecated route — uses a plain try/catch
+    // and does not inspect the specific HTTP status code, so this is safe to be 400.
     let config = StaticAnalysisConfigFile::try_from(WithHint(Base64String(content_str), None))
-        .map_err(|e| Custom(Status::InternalServerError, e))?;
+        .map_err(|e| Custom(Status::BadRequest, e))?;
 
     let can_onboard = config.is_onboarding_allowed();
     Ok(Json(can_onboard))
@@ -95,7 +99,7 @@ pub fn post_can_onboard_v2(
 
     config
         .validate_format(format)
-        .map_err(|e| Custom(Status::InternalServerError, e))?;
+        .map_err(|e| Custom(Status::UnprocessableEntity, e))?;
 
     let can_onboard = config.is_onboarding_allowed();
     Ok(Json(can_onboard))

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -191,7 +191,6 @@ pub fn post_add_rulesets(
     format = "application/json",
     data = "<request>"
 )]
-#[deprecated(note = "IDEs stopped supporting this flow")]
 pub fn post_add_rulesets_v2(
     request: Json<AddRuleSetsRequest>,
 ) -> Result<String, Custom<ConfigFileError>> {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -48,7 +48,7 @@ pub fn post_ignore_rule(
     to_response_result(result, encoded)
 }
 
-/// Checks if onboarding is allowed for the configuration file (deprecated).
+/// Checks if onboarding is allowed for the configuration file (legacy route).
 ///
 /// # Arguments
 /// * `content` - The base64-encoded configuration file content, passed as a URL path segment.

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -51,7 +51,7 @@ pub fn post_ignore_rule(
 /// Checks if onboarding is allowed for the configuration file (deprecated).
 ///
 /// # Arguments
-/// * `content` - The path to the configuration file.
+/// * `content` - The base64-encoded configuration file content, passed as a URL path segment.
 #[instrument()]
 #[rocket::get("/v1/config/can-onboard/<content..>")]
 pub fn get_can_onboard(content: PathBuf) -> Result<Json<bool>, Custom<ConfigFileError>> {
@@ -250,6 +250,9 @@ fn get_rulesets(mut content: String) -> Json<Vec<String>> {
 
 /// Converts the result to a response string, optionally encoding it in base64.
 ///
+/// `SchemaMismatch` is a client error and maps to `400 Bad Request`; all other
+/// failures map to `500 Internal Server Error`.
+///
 /// # Arguments
 /// * `result` - The result string or error.
 /// * `encode` - Whether to encode the result in base64.
@@ -259,5 +262,11 @@ fn to_response_result(
 ) -> Result<String, Custom<ConfigFileError>> {
     result
         .map(|r| if encode { encode_base64_string(r) } else { r })
-        .map_err(|e| Custom(Status::InternalServerError, e))
+        .map_err(|e| {
+            let status = match e {
+                ConfigFileError::SchemaMismatch => Status::BadRequest,
+                _ => Status::InternalServerError,
+            };
+            Custom(status, e)
+        })
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -202,7 +202,7 @@ pub fn post_add_rulesets_v2(
 /// Adds rulesets to the configuration file.
 ///
 /// When no config content is supplied, creates a new file in the format implied by
-/// `schema_version` (unified when `"v1"`, legacy otherwise). When content is supplied,
+/// `schema_version` (unified when `"UNIFIED"`, legacy otherwise). When content is supplied,
 /// validates that the detected format matches the declared one before mutating.
 fn add_rulesets(request: Json<AddRuleSetsRequest>) -> Result<String, Custom<ConfigFileError>> {
     let AddRuleSetsRequest {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/endpoints.rs
@@ -202,7 +202,7 @@ pub fn post_add_rulesets_v2(
 /// Adds rulesets to the configuration file.
 ///
 /// When no config content is supplied, creates a new file in the format implied by
-/// `schema_version` (unified when `"UNIFIED"`, legacy otherwise). When content is supplied,
+/// `schema_version` (unified when `"v1"`, legacy otherwise). When content is supplied,
 /// validates that the detected format matches the declared one before mutating.
 fn add_rulesets(request: Json<AddRuleSetsRequest>) -> Result<String, Custom<ConfigFileError>> {
     let AddRuleSetsRequest {

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/error.rs
@@ -19,6 +19,9 @@ pub enum ConfigFileError {
         #[from]
         source: ReconcileError,
     },
+
+    #[error("Config content does not match the declared schema version")]
+    SchemaMismatch,
 }
 
 impl From<anyhow::Error> for ConfigFileError {
@@ -45,6 +48,7 @@ impl ConfigFileError {
             Self::Parser { .. } => 1,
             Self::Decoder { .. } => 2,
             Self::CommentReconciler { .. } => 3,
+            Self::SchemaMismatch => 4,
         }
     }
 }

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/models.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/models.rs
@@ -6,6 +6,8 @@ pub struct IgnoreRuleRequest {
     #[serde(rename = "configuration")]
     pub configuration_base64: String,
     pub encoded: bool,
+    #[serde(default)]
+    pub schema_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -14,6 +16,8 @@ pub struct AddRuleSetsRequest {
     #[serde(rename = "configuration")]
     pub configuration_base64: Option<String>,
     pub encoded: bool,
+    #[serde(default)]
+    pub schema_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -26,11 +30,15 @@ pub struct GetRulesetsRequest {
 pub struct CanOnboardRequest {
     #[serde(rename = "configuration")]
     pub configuration_base64: String,
+    #[serde(default)]
+    pub schema_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ParseConfigRequest {
     pub configuration: String,
+    #[serde(default)]
+    pub schema_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -44,7 +44,7 @@ pub struct StaticAnalysisConfigFile {
 impl Default for StaticAnalysisConfigFile {
     fn default() -> Self {
         Self {
-            config_file: WithVersion::Legacy(Default::default()),
+            config_file: WithVersion::CodeSecurity(Default::default()),
             original_content: None,
         }
     }
@@ -66,8 +66,8 @@ pub struct Base64String(pub String);
 
 /// Bundles content with an optional format hint for [`TryFrom`] parsing.
 ///
-/// `None` preserves the existing [`ConfigFormat::Legacy`] default for call sites that have
-/// no declared format (e.g. deprecated routes).
+/// `None` means no format was declared by the caller (e.g. deprecated routes); blank content
+/// will fall back to [`StaticAnalysisConfigFile::default_legacy`] in that case.
 #[derive(Debug)]
 pub struct WithHint<T>(pub T, pub Option<ConfigFormat>);
 
@@ -125,7 +125,7 @@ impl StaticAnalysisConfigFile {
         use serde::de::Error;
         if content.trim().is_empty() {
             return Ok(match hint {
-                Some(ConfigFormat::Unified) => Self::default_unified(),
+                Some(ConfigFormat::Legacy) | None => Self::default_legacy(),
                 _ => Self::default(),
             });
         }
@@ -300,8 +300,8 @@ impl StaticAnalysisConfigFile {
                 config
             }
             None => match declared_format {
-                ConfigFormat::Unified => Self::default_unified(),
-                ConfigFormat::Legacy => Self::default(),
+                ConfigFormat::Unified => Self::default(),
+                ConfigFormat::Legacy => Self::default_legacy(),
             },
         };
         config.add_rulesets(rulesets);
@@ -378,11 +378,11 @@ impl StaticAnalysisConfigFile {
         }
     }
 
-    /// Returns an empty unified-format config, used as the new-file default when
-    /// the IDE declares `schema_version: "v1"` and no existing config is present.
-    fn default_unified() -> Self {
+    /// Returns an empty legacy-format config, used as the fallback when the caller
+    /// has declared [`ConfigFormat::Legacy`] or provided no format hint at all.
+    fn default_legacy() -> Self {
         Self {
-            config_file: WithVersion::CodeSecurity(Default::default()),
+            config_file: WithVersion::Legacy(Default::default()),
             original_content: None,
         }
     }
@@ -1251,11 +1251,36 @@ sast:
     }
 
     #[test]
-    fn try_from_returns_default_config_file_if_empty_string() {
-        let expected = super::StaticAnalysisConfigFile::default();
+    fn default_is_unified() {
+        let config = super::StaticAnalysisConfigFile::default();
+        assert_eq!(config.detected_format(), super::ConfigFormat::Unified);
+    }
+
+    #[test]
+    fn try_from_empty_string_with_no_hint_returns_legacy() {
         let config =
             super::StaticAnalysisConfigFile::try_from(WithHint(String::new(), None)).unwrap();
-        assert_eq!(config, expected);
+        assert_eq!(config.detected_format(), super::ConfigFormat::Legacy);
+    }
+
+    #[test]
+    fn try_from_empty_string_with_legacy_hint_returns_legacy() {
+        let config = super::StaticAnalysisConfigFile::try_from(WithHint(
+            String::new(),
+            Some(super::ConfigFormat::Legacy),
+        ))
+        .unwrap();
+        assert_eq!(config.detected_format(), super::ConfigFormat::Legacy);
+    }
+
+    #[test]
+    fn try_from_empty_string_with_unified_hint_returns_unified() {
+        let config = super::StaticAnalysisConfigFile::try_from(WithHint(
+            String::new(),
+            Some(super::ConfigFormat::Unified),
+        ))
+        .unwrap();
+        assert_eq!(config.detected_format(), super::ConfigFormat::Unified);
     }
 
     #[test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -24,16 +24,12 @@ pub enum ConfigFormat {
 
 impl<'a> From<Option<&'a str>> for ConfigFormat {
     /// Maps the IDE-supplied `schema_version` string to a [`ConfigFormat`].
-    ///
-    /// Accepted values for [`ConfigFormat::Unified`]:
-    /// - `"v1"` — legacy wire value sent by older extension versions (kept for backward compat)
-    /// - `"UNIFIED"` — canonical value sent by newer extension versions
-    ///
+    /// `"v1"` is the canonical wire value for [`ConfigFormat::Unified`].
     /// Absent or unrecognized values default to [`ConfigFormat::Legacy`] for backward
     /// compatibility with older extensions that never sent this field.
     fn from(schema_version: Option<&'a str>) -> Self {
         match schema_version {
-            Some("v1") | Some("UNIFIED") => Self::Unified,
+            Some("v1") => Self::Unified,
             _ => Self::Legacy,
         }
     }
@@ -383,7 +379,7 @@ impl StaticAnalysisConfigFile {
     }
 
     /// Returns an empty unified-format config, used as the new-file default when
-    /// the IDE declares `schema_version: "UNIFIED"` and no existing config is present.
+    /// the IDE declares `schema_version: "v1"` and no existing config is present.
     fn default_unified() -> Self {
         Self {
             config_file: WithVersion::CodeSecurity(Default::default()),

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -14,6 +14,26 @@ use tracing::instrument;
 
 const WILDCARD_IGNORE: &str = "**";
 
+/// Whether the IDE-active config file uses the legacy (`static-analysis.datadog.*`) or
+/// unified (`code-security.datadog.*`) format. Determined by filename, never content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigFormat {
+    Legacy,
+    Unified,
+}
+
+impl<'a> From<Option<&'a str>> for ConfigFormat {
+    /// Maps the IDE-supplied `schema_version` string to a [`ConfigFormat`].
+    /// Absent or unrecognized values default to [`ConfigFormat::Legacy`] for backward
+    /// compatibility with older extensions that never sent this field.
+    fn from(schema_version: Option<&'a str>) -> Self {
+        match schema_version {
+            Some("v1") => Self::Unified,
+            _ => Self::Legacy,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct StaticAnalysisConfigFile {
     config_file: WithVersion<file_legacy::ConfigFile, file_v1::YamlConfigFile>,
@@ -43,20 +63,27 @@ impl From<file_legacy::ConfigFile> for StaticAnalysisConfigFile {
 #[derive(Debug)]
 pub struct Base64String(pub String);
 
-impl TryFrom<Base64String> for StaticAnalysisConfigFile {
+/// Bundles content with an optional format hint for [`TryFrom`] parsing.
+///
+/// `None` preserves the existing [`ConfigFormat::Legacy`] default for call sites that have
+/// no declared format (e.g. deprecated routes).
+#[derive(Debug)]
+pub struct WithHint<T>(pub T, pub Option<ConfigFormat>);
+
+impl TryFrom<WithHint<String>> for StaticAnalysisConfigFile {
     type Error = ConfigFileError;
 
-    fn try_from(base64_str: Base64String) -> Result<Self, Self::Error> {
-        let decoded = decode_base64_string(base64_str.0)?;
-        StaticAnalysisConfigFile::try_from(decoded)
+    fn try_from(WithHint(content, hint): WithHint<String>) -> Result<Self, Self::Error> {
+        Self::from_yaml_content(content, hint)
     }
 }
 
-impl TryFrom<String> for StaticAnalysisConfigFile {
+impl TryFrom<WithHint<Base64String>> for StaticAnalysisConfigFile {
     type Error = ConfigFileError;
 
-    fn try_from(content: String) -> Result<Self, Self::Error> {
-        Self::from_yaml_content(content)
+    fn try_from(WithHint(base64_str, hint): WithHint<Base64String>) -> Result<Self, Self::Error> {
+        let decoded = decode_base64_string(base64_str.0)?;
+        Self::from_yaml_content(decoded, hint)
     }
 }
 
@@ -87,26 +114,27 @@ fn create_ignored_rule() -> RuleConfig {
 
 impl StaticAnalysisConfigFile {
     /// Parses a raw YAML configuration string (not base64-encoded) into a [`StaticAnalysisConfigFile`].
-    fn from_yaml_content(content: String) -> Result<Self, ConfigFileError> {
+    ///
+    /// When `content` is blank, `hint` determines the empty default: [`ConfigFormat::Unified`]
+    /// produces a unified empty file; anything else (including `None`) produces the legacy default.
+    fn from_yaml_content(
+        content: String,
+        hint: Option<ConfigFormat>,
+    ) -> Result<Self, ConfigFileError> {
         use serde::de::Error;
         if content.trim().is_empty() {
-            return Ok(Self::default());
+            return Ok(match hint {
+                Some(ConfigFormat::Unified) => Self::default_unified(),
+                _ => Self::default(),
+            });
         }
-        let parsed = if cfg!(test) {
-            parse_any_schema_yaml(&content).map_err(|err| {
-                match err {
-                    // Artificially represent this as a "parse" error for backwards compatibility.
-                    ConfigError::UnsupportedSchema(_) => ConfigFileError::Parser {
-                        source: serde_yaml::Error::custom(err),
-                    },
-                    ConfigError::Parse(err) => ConfigFileError::Parser { source: err },
-                }
-            })
-        } else {
-            file_legacy::parse_yaml(&content)
-                .map(WithVersion::Legacy)
-                .map_err(|err| ConfigFileError::Parser { source: err })
-        }?;
+        let parsed = parse_any_schema_yaml(&content).map_err(|err| match err {
+            // Artificially represent this as a "parse" error for backwards compatibility.
+            ConfigError::UnsupportedSchema(_) => ConfigFileError::Parser {
+                source: serde_yaml::Error::custom(err),
+            },
+            ConfigError::Parse(err) => ConfigFileError::Parser { source: err },
+        })?;
         let config_file = match parsed {
             WithVersion::Legacy(yaml) => WithVersion::Legacy(file_legacy::ConfigFile::from(yaml)),
             WithVersion::CodeSecurity(yaml) => WithVersion::CodeSecurity(yaml),
@@ -121,26 +149,30 @@ impl StaticAnalysisConfigFile {
     ///
     /// # Parameters
     ///
-    /// * `rule`: The rule to be ignored.
+    /// * `rule`: The fully-qualified rule name (`<ruleset>/<rule>`) to ignore.
     /// * `config_content_base64`: The base64-encoded content of the static analysis configuration file.
+    /// * `declared_format`: The format the caller claims the file is in, derived from the
+    ///   filename or the `schema_version` field of the request.
     ///
     /// # Returns
     ///
-    /// If successful, this function returns a `Result` containing a `String`. The `String` is the updated content of the static analysis configuration file with the specified rule ignored.
+    /// If successful, returns a `String` containing the updated YAML of the configuration file
+    /// with the specified rule ignored.
     ///
     /// # Errors
     ///
-    /// This function will return an error of type `ConfigFileError` if:
+    /// Returns a `ConfigFileError` if:
     ///
     /// * The `config_content_base64` string cannot be base64-decoded.
     /// * The decoded content cannot be parsed as a static analysis configuration file.
+    /// * The detected format of the parsed content does not match `declared_format`.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// let rule = "RULE_TO_IGNORE".into();
+    /// let rule = "ruleset/rule-to-ignore".into();
     /// let config_content_base64 = Base64String(kernel::utils::encode_base64_string("...".to_string()));
-    /// let result = StaticAnalysisConfigFile::with_ignored_rule(rule, config_content_base64);
+    /// let result = StaticAnalysisConfigFile::with_ignored_rule(rule, config_content_base64, ConfigFormat::Legacy);
     /// match result {
     ///     Ok(updated_config) => println!("Updated config: {}", updated_config),
     ///     Err(e) => eprintln!("Error: {}", e),
@@ -150,15 +182,17 @@ impl StaticAnalysisConfigFile {
     pub fn with_ignored_rule(
         rule: Cow<str>,
         config_content_base64: Base64String,
+        declared_format: ConfigFormat,
     ) -> Result<String, ConfigFileError> {
-        let mut config = Self::try_from(config_content_base64).map_err(|e| {
-            tracing::error!(error =?e, "Error trying to parse config file");
-            e
-        })?;
-
+        let mut config = Self::try_from(WithHint(config_content_base64, Some(declared_format)))
+            .map_err(|e| {
+                tracing::error!(error =?e, "Error trying to parse config file");
+                e
+            })?;
+        config.validate_format(declared_format)?;
         config.ignore_rule(rule);
         config.to_string().map_err(|e| {
-            tracing::error!(error =?e, "Error trying to serializing config file");
+            tracing::error!(error =?e, "Error trying to serialize config file");
             e
         })
     }
@@ -211,28 +245,37 @@ impl StaticAnalysisConfigFile {
 
     /// Adds new rulesets to the static analysis configuration file.
     ///
+    /// When `config_content_base64` is `None`, a new file is created in the format implied by
+    /// `declared_format` ([`ConfigFormat::Unified`] → unified schema, [`ConfigFormat::Legacy`] →
+    /// legacy schema). Duplicate rulesets are silently ignored.
+    ///
     /// # Parameters
     ///
     /// * `rulesets`: A slice of strings, where each string is a ruleset to be added.
-    /// * `config_content_base64`: The base64-encoded content of the static analysis configuration file. This is optional.
+    /// * `config_content_base64`: The base64-encoded content of the static analysis configuration
+    ///   file, or `None` to start from an empty file.
+    /// * `declared_format`: The format the caller claims the file is in, derived from the
+    ///   filename or the `schema_version` field of the request.
     ///
     /// # Returns
     ///
-    /// If successful, this function returns a `Result` containing a `String`. The `String` is the updated content of the static analysis configuration file with the new rulesets added.
+    /// If successful, returns a `String` containing the updated YAML of the configuration file
+    /// with the new rulesets added.
     ///
     /// # Errors
     ///
-    /// This function will return an error of type `ConfigFileError` if:
+    /// Returns a `ConfigFileError` if:
     ///
     /// * The `config_content_base64` string cannot be base64-decoded.
     /// * The decoded content cannot be parsed as a static analysis configuration file.
+    /// * The detected format of the parsed content does not match `declared_format`.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// let rulesets = vec!["RULESET_TO_ADD".to_string()];
+    /// let rulesets = vec!["ruleset-to-add".to_string()];
     /// let config_content_base64 = Base64String(kernel::utils::encode_base64_string("...".to_string()));
-    /// let result = StaticAnalysisConfigFile::with_added_rulesets(&rulesets, Some(config_content_base64));
+    /// let result = StaticAnalysisConfigFile::with_added_rulesets(&rulesets, Some(config_content_base64), ConfigFormat::Legacy);
     /// match result {
     ///     Ok(updated_config) => println!("Updated config: {}", updated_config),
     ///     Err(e) => eprintln!("Error: {}", e),
@@ -243,17 +286,26 @@ impl StaticAnalysisConfigFile {
     pub fn with_added_rulesets(
         rulesets: &[impl AsRef<str> + Debug],
         config_content_base64: Option<Base64String>,
+        declared_format: ConfigFormat,
     ) -> Result<String, ConfigFileError> {
-        let mut config = config_content_base64.map_or(Ok(Self::default()), |content| {
-            Self::try_from(content).map_err(|e| {
-                tracing::error!(error =?e, "Error trying to parse config file");
-                e
-            })
-        })?;
-
+        let mut config = match config_content_base64 {
+            Some(content) => {
+                let config =
+                    Self::try_from(WithHint(content, Some(declared_format))).map_err(|e| {
+                        tracing::error!(error = ?e, "Error trying to parse config file");
+                        e
+                    })?;
+                config.validate_format(declared_format)?;
+                config
+            }
+            None => match declared_format {
+                ConfigFormat::Unified => Self::default_unified(),
+                ConfigFormat::Legacy => Self::default(),
+            },
+        };
         config.add_rulesets(rulesets);
         config.to_string().map_err(|e| {
-            tracing::error!(error =?e, "Error trying to serializing config file");
+            tracing::error!(error = ?e, "Error trying to serialize config file");
             e
         })
     }
@@ -308,6 +360,32 @@ impl StaticAnalysisConfigFile {
         }
     }
 
+    /// Returns the config format as detected from the parsed content.
+    fn detected_format(&self) -> ConfigFormat {
+        match &self.config_file {
+            WithVersion::Legacy(_) => ConfigFormat::Legacy,
+            WithVersion::CodeSecurity(_) => ConfigFormat::Unified,
+        }
+    }
+
+    /// Returns `Err(SchemaMismatch)` when the detected format does not match `declared`.
+    pub fn validate_format(&self, declared: ConfigFormat) -> Result<(), ConfigFileError> {
+        if self.detected_format() == declared {
+            Ok(())
+        } else {
+            Err(ConfigFileError::SchemaMismatch)
+        }
+    }
+
+    /// Returns an empty unified-format config, used as the new-file default when
+    /// the IDE declares `schema_version: "v1"` and no existing config is present.
+    fn default_unified() -> Self {
+        Self {
+            config_file: WithVersion::CodeSecurity(Default::default()),
+            original_content: None,
+        }
+    }
+
     /// Serializes the `StaticAnalysisConfigFile` into a YAML string.
     ///
     /// # Returns
@@ -356,7 +434,7 @@ impl StaticAnalysisConfigFile {
 mod tests {
 
     use kernel::utils::encode_base64_string;
-    use crate::datadog_static_analyzer_server::ide::configuration_file::static_analysis_config_file::Base64String;
+    use crate::datadog_static_analyzer_server::ide::configuration_file::static_analysis_config_file::{Base64String, WithHint};
 
     fn to_encoded_content(content: &'static str) -> Base64String {
         Base64String(encode_base64_string(content.to_owned()))
@@ -376,7 +454,7 @@ rulesets:
 - java-1
 ",
             );
-            let config = StaticAnalysisConfigFile::try_from(content).unwrap();
+            let config = StaticAnalysisConfigFile::try_from(WithHint(content, None)).unwrap();
             let rulesets = config.sast_rulesets();
             assert_eq!(rulesets, vec!["java-security", "java-1"]);
         }
@@ -399,7 +477,7 @@ rulesets:
           - "**"
 "#,
             );
-            let config = StaticAnalysisConfigFile::try_from(content).unwrap();
+            let config = StaticAnalysisConfigFile::try_from(WithHint(content, None)).unwrap();
             let rulesets = config.sast_rulesets();
             assert_eq!(rulesets, vec!["java-security", "java-1", "ruleset1"]);
         }
@@ -422,7 +500,7 @@ rulesets:
                 - '**'
 ",
             );
-            let err = StaticAnalysisConfigFile::try_from(content).unwrap_err();
+            let err = StaticAnalysisConfigFile::try_from(WithHint(content, None)).unwrap_err();
             assert_eq!(err.code(), 1);
         }
 
@@ -436,7 +514,7 @@ rulesets:
 - java-1
 ",
             );
-            let err = StaticAnalysisConfigFile::try_from(content).unwrap_err();
+            let err = StaticAnalysisConfigFile::try_from(WithHint(content, None)).unwrap_err();
             assert_eq!(err.code(), 1);
         }
     }
@@ -450,6 +528,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1", "ruleset2", "a-ruleset3"],
                 None,
+                ConfigFormat::Legacy,
             )
             .unwrap();
             let expected = r"
@@ -467,6 +546,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1"],
                 Some(to_encoded_content("\n")),
+                ConfigFormat::Legacy,
             )
             .unwrap();
             let expected = r"
@@ -500,6 +580,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1", "ruleset2", "a-ruleset3"],
                 Some(to_encoded_content(legacy)),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -525,6 +606,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["new-ruleset", "new-ruleset"],
                 Some(to_encoded_content(legacy)),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -553,6 +635,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1", "ruleset2", "a-ruleset3"],
                 Some(content),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -591,10 +674,115 @@ rulesets:
             let err = StaticAnalysisConfigFile::with_added_rulesets(
                 &["ruleset1", "ruleset2", "a-ruleset3"],
                 Some(content),
+                ConfigFormat::Legacy,
             )
             .unwrap_err();
 
             assert_eq!(err.code(), 1);
+        }
+
+        #[test]
+        fn it_creates_new_unified_file_when_no_existing_content() {
+            let config = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1", "ruleset2"],
+                None,
+                ConfigFormat::Unified,
+            )
+            .unwrap();
+
+            assert!(config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("ruleset1"), "body: {config}");
+            assert!(config.contains("ruleset2"), "body: {config}");
+        }
+
+        #[test]
+        fn it_works_simple_unified() {
+            // language=yaml
+            let unified = r"
+schema-version: v1.0
+sast:
+  use-rulesets:
+    - python-security
+";
+            let config = StaticAnalysisConfigFile::with_added_rulesets(
+                &["java-security"],
+                Some(to_encoded_content(unified)),
+                ConfigFormat::Unified,
+            )
+            .unwrap();
+
+            assert!(config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("python-security"), "body: {config}");
+            assert!(config.contains("java-security"), "body: {config}");
+        }
+
+        #[test]
+        fn it_fails_if_schema_mismatch_legacy_declared_as_unified() {
+            // language=yaml
+            let legacy = to_encoded_content(
+                r"
+schema-version: v1
+rulesets:
+- java-security
+",
+            );
+            let err = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1"],
+                Some(legacy),
+                ConfigFormat::Unified,
+            )
+            .unwrap_err();
+
+            assert_eq!(err.code(), 4);
+        }
+
+        #[test]
+        fn it_fails_if_schema_mismatch_unified_declared_as_legacy() {
+            // language=yaml
+            let unified = to_encoded_content(
+                r"
+schema-version: v1.0
+sast:
+  use-rulesets:
+    - java-security
+",
+            );
+            let err = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1"],
+                Some(unified),
+                ConfigFormat::Legacy,
+            )
+            .unwrap_err();
+
+            assert_eq!(err.code(), 4);
+        }
+
+        #[test]
+        fn empty_content_with_unified_format_creates_unified_default() {
+            let config = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1", "ruleset2"],
+                Some(to_encoded_content("\n")),
+                ConfigFormat::Unified,
+            )
+            .unwrap();
+
+            assert!(config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("ruleset1"), "body: {config}");
+            assert!(config.contains("ruleset2"), "body: {config}");
+        }
+
+        #[test]
+        fn empty_content_with_legacy_format_creates_legacy_default() {
+            let config = StaticAnalysisConfigFile::with_added_rulesets(
+                &["ruleset1", "ruleset2"],
+                Some(to_encoded_content("\n")),
+                ConfigFormat::Legacy,
+            )
+            .unwrap();
+
+            assert!(!config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("ruleset1"), "body: {config}");
+            assert!(config.contains("ruleset2"), "body: {config}");
         }
     }
 
@@ -627,6 +815,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_ignored_rule(
                 "ruleset1/rule1".into(),
                 to_encoded_content(legacy),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -659,6 +848,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_ignored_rule(
                 "ruleset1/rule1".into(),
                 to_encoded_content(legacy),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -700,6 +890,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_ignored_rule(
                 "ruleset1/rule1".into(),
                 to_encoded_content(legacy),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -722,9 +913,12 @@ rulesets:
       - foo/bar
 ",
             );
-            let config =
-                StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
-                    .unwrap();
+            let config = StaticAnalysisConfigFile::with_ignored_rule(
+                "ruleset1/rule1".into(),
+                content,
+                ConfigFormat::Legacy,
+            )
+            .unwrap();
 
             // language=yaml
             let expected = r#"
@@ -755,8 +949,12 @@ rulesets:
 - java-1
 ",
             );
-            let err = StaticAnalysisConfigFile::with_ignored_rule("ruleset1/rule1".into(), content)
-                .unwrap_err();
+            let err = StaticAnalysisConfigFile::with_ignored_rule(
+                "ruleset1/rule1".into(),
+                content,
+                ConfigFormat::Legacy,
+            )
+            .unwrap_err();
 
             assert_eq!(err.code(), 1);
         }
@@ -792,6 +990,7 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_ignored_rule(
                 "ruleset1/rule1".into(),
                 to_encoded_content(legacy),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
@@ -828,10 +1027,87 @@ rulesets:
             let config = StaticAnalysisConfigFile::with_ignored_rule(
                 "ruleset1/rule2".into(),
                 to_encoded_content(legacy),
+                ConfigFormat::Legacy,
             )
             .unwrap();
 
             assert_eq!(config.trim(), legacy_expected.trim());
+        }
+
+        #[test]
+        fn it_works_with_unified_content() {
+            // language=yaml
+            let unified = r"
+schema-version: v1.0
+sast:
+  use-rulesets:
+    - ruleset1
+";
+            let config = StaticAnalysisConfigFile::with_ignored_rule(
+                "ruleset1/rule1".into(),
+                to_encoded_content(unified),
+                ConfigFormat::Unified,
+            )
+            .unwrap();
+
+            assert!(config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("ruleset1"), "body: {config}");
+            assert!(config.contains("rule1"), "body: {config}");
+        }
+
+        #[test]
+        fn it_fails_if_schema_mismatch_legacy_declared_as_unified() {
+            // language=yaml
+            let legacy = to_encoded_content(
+                r"
+schema-version: v1
+rulesets:
+- java-security
+",
+            );
+            let err = StaticAnalysisConfigFile::with_ignored_rule(
+                "java-security/rule1".into(),
+                legacy,
+                ConfigFormat::Unified,
+            )
+            .unwrap_err();
+
+            assert_eq!(err.code(), 4);
+        }
+
+        #[test]
+        fn it_fails_if_schema_mismatch_unified_declared_as_legacy() {
+            // language=yaml
+            let unified = to_encoded_content(
+                r"
+schema-version: v1.0
+sast:
+  use-rulesets:
+    - java-security
+",
+            );
+            let err = StaticAnalysisConfigFile::with_ignored_rule(
+                "java-security/rule1".into(),
+                unified,
+                ConfigFormat::Legacy,
+            )
+            .unwrap_err();
+
+            assert_eq!(err.code(), 4);
+        }
+
+        #[test]
+        fn empty_content_with_unified_format_ignores_rule() {
+            let config = StaticAnalysisConfigFile::with_ignored_rule(
+                "ruleset1/rule1".into(),
+                to_encoded_content("\n"),
+                ConfigFormat::Unified,
+            )
+            .unwrap();
+
+            assert!(config.contains("schema-version: v1.0"), "body: {config}");
+            assert!(config.contains("ruleset1"), "body: {config}");
+            assert!(config.contains("rule1"), "body: {config}");
         }
     }
 
@@ -906,7 +1182,9 @@ sast:
                 v1_ignore,
                 v1_both,
             ] {
-                let config = StaticAnalysisConfigFile::try_from(to_encoded_content(yaml)).unwrap();
+                let config =
+                    StaticAnalysisConfigFile::try_from(WithHint(to_encoded_content(yaml), None))
+                        .unwrap();
                 assert!(!config.is_onboarding_allowed())
             }
         }
@@ -934,7 +1212,9 @@ sast:
 ";
 
             for yaml in [legacy, v1_no_sast, v1_with_sast_global] {
-                let config = StaticAnalysisConfigFile::try_from(to_encoded_content(yaml)).unwrap();
+                let config =
+                    StaticAnalysisConfigFile::try_from(WithHint(to_encoded_content(yaml), None))
+                        .unwrap();
                 assert!(config.is_onboarding_allowed())
             }
         }
@@ -961,7 +1241,9 @@ sast:
 ";
 
             for yaml in [legacy, v1] {
-                let config = StaticAnalysisConfigFile::try_from(to_encoded_content(yaml)).unwrap();
+                let config =
+                    StaticAnalysisConfigFile::try_from(WithHint(to_encoded_content(yaml), None))
+                        .unwrap();
                 assert!(config.is_onboarding_allowed())
             }
         }
@@ -970,7 +1252,8 @@ sast:
     #[test]
     fn try_from_returns_default_config_file_if_empty_string() {
         let expected = super::StaticAnalysisConfigFile::default();
-        let config = super::StaticAnalysisConfigFile::try_from(String::new()).unwrap();
+        let config =
+            super::StaticAnalysisConfigFile::try_from(WithHint(String::new(), None)).unwrap();
         assert_eq!(config, expected);
     }
 
@@ -992,6 +1275,7 @@ rulesets:
         let config = super::StaticAnalysisConfigFile::with_added_rulesets(
             &["ruleset1", "ruleset2", "a-ruleset3"],
             Some(content),
+            super::ConfigFormat::Legacy,
         )
         .unwrap();
 

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/configuration_file/static_analysis_config_file.rs
@@ -24,11 +24,16 @@ pub enum ConfigFormat {
 
 impl<'a> From<Option<&'a str>> for ConfigFormat {
     /// Maps the IDE-supplied `schema_version` string to a [`ConfigFormat`].
+    ///
+    /// Accepted values for [`ConfigFormat::Unified`]:
+    /// - `"v1"` — legacy wire value sent by older extension versions (kept for backward compat)
+    /// - `"UNIFIED"` — canonical value sent by newer extension versions
+    ///
     /// Absent or unrecognized values default to [`ConfigFormat::Legacy`] for backward
     /// compatibility with older extensions that never sent this field.
     fn from(schema_version: Option<&'a str>) -> Self {
         match schema_version {
-            Some("v1") => Self::Unified,
+            Some("v1") | Some("UNIFIED") => Self::Unified,
             _ => Self::Legacy,
         }
     }
@@ -378,7 +383,7 @@ impl StaticAnalysisConfigFile {
     }
 
     /// Returns an empty unified-format config, used as the new-file default when
-    /// the IDE declares `schema_version: "v1"` and no existing config is present.
+    /// the IDE declares `schema_version: "UNIFIED"` and no existing config is present.
     fn default_unified() -> Self {
         Self {
             config_file: WithVersion::CodeSecurity(Default::default()),

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -549,7 +549,7 @@ rulesets:
             ))
             .dispatch();
 
-        assert_eq!(response.status(), Status::InternalServerError);
+        assert_eq!(response.status(), Status::BadRequest);
     }
 
     #[test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -128,7 +128,7 @@ rulesets:
 
         let response = client.get(uri).dispatch();
 
-        assert_eq!(response.status(), Status::InternalServerError);
+        assert_eq!(response.status(), Status::BadRequest);
         assert!(response.into_string().contains("Error parsing yaml file"));
     }
 
@@ -570,7 +570,7 @@ rulesets:
             ))
             .dispatch();
 
-        assert_eq!(response.status(), Status::InternalServerError);
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     #[test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -478,7 +478,7 @@ rulesets:
             )
             .dispatch();
 
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::UnprocessableEntity);
         assert!(response
             .into_string()
             .unwrap()
@@ -503,7 +503,7 @@ rulesets:
             .dispatch();
 
         // absent schema_version defaults to LEGACY; unified content is a mismatch
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     /// Backward compat: old extensions send legacy content without schema_version — must work.
@@ -549,7 +549,7 @@ rulesets:
             ))
             .dispatch();
 
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     #[test]

--- a/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
+++ b/crates/bins/src/bin/datadog_static_analyzer_server/ide/mod.rs
@@ -61,6 +61,15 @@ rulesets:
 - java-1-??
 - java-security"#;
 
+    const UNIFIED_CONFIGURATION: &'static str = r#"schema-version: v1.0
+sast:
+  use-rulesets:
+    - python-security
+    - java-security
+"#;
+
+    const UNIFIED_CONFIGURATION_NO_RULESETS: &'static str = "schema-version: v1.0\n";
+
     #[test]
     fn post_ignore_rule() {
         let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
@@ -423,5 +432,192 @@ rulesets:
 
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.into_string().unwrap(), expected);
+    }
+
+    // --- schema_version strict validation ---
+
+    #[test]
+    fn parse_config_accepts_unified_content_with_v1_schema_version() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": UNIFIED_CONFIGURATION,
+                    "schema_version": "v1",
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        assert!(body.contains("python-security"));
+        assert!(body.contains("java-security"));
+    }
+
+    #[test]
+    fn parse_config_rejects_legacy_content_declared_as_unified() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": NORMAL_CONFIGURATION,
+                    "schema_version": "v1",
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        assert_eq!(response.status(), Status::BadRequest);
+        assert!(response
+            .into_string()
+            .unwrap()
+            .contains("does not match the declared schema version"));
+    }
+
+    #[test]
+    fn parse_config_rejects_unified_content_with_no_schema_version() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": UNIFIED_CONFIGURATION,
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        // absent schema_version defaults to LEGACY; unified content is a mismatch
+        assert_eq!(response.status(), Status::BadRequest);
+    }
+
+    /// Backward compat: old extensions send legacy content without schema_version — must work.
+    #[test]
+    fn parse_config_backward_compat_legacy_content_no_schema_version() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_parse_config
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "configuration": NORMAL_CONFIGURATION,
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(
+            response.into_string().unwrap(),
+            r#"{"sast":{"rulesets":["java-1","java-security"]}}"#
+        );
+    }
+
+    #[test]
+    fn ignore_rule_rejects_schema_version_mismatch() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+        let config = encode_base64_string(NORMAL_CONFIGURATION.to_string());
+
+        let response = client
+            .post(uri!(super::configuration_file::endpoints::post_ignore_rule))
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{
+                "rule": "ruleset1/rule1",
+                "configuration": "{config}",
+                "encoded": false,
+                "schema_version": "v1"
+            }}"#
+            ))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::InternalServerError);
+    }
+
+    #[test]
+    fn can_onboard_v2_rejects_schema_version_mismatch() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+        let config = encode_base64_string(NORMAL_CONFIGURATION.to_string());
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_can_onboard_v2
+            ))
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{
+                "configuration": "{config}",
+                "schema_version": "v1"
+            }}"#
+            ))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::InternalServerError);
+    }
+
+    #[test]
+    fn add_rulesets_creates_unified_file_when_schema_version_v1() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_add_rulesets_v2
+            ))
+            .header(ContentType::JSON)
+            .body(
+                serde_json::json!({
+                    "rulesets": ["python-security"],
+                    "encoded": false,
+                    "schema_version": "v1",
+                })
+                .to_string(),
+            )
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().unwrap();
+        // unified format uses schema-version: v1.0
+        assert!(body.contains("schema-version: v1.0"), "body: {body}");
+        assert!(body.contains("python-security"), "body: {body}");
+    }
+
+    #[test]
+    fn can_onboard_v2_accepts_unified_content_with_v1_schema_version() {
+        let client = Client::tracked(mount_rocket()).expect("valid rocket instance");
+        let config = encode_base64_string(UNIFIED_CONFIGURATION_NO_RULESETS.to_string());
+
+        let response = client
+            .post(uri!(
+                super::configuration_file::endpoints::post_can_onboard_v2
+            ))
+            .header(ContentType::JSON)
+            .body(format!(
+                r#"{{
+                "configuration": "{config}",
+                "schema_version": "v1"
+            }}"#
+            ))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().unwrap(), "true");
     }
 }

--- a/crates/static-analysis-kernel/src/config/file_v1.rs
+++ b/crates/static-analysis-kernel/src/config/file_v1.rs
@@ -38,6 +38,19 @@ pub struct YamlConfigFile {
     pub(crate) iast: Option<serde_yaml::Value>,
 }
 
+impl Default for YamlConfigFile {
+    fn default() -> Self {
+        Self {
+            schema_version: YamlSchemaVersion::MajorMinor((1, 0)),
+            sast: None,
+            secrets: None,
+            iac: None,
+            sca: None,
+            iast: None,
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for YamlConfigFile {
     fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
## Context

As part of the work described in [Section 4 — Prerequisite: Unified Config File Support](https://docs.google.com/document/d/1L4rdpTwafiVxFn1HIlSw0f6cJ61GihDOzMFvZwuzlMw/edit?tab=t.0#heading=h.mr90lg23mmfd), the static-analyzer server needs to understand both the legacy `static-analysis.datadog.yml` format and the new unified `code-security.datadog.yaml` format (schema version `v1.0`), so the VS Code extension can drive mutations against whichever file the user has.

The dd-source backend already supports `schema_version=v1` (unified) on `POST /api/v2/static-analysis/config/client`. This PR covers only the **local static-analyzer server** side — the VS Code extension changes will follow in a [separate PR](https://github.com/DataDog/datadog-vscode/pull/2459).

## Problem

The server had two issues that would prevent it from being usable as a unified-config host:

1. **Production parsing was locked to legacy.** `from_yaml_content` called `parse_any_schema_yaml` only under `cfg!(test)` and `file_legacy::parse_yaml` in release builds. A `code-security.datadog.yaml` sent to the server would silently be parsed as legacy content — or fail without a useful error — making every mutation endpoint incorrect for unified files.

2. **No format signal on mutation/validation requests.** Endpoints like `ignore-rule`, `add-rulesets`, and `can-onboard` had no way for the caller to declare what format the file is in. Without that signal, the server could not validate that the content matches the declared filename format (matching CLI behaviour), could not pick the right empty-file default when creating a new config, and could not produce the correct YAML serialization on write-back.

3. **Blank-content edge case.** When an existing but empty `code-security.datadog.yaml` (e.g. just created, content = `base64("\n")`) was sent to `add-rulesets`, `from_yaml_content`'s early-return for blank content always yielded a legacy default, which then failed `validate_format(Unified)` with `SchemaMismatch` even though there was nothing wrong.

## Approach: Option A — `schema_version` field on existing routes, no new routes

Following the design in the RFC above, format is signalled via an optional `schema_version` field added to the JSON body of existing endpoints. This avoids proliferating product-scoped routes: the IDE determines format from the filename, sends it as `"v1"` (unified) or omits it (legacy), and the server validates accordingly.

**Backward compatibility is a hard requirement.** Old extensions that never send `schema_version` must continue to work unchanged. This is guaranteed by:
- `schema_version` is `#[serde(default)] Option<String>` on every request struct — missing field deserializes as `None`.
- `None` → `ConfigFormat::Legacy` everywhere.
- No `#[serde(deny_unknown_fields)]` on request structs, so a new extension talking to an old binary simply has its `schema_version` field ignored.

## What changed

### `static_analysis_config_file.rs`

- **Un-gated dual-format parsing.** Removed the `cfg!(test)` guard; production now always calls `parse_any_schema_yaml`, which detects the actual schema variant and stores it in `WithVersion<Legacy, CodeSecurity>`.
- **`ConfigFormat` enum + `detected_format()` accessor.** `ConfigFormat::Legacy` / `ConfigFormat::Unified` derived from the `WithVersion` discriminant. Used everywhere format validation is needed.
- **`validate_format(declared)`** method returns `Err(SchemaMismatch)` when detected ≠ declared, mirroring CLI filename-strict behaviour.
- **`default_unified()` constructor.** Returns an empty `WithVersion::CodeSecurity` config — used when `add-rulesets` is called with no existing content and `schema_version=v1`.
- **`WithHint<T>` wrapper + new `TryFrom` impls.** Replaces the old format-unaware `TryFrom<String>` / `TryFrom<Base64String>`. `WithHint<T>(T, Option<ConfigFormat>)` carries the caller's declared format so `from_yaml_content` can pick the right empty default. Callers with `schema_version` pass `Some(format)`; deprecated/legacy routes pass `None`.
- **Bug fix — blank content edge case.** `from_yaml_content` now accepts `Option<ConfigFormat> hint`; when content is blank it returns `default_unified()` for `Some(Unified)` and the legacy default otherwise. This prevents `add-rulesets` and `ignore-rule` from failing with `SchemaMismatch` when a `code-security.datadog.yaml` exists but is empty.
- **`with_ignored_rule` and `with_added_rulesets`** updated to forward `declared_format` via `WithHint`.

### `models.rs`

Added `#[serde(default)] schema_version: Option<String>` to:
- `IgnoreRuleRequest`
- `AddRuleSetsRequest`
- `CanOnboardRequest`
- `ParseConfigRequest`

### `endpoints.rs`

- **`post_parse_config`** — now accepts `schema_version`; constructs via `WithHint(configuration, Some(format))`, then calls `validate_format` — returns `400` on mismatch.
- **`post_can_onboard_v2`** — now accepts `schema_version`; same parse + validate pattern; returns `500` on mismatch (existing error path the client already treats as blocking).
- **`post_ignore_rule` / `add_rulesets`** — delegate to the updated `with_ignored_rule` / `with_added_rulesets` which now carry the format hint.
- **Deprecated routes** (`get_can_onboard`, `get_rulesets`) updated to `WithHint(..., None)` — legacy-default, no behaviour change.

### `error.rs`

Added `SchemaMismatch` variant (`code: 4`) to `ConfigFileError`.

### `mod.rs` (IDE integration tests)

Extended the test suite with coverage for:
- Strict parse: unified content + `schema_version=v1` → 200; legacy content + `schema_version=v1` → 400 (`SchemaMismatch`); unified content + no `schema_version` → 400.
- Mutation (`add-rulesets`, `ignore-rule`) format validation.
- `can-onboard` with `schema_version`.
- Backward compat: legacy content + no `schema_version` → behaves as today.
- Empty content + `schema_version=v1` → creates a unified default file.

### `file_v1.rs`

Added `Default` impl for `YamlConfigFile`, needed by `default_unified()`.

## Validation

`cargo test` ->? 77 tests, all pass 
`cargo fmt -- --check` -> clean 
`cargo clippy -- -D warnings` -> clean

Retrocompatibility: Tested this binary with the current extension and it works. 

## What's not in this PR

The VS Code extension changes (unified-first discovery, sending `schema_version` in request bodies, binary version gate, etc.) are the next step and will be in a separate PR against the `datadog-vscode` repo.


K9CODESEC-2169
K9CODESEC-2303

