### PR TITLE
Release version 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "bstr",
@@ -997,7 +997,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datadog-static-analyzer"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "secrets"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "common",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-kernel"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "static-analysis-server"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 
 [profile.release]
 lto = true

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,33 @@
 {
     "0": {
+      "0.9.3": {
+        "cli": {
+          "windows": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-x86_64-pc-windows-msvc.zip"
+          },
+          "linux": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-x86_64-unknown-linux-gnu.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-aarch64-unknown-linux-gnu.zip"
+          },
+          "macos": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-x86_64-apple-darwin.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-aarch64-apple-darwin.zip"
+          }
+        },
+        "server": {
+          "windows": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-server-x86_64-pc-windows-msvc.zip"
+          },
+          "linux": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-server-x86_64-unknown-linux-gnu.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-server-aarch64-unknown-linux-gnu.zip"
+          },
+          "macos": {
+            "x86_64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-server-x86_64-apple-darwin.zip",
+            "aarch64": "https://github.com/DataDog/datadog-static-analyzer/releases/download/0.9.3/datadog-static-analyzer-server-aarch64-apple-darwin.zip"
+          }
+        }
+      },
       "0.9.2": {
         "cli": {
           "windows": {


### PR DESCRIPTION
## Summary
- Release version 0.9.3

## Changes since 0.9.2
- Fix a regression from 0.9.2 where a configuration served by the backend that is not a valid Code Security document configuration (e.g. empty string) fails the run instead of being ignored (#950)
- Add rust-analyzer as a toolchain component (#951)
