### PR TITLE
Print all secrets config options in verbose output

### DIFF
--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -83,6 +83,9 @@ pub fn print_sast_configuration(sast_config: &SastConfiguration) {
         None => "all paths".to_string(),
     };
 
+    println!();
+    println!("Static analysis");
+    println!("---------------");
     println!("#static analysis rules    : {}", sast_config.rules.len());
     println!("ignore paths              : {}", ignore_paths_str);
     println!("only paths                : {}", only_paths_str);
@@ -103,6 +106,33 @@ pub fn print_sast_configuration(sast_config: &SastConfiguration) {
 
 /// Prints secrets' own settings. Only meaningful (and only called) when secrets is enabled.
 pub fn print_secrets_configuration(secrets_config: &SecretsConfiguration) {
+    let ignore_paths_str = if secrets_config.path_config.ignore.is_empty() {
+        "no ignore path".to_string()
+    } else {
+        secrets_config.path_config.ignore.join(",")
+    };
+    let only_paths_str = match &secrets_config.path_config.only {
+        Some(x) => x.join(","),
+        None => "all paths".to_string(),
+    };
+
+    println!();
+    println!("Secrets");
+    println!("-------");
     println!("#secrets rules loaded     : {}", secrets_config.rules.len());
+    println!("ignore paths              : {}", ignore_paths_str);
+    println!("only paths                : {}", only_paths_str);
+    println!(
+        "ignore gitignore          : {}",
+        secrets_config.ignore_gitignore
+    );
+    println!(
+        "ignore gen files          : {}",
+        secrets_config.ignore_generated_files
+    );
+    println!(
+        "max file size             : {} kb",
+        secrets_config.max_file_size_kb
+    );
     println!("[experimental] ast filter : {}", secrets_config.ast_filter);
 }


### PR DESCRIPTION
## Summary
- `print_secrets_configuration()` only printed the secrets rule count, missing the path filtering, gitignore, generated-files, and max-file-size options added to `SecretsConfiguration` in #942
- Brings it in line with `print_sast_configuration()`, and adds a short section header ("Static analysis" / "Secrets") before each block so shared field labels aren't ambiguous when both products are enabled

## Test plan
- [x] `cargo check -p cli`
- [x] `cargo fmt -p cli -- --check`