### PR TITLE
fix(ci): give reusable workflows unique concurrency groups

### DIFF
--- a/.github/workflows/coverage.yaml.yml
+++ b/.github/workflows/coverage.yaml.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: coverage-${{ github.head_ref || github.ref_name }}
+  queue: max
 
 jobs:
   coverage:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,8 +18,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: docker-build-${{ github.head_ref || github.ref_name }}
+  queue: max
 
 name: Test Docker Container
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,8 +11,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: integration-tests-${{ github.head_ref || github.ref_name }}
+  queue: max
 
 jobs:
   test_scripts:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: rust-${{ github.head_ref || github.ref_name }}
+  queue: max
 
 name: Check Code
 jobs:

--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -11,8 +11,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: test-rules-${{ github.head_ref || github.ref_name }}
+  queue: max
 
 jobs:
   extract-languages:


### PR DESCRIPTION
## What & why
`test-rules`, `docker-build`, and `integration-tests` are called as reusable workflows from `release.yml`. In a reusable call, `github.workflow` resolves to the caller's name, so all three computed the same concurrency group (`Release new version-<tag>`) and cancelled each other mid-release.

## Fix
Hardcode the concurrency group name per workflow file so it no longer depends on which workflow calls it.
Also use `queue: max` instead of `cancel-in-progress: true` so it worst case to just running them sequentially.