### PR TITLE
Fix GitLab CI image signing and misc CI flakiness

### DIFF
--- a/.github/workflows/coverage.yaml.yml
+++ b/.github/workflows/coverage.yaml.yml
@@ -1,6 +1,14 @@
 name: Code Coverage
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   coverage:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,7 @@ on:
       - "**/Cargo.toml"
       - ".github/workflows/docker-build.yml"
     branches:
-      - "**"
+      - main
   pull_request:
     paths:
       - "Dockerfile"
@@ -16,6 +16,10 @@ on:
       - "**/Cargo.toml"
       - ".github/workflows/docker-build.yml"
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 name: Test Docker Container
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,12 +3,16 @@ name: Run Integration tests
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
   schedule:
     # run every day at 9am UTC
     - cron: '0 9 * * *'
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   test_scripts:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,8 +1,12 @@
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 name: Check Code
 jobs:

--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -3,12 +3,16 @@ name: Test Rules
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
   schedule:
     # run every day at 9am UTC
     - cron:  '0 9 * * *'
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   extract-languages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/ubuntu:22.04
+image: registry.ddbuild.io/rust:ubuntu-22.04
 
 stages:
   - test
@@ -17,13 +17,9 @@ test-and-build-arm64:
     - .jobs-resource-allocation
   stage: test
   script:
-    - apt-get update
-    - apt-get install -y git curl build-essential pkg-config libssl-dev
-    - curl https://sh.rustup.rs -sSf  > rustup.sh && chmod a+x rustup.sh && ./rustup.sh -y && rm -f rustup.sh
-    - source "$HOME/.cargo/env"
     - cargo build -r
     - cargo test
-    - apt-get install -y python3 python3-requests
+    - apt-get update && apt-get install -y python3 python3-requests
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l java
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l javascript
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l typescript
@@ -42,13 +38,9 @@ test-and-build-amd64:
     - .jobs-resource-allocation
   stage: test
   script:
-    - apt-get update
-    - apt-get install -y git curl build-essential pkg-config libssl-dev
-    - curl https://sh.rustup.rs -sSf  > rustup.sh && chmod a+x rustup.sh && ./rustup.sh -y && rm -f rustup.sh
-    - source "$HOME/.cargo/env"
     - cargo build -r
     - cargo test
-    - apt-get install -y python3 python3-requests
+    - apt-get update && apt-get install -y python3 python3-requests
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l java
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l javascript
     - python3 misc/test-rules.py -c $PWD/target/release/datadog-static-analyzer -s $PWD/target/release/datadog-static-analyzer-server -l typescript

--- a/crates/static-analysis-kernel/build.rs
+++ b/crates/static-analysis-kernel/build.rs
@@ -282,6 +282,10 @@ fn main() {
 
             env::set_current_dir(&project_dir).unwrap();
             assert!(run("git", |cmd| { cmd.args(["init", "-q"]) }));
+            // Disable auto-gc: it can run as a detached background process past the
+            // fetch/checkout call, still writing into .git when we remove it below,
+            // causing an intermittent `ENOTEMPTY` on the removal.
+            assert!(run("git", |cmd| { cmd.args(["config", "gc.auto", "0"]) }));
             assert!(run("git", |cmd| {
                 cmd.args(["remote", "add", "origin", &proj.repository])
             }));


### PR DESCRIPTION
## What & Why

Our GitLab CI jobs pulled `registry.ddbuild.io/ubuntu:22.04`, which isn't signed. On runners with image signature verification enforced, the pull gets blocked, causing intermittent CI failures that only cleared up by retrying until a non-enforced runner was picked.

Switching to `registry.ddbuild.io/rust:ubuntu-22.04` (signed, and already bundles the Rust toolchain) avoids this, removing the need to install tools via `rustup`/`apt-get` on every job.

Two other CI issues surfaced while working on this and are fixed here in separate commits:

- Several GitHub Actions workflows trigger on both `push` and `pull_request`, so every push to a branch with an open PR ran them twice (probably not an major issue, but still wasteful).
- the `build.rs` script that vendors tree-sitter grammars could intermittently panic while cleaning up the cloned `.git` directory, because of git's automatic garbage collection writing to it in the background. Disabling auto-gc for these throwaway clones should avoid this.