### PR TITLE
Bump SDS to include change to match CamelCase keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -464,6 +473,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
@@ -1015,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "dd-sensitive-data-scanner"
 version = "0.0.0"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=dd8be015454dc75307dc6f045a1fba6b21f2b3fc#dd8be015454dc75307dc6f045a1fba6b21f2b3fc"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=972b5d8d18279b47470dadb313b368c591c76369#972b5d8d18279b47470dadb313b368c591c76369"
 dependencies = [
  "ahash",
  "aws-sign-v4",
@@ -1050,6 +1065,7 @@ dependencies = [
  "slotmap",
  "strum",
  "thiserror 1.0.69",
+ "tiktoken-rs",
  "tokio",
 ]
 
@@ -1072,8 +1088,8 @@ dependencies = [
  "anyhow",
  "az",
  "bincode",
- "bit-set",
- "bit-vec",
+ "bit-set 0.5.3",
+ "bit-vec 0.6.3",
  "bytes",
  "capacity_builder",
  "cooked-waker",
@@ -1361,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1407,8 +1423,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2082,7 +2109,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2331,7 +2358,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2437,7 +2464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
@@ -2802,7 +2829,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3319,7 +3346,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3356,9 +3383,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3780,7 +3807,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4557,7 +4584,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4643,6 +4670,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -5142,7 +5184,7 @@ dependencies = [
  "chrono",
  "downcast-rs",
  "erased-serde",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "json-pointer",
  "jsonway",
  "percent-encoding",
@@ -5379,7 +5421,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "dd-sensitive-data-scanner"
 version = "0.0.0"
-source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=b2dca51b27a87ecb2d847ad4167a0537afca1972#b2dca51b27a87ecb2d847ad4167a0537afca1972"
+source = "git+https://github.com/DataDog/dd-sensitive-data-scanner.git?rev=dd8be015454dc75307dc6f045a1fba6b21f2b3fc#dd8be015454dc75307dc6f045a1fba6b21f2b3fc"
 dependencies = [
  "ahash",
  "aws-sign-v4",
@@ -1361,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2331,7 +2331,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2802,7 +2802,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3356,9 +3356,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3780,7 +3780,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4557,7 +4557,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5379,7 +5379,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { package = "dd-sensitive-data-scanner", git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "dd8be015454dc75307dc6f045a1fba6b21f2b3fc" }
+dd-sds = { package = "dd-sensitive-data-scanner", git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "972b5d8d18279b47470dadb313b368c591c76369" }
 strum = "0.25.0"
 
 [dev-dependencies]

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.31"
 lazy_static = "1.5.0"
 
 # remote
-dd-sds = { package = "dd-sensitive-data-scanner", git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "b2dca51b27a87ecb2d847ad4167a0537afca1972" }
+dd-sds = { package = "dd-sensitive-data-scanner", git = "https://github.com/DataDog/dd-sensitive-data-scanner.git", rev = "dd8be015454dc75307dc6f045a1fba6b21f2b3fc" }
 strum = "0.25.0"
 
 [dev-dependencies]


### PR DESCRIPTION
`datadog-static-analyzer` pins `dd-sensitive-data-scanner` to `b2dca51` (2026-06-18), which predates https://github.com/DataDog/dd-sensitive-data-scanner/pull/369. 

Bumping this to include the change of improved matching with camelcase keywords (ie. a rule keyed on `access key` now also matches `accessKey`; not case-sensitive).

Also pulling in https://github.com/DataDog/dd-sensitive-data-scanner/pull/378, which is not yet wired to any rule used by `datadog-static-analyzer` and should have no impact today (needed only if a rule later opts into it).
