### PR TITLE
chore(toolchain): add rust-analyzer as a toolchain component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.91.1"
 profile = "default"
+components = ["rust-analyzer"]


### PR DESCRIPTION
## What problem are you trying to solve?

When using Cursor or VS Code Rust Analyzer won't work and you'll see something like this

<img width="292" height="405" alt="image" src="https://github.com/user-attachments/assets/7e678841-0916-4a62-876d-4d2b83852e70" />

## What is your solution?

 Added rust-analyzer to rust-toolchain.toml so rustup installs a language server matching the pinned 1.91.1 compiler


