### PR TITLE
Release 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bstr",
@@ -979,7 +979,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datadog-static-analyzer"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "secrets"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "common",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-kernel"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-server"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.9"
+version = "0.9.0"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+      "0.9.0": {
+        "cli": {
+          "windows": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+          },
+          "linux": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+          },
+          "macos": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-x86_64-apple-darwin.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-aarch64-apple-darwin.zip"
+          }
+        },
+        "server": {
+          "windows": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+          },
+          "linux": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+          },
+          "macos": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.0/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+          }
+        }
+      },
       "0.8.9": {
         "cli": {
           "windows": {


### PR DESCRIPTION
## Summary
- Release version 0.9.0

## Changes since 0.8.9
- Add git history secret scanning (`--scan-git-history-only`): report secrets that existed in past commits but are no longer present at HEAD (#935)