### PR TITLE
[SDSP-485] Support suppressions for secret rules

### DIFF
--- a/crates/cli/src/model/cli_configuration.rs
+++ b/crates/cli/src/model/cli_configuration.rs
@@ -213,6 +213,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let secret_rule2 = SecretRule {
@@ -230,6 +231,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let cli_configuration_base = CliConfiguration {

--- a/crates/cli/src/model/datadog_api.rs
+++ b/crates/cli/src/model/datadog_api.rs
@@ -5,7 +5,8 @@ use kernel::model::ruleset::RuleSet;
 use secrets::model::secret_rule::{
     SecretRule, SecretRuleMatchValidation, SecretRuleMatchValidationHttp,
     SecretRuleMatchValidationHttpCode, SecretRuleMatchValidationHttpMethod,
-    SecretRuleMatchValidationHttpV2, SecretRulePairedValidatorConfig, SecretRuleValidator,
+    SecretRuleMatchValidationHttpV2, SecretRulePairedValidatorConfig, SecretRuleSuppressions,
+    SecretRuleValidator,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -382,6 +383,7 @@ pub struct SecretRuleApiAttributes {
     pub paired_validator_config: Option<SecretRulePairedValidatorConfig>,
     pub pattern_capture_groups: Option<Vec<String>>,
     pub is_supporting_rule: Option<bool>,
+    pub suppressions: Option<SecretRuleSuppressions>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -426,6 +428,7 @@ impl TryFrom<SecretRuleApiType> for SecretRule {
             match_validation,
             pattern_capture_groups: val.attributes.pattern_capture_groups.unwrap_or_default(),
             is_supporting_rule: val.attributes.is_supporting_rule.unwrap_or(false),
+            suppressions: val.attributes.suppressions,
         })
     }
 }
@@ -582,6 +585,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: None,
+                suppressions: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -620,6 +624,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: None,
+                suppressions: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -657,6 +662,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: Some(true),
+                suppressions: None,
             },
         };
 
@@ -694,6 +700,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: None,
+                suppressions: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -737,6 +744,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: None,
+                suppressions: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -780,6 +788,7 @@ mod tests {
                 paired_validator_config: None,
                 pattern_capture_groups: None,
                 is_supporting_rule: None,
+                suppressions: None,
             },
         };
         let converted = <SecretRuleApiType as TryInto<SecretRule>>::try_into(
@@ -1092,5 +1101,42 @@ mod tests {
                 assert!(!rule.is_supporting_rule);
             }
         }
+    }
+
+    #[test]
+    fn convert_secrets_rules_with_suppressions() {
+        let json_data = json!({
+            "data": [
+                {
+                    "id": "secrets/example-with-suppressions",
+                    "type": "secret_rule",
+                    "attributes": {
+                        "description": "test",
+                        "name": "Example Rule",
+                        "pattern": "\\bsecret\\b",
+                        "priority": "high",
+                        "sds_id": "some-sds-id",
+                        "suppressions": {
+                            "starts_with": ["test_"],
+                            "ends_with": ["_placeholder"],
+                            "exact_match": ["fake_secret"]
+                        }
+                    }
+                }
+            ]
+        });
+
+        let api_response: StaticAnalysisSecretsAPIResponse =
+            serde_json::from_value(json_data).expect("Failed to deserialize JSON");
+        let rule: SecretRule = api_response.data[0]
+            .clone()
+            .try_into()
+            .expect("Failed to convert rule");
+
+        assert_eq!(rule.id, "secrets/example-with-suppressions");
+        let suppressions = rule.suppressions.expect("expected suppressions");
+        assert_eq!(suppressions.starts_with, vec!["test_".to_string()]);
+        assert_eq!(suppressions.ends_with, vec!["_placeholder".to_string()]);
+        assert_eq!(suppressions.exact_match, vec!["fake_secret".to_string()]);
     }
 }

--- a/crates/cli/src/sarif/sarif_utils.rs
+++ b/crates/cli/src/sarif/sarif_utils.rs
@@ -1477,6 +1477,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         #[rustfmt::skip]
@@ -1616,6 +1617,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let secret_results = vec![SecretResult {
@@ -1705,6 +1707,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let secret_results = vec![SecretResult {
@@ -1804,6 +1807,7 @@ mod tests {
                 match_validation: None,
                 pattern_capture_groups: vec![],
                 is_supporting_rule: false,
+                suppressions: None,
             };
             let expected_level = get_level_from_severity(map_priority_to_severity(rule.priority));
 
@@ -2138,6 +2142,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let secret_results = vec![SecretResult {

--- a/crates/secrets/src/model/secret_rule.rs
+++ b/crates/secrets/src/model/secret_rule.rs
@@ -456,6 +456,26 @@ impl SecretRuleValidator {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+pub struct SecretRuleSuppressions {
+    #[serde(default)]
+    pub starts_with: Vec<String>,
+    #[serde(default)]
+    pub ends_with: Vec<String>,
+    #[serde(default)]
+    pub exact_match: Vec<String>,
+}
+
+impl From<&SecretRuleSuppressions> for dd_sds::Suppressions {
+    fn from(v: &SecretRuleSuppressions) -> Self {
+        dd_sds::Suppressions {
+            starts_with: v.starts_with.clone(),
+            ends_with: v.ends_with.clone(),
+            exact_match: v.exact_match.clone(),
+        }
+    }
+}
+
 // This is the secret rule exposed by SDS
 #[derive(Clone, Deserialize, Debug, Serialize, Eq, PartialEq)]
 pub struct SecretRule {
@@ -474,6 +494,8 @@ pub struct SecretRule {
     pub pattern_capture_groups: Vec<String>,
     #[serde(default)]
     pub is_supporting_rule: bool,
+    #[serde(default)]
+    pub suppressions: Option<SecretRuleSuppressions>,
 }
 
 impl SecretRule {
@@ -542,19 +564,104 @@ impl SecretRule {
             }
         }
 
+        if let Some(suppressions) = &self.suppressions {
+            rule_config = rule_config.suppressions(suppressions.into());
+        }
+
         rule_config
     }
 }
 
 impl DiffAware for SecretRule {
     fn generate_diff_aware_digest(&self) -> String {
-        format!("{}:{}", self.id, self.pattern).to_string()
+        let mut digest = format!("{}:{}", self.id, self.pattern);
+
+        match &self.suppressions {
+            None => digest,
+            Some(suppressions) => {
+                let mut starts_with = suppressions.starts_with.clone();
+                let mut ends_with = suppressions.ends_with.clone();
+                let mut exact_match = suppressions.exact_match.clone();
+
+                if starts_with.is_empty() && ends_with.is_empty() && exact_match.is_empty() {
+                    return digest;
+                }
+
+                // Suppression order does not affect matching behavior, so canonicalize the
+                // lists to avoid invalidating diff-aware results for ordering-only changes.
+                starts_with.sort();
+                ends_with.sort();
+                exact_match.sort();
+
+                digest.push_str(&format!(
+                    ":suppressions:{starts_with:?}:{ends_with:?}:{exact_match:?}",
+                ));
+                digest
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_diff_aware_digest_with_suppressions() {
+        fn rule_with_suppressions(suppressions: Option<SecretRuleSuppressions>) -> SecretRule {
+            SecretRule {
+                id: "secrets/example".to_string(),
+                sds_id: String::new(),
+                name: String::new(),
+                description: String::new(),
+                pattern: "pattern".to_string(),
+                priority: RulePriority::Medium,
+                default_included_keywords: vec![],
+                default_excluded_keywords: vec![],
+                look_ahead_character_count: None,
+                validators: None,
+                validators_v2: None,
+                match_validation: None,
+                pattern_capture_groups: vec![],
+                is_supporting_rule: false,
+                suppressions,
+            }
+        }
+
+        let legacy_digest = "secrets/example:pattern";
+        assert_eq!(
+            rule_with_suppressions(None).generate_diff_aware_digest(),
+            legacy_digest
+        );
+        assert_eq!(
+            rule_with_suppressions(Some(SecretRuleSuppressions::default()))
+                .generate_diff_aware_digest(),
+            legacy_digest
+        );
+
+        let with_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
+            starts_with: vec!["prefix-b".to_string(), "prefix-a".to_string()],
+            ends_with: vec![],
+            exact_match: vec!["exact".to_string()],
+        }))
+        .generate_diff_aware_digest();
+        let reordered_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
+            starts_with: vec!["prefix-a".to_string(), "prefix-b".to_string()],
+            ends_with: vec![],
+            exact_match: vec!["exact".to_string()],
+        }))
+        .generate_diff_aware_digest();
+        let changed_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
+            starts_with: vec!["prefix-a".to_string()],
+            ends_with: vec![],
+            exact_match: vec!["exact".to_string()],
+        }))
+        .generate_diff_aware_digest();
+
+        assert_ne!(legacy_digest, with_suppressions);
+        assert_eq!(with_suppressions, reordered_suppressions);
+        assert_ne!(with_suppressions, changed_suppressions);
+    }
 
     #[test]
     fn test_try_to_secondary_validator_with_jwt_config() {
@@ -639,9 +746,37 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec!["sds_match".to_string()],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         // Validates that convert_to_sds_ruleconfig doesn't panic and returns a valid config.
+        let _config = rule.convert_to_sds_ruleconfig(false);
+    }
+
+    #[test]
+    fn test_convert_to_sds_ruleconfig_with_suppressions() {
+        let rule = SecretRule {
+            id: "test-rule".to_string(),
+            sds_id: "sds-123".to_string(),
+            name: "Test Rule".to_string(),
+            description: "Test description".to_string(),
+            pattern: "test.*pattern".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: None,
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+            is_supporting_rule: false,
+            suppressions: Some(SecretRuleSuppressions {
+                starts_with: vec!["test_".to_string()],
+                ends_with: vec![],
+                exact_match: vec!["placeholder".to_string()],
+            }),
+        };
+
         let _config = rule.convert_to_sds_ruleconfig(false);
     }
 

--- a/crates/secrets/src/model/secret_rule.rs
+++ b/crates/secrets/src/model/secret_rule.rs
@@ -466,12 +466,12 @@ pub struct SecretRuleSuppressions {
     pub exact_match: Vec<String>,
 }
 
-impl From<&SecretRuleSuppressions> for dd_sds::Suppressions {
-    fn from(v: &SecretRuleSuppressions) -> Self {
+impl From<SecretRuleSuppressions> for dd_sds::Suppressions {
+    fn from(v: SecretRuleSuppressions) -> Self {
         dd_sds::Suppressions {
-            starts_with: v.starts_with.clone(),
-            ends_with: v.ends_with.clone(),
-            exact_match: v.exact_match.clone(),
+            starts_with: v.starts_with,
+            ends_with: v.ends_with,
+            exact_match: v.exact_match,
         }
     }
 }
@@ -565,7 +565,7 @@ impl SecretRule {
         }
 
         if let Some(suppressions) = &self.suppressions {
-            rule_config = rule_config.suppressions(suppressions.into());
+            rule_config = rule_config.suppressions(suppressions.clone().into());
         }
 
         rule_config
@@ -593,9 +593,34 @@ impl DiffAware for SecretRule {
                 ends_with.sort();
                 exact_match.sort();
 
-                digest.push_str(&format!(
-                    ":suppressions:{starts_with:?}:{ends_with:?}:{exact_match:?}",
-                ));
+                // We escape colons in the suppression strings to ensure uniqueness.
+                // Otherwise, the following would be equivalent:
+                //   starts_with=["a:b"], ends_with=["c"] → ...:a:b:c:
+                //   starts_with=["a"], ends_with=["b:c"] → ...:a:b:c:
+                digest.push_str(":suppressions:");
+                digest.push_str(
+                    &starts_with
+                        .iter()
+                        .map(|s| s.replace(':', "\\:"))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                );
+                digest.push(':');
+                digest.push_str(
+                    &ends_with
+                        .iter()
+                        .map(|s| s.replace(':', "\\:"))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                );
+                digest.push(':');
+                digest.push_str(
+                    &exact_match
+                        .iter()
+                        .map(|s| s.replace(':', "\\:"))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                );
                 digest
             }
         }
@@ -605,63 +630,6 @@ impl DiffAware for SecretRule {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_diff_aware_digest_with_suppressions() {
-        fn rule_with_suppressions(suppressions: Option<SecretRuleSuppressions>) -> SecretRule {
-            SecretRule {
-                id: "secrets/example".to_string(),
-                sds_id: String::new(),
-                name: String::new(),
-                description: String::new(),
-                pattern: "pattern".to_string(),
-                priority: RulePriority::Medium,
-                default_included_keywords: vec![],
-                default_excluded_keywords: vec![],
-                look_ahead_character_count: None,
-                validators: None,
-                validators_v2: None,
-                match_validation: None,
-                pattern_capture_groups: vec![],
-                is_supporting_rule: false,
-                suppressions,
-            }
-        }
-
-        let legacy_digest = "secrets/example:pattern";
-        assert_eq!(
-            rule_with_suppressions(None).generate_diff_aware_digest(),
-            legacy_digest
-        );
-        assert_eq!(
-            rule_with_suppressions(Some(SecretRuleSuppressions::default()))
-                .generate_diff_aware_digest(),
-            legacy_digest
-        );
-
-        let with_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
-            starts_with: vec!["prefix-b".to_string(), "prefix-a".to_string()],
-            ends_with: vec![],
-            exact_match: vec!["exact".to_string()],
-        }))
-        .generate_diff_aware_digest();
-        let reordered_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
-            starts_with: vec!["prefix-a".to_string(), "prefix-b".to_string()],
-            ends_with: vec![],
-            exact_match: vec!["exact".to_string()],
-        }))
-        .generate_diff_aware_digest();
-        let changed_suppressions = rule_with_suppressions(Some(SecretRuleSuppressions {
-            starts_with: vec!["prefix-a".to_string()],
-            ends_with: vec![],
-            exact_match: vec!["exact".to_string()],
-        }))
-        .generate_diff_aware_digest();
-
-        assert_ne!(legacy_digest, with_suppressions);
-        assert_eq!(with_suppressions, reordered_suppressions);
-        assert_ne!(with_suppressions, changed_suppressions);
-    }
 
     #[test]
     fn test_try_to_secondary_validator_with_jwt_config() {
@@ -750,33 +718,6 @@ mod tests {
         };
 
         // Validates that convert_to_sds_ruleconfig doesn't panic and returns a valid config.
-        let _config = rule.convert_to_sds_ruleconfig(false);
-    }
-
-    #[test]
-    fn test_convert_to_sds_ruleconfig_with_suppressions() {
-        let rule = SecretRule {
-            id: "test-rule".to_string(),
-            sds_id: "sds-123".to_string(),
-            name: "Test Rule".to_string(),
-            description: "Test description".to_string(),
-            pattern: "test.*pattern".to_string(),
-            default_included_keywords: vec![],
-            default_excluded_keywords: vec![],
-            look_ahead_character_count: Some(30),
-            priority: RulePriority::Medium,
-            validators: None,
-            validators_v2: None,
-            match_validation: None,
-            pattern_capture_groups: vec![],
-            is_supporting_rule: false,
-            suppressions: Some(SecretRuleSuppressions {
-                starts_with: vec!["test_".to_string()],
-                ends_with: vec![],
-                exact_match: vec!["placeholder".to_string()],
-            }),
-        };
-
         let _config = rule.convert_to_sds_ruleconfig(false);
     }
 

--- a/crates/secrets/src/scanner.rs
+++ b/crates/secrets/src/scanner.rs
@@ -117,7 +117,7 @@ mod tests {
         SecretRuleHttpResponseConfig, SecretRuleMatchPairingConfig, SecretRuleMatchValidation,
         SecretRuleMatchValidationHttpMethod, SecretRuleMatchValidationHttpV2,
         SecretRulePairedValidatorConfig, SecretRuleResponseCondition,
-        SecretRuleResponseConditionType, SecretRuleStatusCodeMatcher,
+        SecretRuleResponseConditionType, SecretRuleStatusCodeMatcher, SecretRuleSuppressions,
     };
 
     #[test]
@@ -151,6 +151,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";
@@ -198,6 +199,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: true,
+            suppressions: None,
         };
         let primary_rule = SecretRule {
             id: "primary".to_string(),
@@ -214,6 +216,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let rules = vec![supporting_rule, primary_rule];
@@ -250,6 +253,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Line 1: FOOBAR - should be found
@@ -289,6 +293,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Line 1: FOOBAR - should be found
@@ -338,6 +343,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         let text = "FOO\nFOOBAR\nFOOBAZ\nCAT";
@@ -398,6 +404,7 @@ mod tests {
             )),
             pattern_capture_groups: vec![],
             is_supporting_rule: true,
+            suppressions: None,
         };
 
         let mut parameters = BTreeMap::new();
@@ -449,6 +456,7 @@ mod tests {
             )),
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let rules = vec![supporting_rule, primary_rule];
@@ -540,6 +548,7 @@ mod tests {
             )),
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         };
 
         let rules = vec![rule];
@@ -589,6 +598,7 @@ mod tests {
             match_validation: None,
             pattern_capture_groups: vec![],
             is_supporting_rule: false,
+            suppressions: None,
         }];
         let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
         // Directive on line 1 means ignore entire file
@@ -607,5 +617,46 @@ mod tests {
         let first = matches.first().unwrap().matches.first().unwrap();
         assert_eq!(first.start, Position { line: 2, col: 1 });
         assert!(first.is_suppressed);
+    }
+
+    #[test]
+    fn test_find_secrets_with_rule_suppressions() {
+        let rules: Vec<SecretRule> = vec![SecretRule {
+            id: "secret_rule".to_string(),
+            sds_id: "sds_id".to_string(),
+            name: "detect secrets".to_string(),
+            description: "super secret!".to_string(),
+            pattern: "SECRET_[A-Z]+".to_string(),
+            default_included_keywords: vec![],
+            default_excluded_keywords: vec![],
+            look_ahead_character_count: Some(30),
+            priority: RulePriority::Medium,
+            validators: Some(vec![]),
+            validators_v2: None,
+            match_validation: None,
+            pattern_capture_groups: vec![],
+            is_supporting_rule: false,
+            suppressions: Some(SecretRuleSuppressions {
+                starts_with: vec![],
+                ends_with: vec![],
+                exact_match: vec!["SECRET_PLACEHOLDER".to_string()],
+            }),
+        }];
+        let scanner = build_sds_scanner(rules.as_slice(), false).expect("error building scanner");
+        let text = "SECRET_VALUE\nSECRET_PLACEHOLDER\n";
+        let matches = find_secrets(
+            &scanner,
+            rules.as_slice(),
+            "myfile",
+            text,
+            &AnalysisOptions::default(),
+        );
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches.first().unwrap().matches.len(), 1);
+        assert_eq!(
+            matches.first().unwrap().matches.first().unwrap().start,
+            Position { line: 1, col: 1 }
+        );
     }
 }


### PR DESCRIPTION
## What problem are you trying to solve?

Some secrets matched by secret rules aren't actual secrets: they may be test tokens, test card numbers, dummy values, etc.

## What is your solution?

Add support for suppressions, which are natively supported by the secret scanning engine already. This allows users to specify "suppressions" which are some kind of filter on top of the matches, to determine whether the match should be kept or not.

